### PR TITLE
[B2BP-26] Add stale workflow

### DIFF
--- a/.github/stale.yaml
+++ b/.github/stale.yaml
@@ -16,7 +16,7 @@ jobs:
       DAYS_BEFORE_CLOSE: 21
 
     steps:
-      - name: Check is some PR is stale
+      - name: Check if some PR is stale
         uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/stale.yaml
+++ b/.github/stale.yaml
@@ -1,4 +1,4 @@
-name: Mark stale pull requests
+name: Mark PR as stale
 
 on:
   schedule:
@@ -16,14 +16,14 @@ jobs:
       DAYS_BEFORE_CLOSE: 21
 
     steps:
-      - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8.0.0
+      - name: Check is some PR is stale
+        uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-pr-stale: ${{ env.DAYS_BEFORE_STALE }}
           days-before-pr-close: ${{ env.DAYS_BEFORE_CLOSE }}
           stale-pr-message: This pull request is stale because it has been open for ${{ env.DAYS_BEFORE_STALE }} days with no activity. If the pull request is still valid, please update it within ${{ env.DAYS_BEFORE_CLOSE }} days to keep it open or merge it, otherwise it will be closed automatically.
-	  close-pr-message: This pull request was closed because it has been inactive for ${{ env.DAYS_BEFORE_CLOSE }} days since being marked as stale.
+          close-pr-message: This pull request was closed because it has been inactive for ${{ env.DAYS_BEFORE_CLOSE }} days since being marked as stale.
           stale-pr-label: 'stale'
           remove-stale-when-updated: true
           delete-branch: true
-


### PR DESCRIPTION
This workflow will check the PR and mark them as stale (adding the `stale` label) if no activity has been recorded on the PR for 14 days.

After that, if for another 21 days the PR is still stale, the PR will be close.