### PR TITLE
[B2BP-172] - Terraform ECS Task Definition AWS

### DIFF
--- a/.infrastructure/04_secrets.tf
+++ b/.infrastructure/04_secrets.tf
@@ -21,3 +21,51 @@ resource "aws_ssm_parameter" "cms_admin_jwt_secret" {
   type  = "SecureString"
   value = random_password.cms_admin_jwt_secret.result
 }
+
+resource "random_password" "cms_jwt_secret" {
+  length           = 16
+  special          = true
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+}
+
+resource "aws_ssm_parameter" "cms_jwt_secret" {
+  name  = "/cms/jwt_secret"
+  type  = "SecureString"
+  value = random_password.cms_jwt_secret.result
+}
+
+resource "random_password" "cms_app_keys" {
+  length           = 16
+  special          = true
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+}
+
+resource "aws_ssm_parameter" "cms_app_keys" {
+  name  = "/cms/app_keys"
+  type  = "SecureString"
+  value = random_password.cms_app_keys.result
+}
+
+resource "random_password" "cms_api_token_salt" {
+  length           = 16
+  special          = true
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+}
+
+resource "aws_ssm_parameter" "cms_api_token_salt" {
+  name  = "/cms/api_token_salt"
+  type  = "SecureString"
+  value = random_password.cms_api_token_salt.result
+}
+
+resource "random_password" "cms_transfer_token_salt" {
+  length           = 16
+  special          = true
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+}
+
+resource "aws_ssm_parameter" "cms_transfer_token_salt" {
+  name  = "/cms/transfer_token_salt"
+  type  = "SecureString"
+  value = random_password.cms_transfer_token_salt.result
+}

--- a/.infrastructure/07_ecs.tf
+++ b/.infrastructure/07_ecs.tf
@@ -22,7 +22,6 @@ data "template_file" "cms_app" {
     api_token_salt       = aws_ssm_parameter.cms_api_token_salt.arn
     transfer_token_salt  = aws_ssm_parameter.cms_transfer_token_salt.arn
     jwt_secret           = aws_ssm_parameter.cms_jwt_secret.arn
-    aws_region           = var.aws_region
     access_key_id        = aws_iam_access_key.strapi.id
     access_key_secret    = aws_iam_access_key.strapi.secret
   }

--- a/.infrastructure/07_ecs.tf
+++ b/.infrastructure/07_ecs.tf
@@ -47,7 +47,7 @@ resource "aws_ecs_service" "cms_ecs_service" {
   }
 
   load_balancer {
-    target_group_arn = aws_alb_target_group.app.id
+    target_group_arn = aws_alb_target_group.cms.id
     container_name   = "cms-docker"
     container_port   = var.cms_app_port
   }

--- a/.infrastructure/07_ecs.tf
+++ b/.infrastructure/07_ecs.tf
@@ -41,7 +41,7 @@ resource "aws_ecs_task_definition" "cms_task_def" {
 resource "aws_ecs_service" "cms_ecs_service" {
   name                              = "cms-ecs"
   cluster                           = aws_ecs_cluster.cms_ecs_cluster.id
-  desired_count                     = 1
+  desired_count                     = 0
   launch_type                       = "FARGATE"
   force_new_deployment              = true
   task_definition                   = aws_ecs_task_definition.cms_task_def.arn

--- a/.infrastructure/07_ecs.tf
+++ b/.infrastructure/07_ecs.tf
@@ -18,6 +18,12 @@ data "template_file" "cms_app" {
     db_name              = aws_rds_cluster.cms_database_cluster.database_name
     db_client            = "postgres"
     container_port       = var.cms_app_port
+    app_keys             = aws_ssm_parameter.cms_app_keys.arn
+    api_token_salt       = aws_ssm_parameter.cms_api_token_salt.arn
+    transfer_token_salt  = aws_ssm_parameter.cms_transfer_token_salt.arn
+    jwt_secret           = aws_ssm_parameter.cms_jwt_secret.arn
+    aws_region           = var.aws_region
+
   }
 }
 

--- a/.infrastructure/07_ecs.tf
+++ b/.infrastructure/07_ecs.tf
@@ -7,8 +7,8 @@ data "template_file" "cms_app" {
 
   vars = {
     image                = aws_ecr_repository.image_repository.repository_url
-    fargate_cpu          = var.fargate_cpu
-    fargate_memory       = var.fargate_memory
+    fargate_cpu          = var.cms_app_cpu
+    fargate_memory       = var.cms_app_memory
     aws_region           = var.aws_region
     db_host              = aws_rds_cluster.cms_database_cluster.endpoint
     db_user              = aws_rds_cluster.cms_database_cluster.master_username
@@ -26,8 +26,8 @@ resource "aws_ecs_task_definition" "cms_task_def" {
   task_role_arn            = aws_iam_role.task_role.arn
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
-  cpu                      = var.fargate_cpu
-  memory                   = var.fargate_memory
+  cpu                      = var.cms_app_cpu
+  memory                   = var.cms_app_memory
   container_definitions    = data.template_file.cms_app.rendered
 }
 

--- a/.infrastructure/07_ecs.tf
+++ b/.infrastructure/07_ecs.tf
@@ -16,12 +16,12 @@ data "template_file" "cms_app" {
     bucket_name          = aws_s3_bucket.cms_medialibrary_bucket.bucket
     admin_jwt_secret_arn = aws_ssm_parameter.cms_admin_jwt_secret.arn
     db_name              = aws_rds_cluster.cms_database_cluster.database_name
-    db_client            = var.db_client
+    db_client            = "postgres"
   }
 }
 
 resource "aws_ecs_task_definition" "cms_task_def" {
-  family                   = var.ecs_task_def
+  family                   = "cms-task-def"
   execution_role_arn       = aws_iam_role.ecs_task_execution_role.arn
   task_role_arn            = aws_iam_role.task_role.arn
   network_mode             = "awsvpc"
@@ -32,8 +32,8 @@ resource "aws_ecs_task_definition" "cms_task_def" {
 }
 
 resource "aws_ecs_service" "cms_ecs_service" {
-  name                              = var.ecs_serv
-  cluster                           = var.ecs_cluster
+  name                              = "cms-ecs"
+  cluster                           = "cms-ecs-cluster"
   desired_count                     = 1
   launch_type                       = "FARGATE"
   force_new_deployment              = true
@@ -48,7 +48,7 @@ resource "aws_ecs_service" "cms_ecs_service" {
 
   load_balancer {
     target_group_arn = aws_alb_target_group.app.id
-    container_name   = var.container_name
+    container_name   = "cms-docker"
     container_port   = var.cms_app_port
   }
 }

--- a/.infrastructure/07_ecs.tf
+++ b/.infrastructure/07_ecs.tf
@@ -49,6 +49,6 @@ resource "aws_ecs_service" "cms_ecs_service" {
   load_balancer {
     target_group_arn = aws_alb_target_group.app.id
     container_name   = var.container_name
-    container_port   = var.app_port
+    container_port   = var.cms_app_port
   }
 }

--- a/.infrastructure/07_ecs.tf
+++ b/.infrastructure/07_ecs.tf
@@ -6,7 +6,7 @@ data "template_file" "cms_app" {
   template = file("./task-definitions/cms_app.json.tpl")
 
   vars = {
-    image                = aws_ecr_repository.image_repository.repository_url
+    image                = aws_ecr_repository.strapi_image_repository.repository_url
     fargate_cpu          = var.cms_app_cpu
     fargate_memory       = var.cms_app_memory
     aws_region           = var.aws_region

--- a/.infrastructure/07_ecs.tf
+++ b/.infrastructure/07_ecs.tf
@@ -1,5 +1,5 @@
 resource "aws_ecs_cluster" "cms_ecs_cluster" {
-  name = var.ecs_cluster
+  name = "cms-ecs-cluster"
 }
 
 data "template_file" "cms_app" {

--- a/.infrastructure/07_ecs.tf
+++ b/.infrastructure/07_ecs.tf
@@ -17,6 +17,7 @@ data "template_file" "cms_app" {
     admin_jwt_secret_arn = aws_ssm_parameter.cms_admin_jwt_secret.arn
     db_name              = aws_rds_cluster.cms_database_cluster.database_name
     db_client            = "postgres"
+    container_port       = var.cms_app_port
   }
 }
 
@@ -33,7 +34,7 @@ resource "aws_ecs_task_definition" "cms_task_def" {
 
 resource "aws_ecs_service" "cms_ecs_service" {
   name                              = "cms-ecs"
-  cluster                           = "cms-ecs-cluster"
+  cluster                           = aws_ecs_cluster.cms_ecs_cluster.id
   desired_count                     = 1
   launch_type                       = "FARGATE"
   force_new_deployment              = true

--- a/.infrastructure/07_ecs.tf
+++ b/.infrastructure/07_ecs.tf
@@ -1,0 +1,54 @@
+resource "aws_ecs_cluster" "cms_ecs_cluster" {
+  name = var.ecs_cluster
+}
+
+data "template_file" "cms_app" {
+  template = file("./task-definitions/cms_app.json.tpl")
+
+  vars = {
+    image                = aws_ecr_repository.image_repository.repository_url
+    fargate_cpu          = var.fargate_cpu
+    fargate_memory       = var.fargate_memory
+    aws_region           = var.aws_region
+    db_host              = aws_rds_cluster.cms_database_cluster.endpoint
+    db_user              = aws_rds_cluster.cms_database_cluster.master_username
+    db_password_arn      = aws_ssm_parameter.cms_database_password.arn
+    bucket_name          = aws_s3_bucket.cms_medialibrary_bucket.bucket
+    admin_jwt_secret_arn = aws_ssm_parameter.cms_admin_jwt_secret.arn
+    db_name              = aws_rds_cluster.cms_database_cluster.database_name
+    db_client            = var.db_client
+  }
+}
+
+resource "aws_ecs_task_definition" "cms_task_def" {
+  family                   = var.ecs_task_def
+  execution_role_arn       = aws_iam_role.ecs_task_execution_role.arn
+  task_role_arn            = aws_iam_role.task_role.arn
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.fargate_cpu
+  memory                   = var.fargate_memory
+  container_definitions    = data.template_file.cms_app.rendered
+}
+
+resource "aws_ecs_service" "cms_ecs_service" {
+  name                              = var.ecs_serv
+  cluster                           = var.ecs_cluster
+  desired_count                     = 1
+  launch_type                       = "FARGATE"
+  force_new_deployment              = true
+  task_definition                   = aws_ecs_task_definition.cms_task_def.arn
+  health_check_grace_period_seconds = 60000
+
+  network_configuration {
+    security_groups  = [aws_security_group.ecs_tasks.id]
+    subnets          = module.vpc.private_subnets
+    assign_public_ip = true
+  }
+
+  load_balancer {
+    target_group_arn = aws_alb_target_group.app.id
+    container_name   = var.container_name
+    container_port   = var.app_port
+  }
+}

--- a/.infrastructure/07_ecs.tf
+++ b/.infrastructure/07_ecs.tf
@@ -23,7 +23,8 @@ data "template_file" "cms_app" {
     transfer_token_salt  = aws_ssm_parameter.cms_transfer_token_salt.arn
     jwt_secret           = aws_ssm_parameter.cms_jwt_secret.arn
     aws_region           = var.aws_region
-
+    access_key_id        = aws_iam_access_key.strapi.id
+    access_key_secret    = aws_iam_access_key.strapi.secret
   }
 }
 

--- a/.infrastructure/08_ecr.tf
+++ b/.infrastructure/08_ecr.tf
@@ -1,13 +1,13 @@
-resource "aws_ecr_repository" "image_repository" {
-  name = var.ecr_repository
+resource "aws_ecr_repository" "strapi_image_repository" {
+  name = "strapi"
 
   image_scanning_configuration {
     scan_on_push = true
   }
 }
 
-resource "aws_ecr_lifecycle_policy" "policy" {
-  repository = aws_ecr_repository.image_repository.name
+resource "aws_ecr_lifecycle_policy" "strapi_policy" {
+  repository = aws_ecr_repository.strapi_image_repository.name
 
   policy = <<EOF
   {

--- a/.infrastructure/08_ecr.tf
+++ b/.infrastructure/08_ecr.tf
@@ -1,0 +1,30 @@
+resource "aws_ecr_repository" "image_repository" {
+  name = var.ecr_repository
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "policy" {
+  repository = aws_ecr_repository.image_repository.name
+
+  policy = <<EOF
+  {
+      "rules": [
+          {
+              "rulePriority": 1,
+              "description": "Keep last 5 images",
+              "selection": {
+                  "tagStatus": "any",
+                  "countType": "imageCountMoreThan",
+                  "countNumber": 5
+              },
+              "action": {
+                  "type": "expire"
+              }
+          }
+      ]
+  }
+  EOF
+}

--- a/.infrastructure/08_ecr.tf
+++ b/.infrastructure/08_ecr.tf
@@ -1,5 +1,7 @@
 resource "aws_ecr_repository" "strapi_image_repository" {
   name = "strapi"
+  
+  image_tag_mutability = "IMMUTABLE"
 
   image_scanning_configuration {
     scan_on_push = true

--- a/.infrastructure/08_ecr.tf
+++ b/.infrastructure/08_ecr.tf
@@ -1,6 +1,6 @@
 resource "aws_ecr_repository" "strapi_image_repository" {
   name = "strapi"
-  
+
   image_tag_mutability = "IMMUTABLE"
 
   image_scanning_configuration {

--- a/.infrastructure/09_iam_role.tf
+++ b/.infrastructure/09_iam_role.tf
@@ -61,16 +61,6 @@ data "aws_iam_policy_document" "ecs_task_execution" {
   statement {
     effect = "Allow"
     actions = [
-      "s3:GetObject"
-    ]
-    resources = [
-      "${aws_s3_bucket.cms_medialibrary_bucket.arn}/.env"
-    ]
-  }
-
-  statement {
-    effect = "Allow"
-    actions = [
       "s3:GetBucketLocation"
     ]
     resources = [

--- a/.infrastructure/09_iam_role.tf
+++ b/.infrastructure/09_iam_role.tf
@@ -1,0 +1,113 @@
+resource "aws_iam_role" "ecs_task_execution_role" {
+  name = "ecs-task-execution-role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ecs-tasks.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "ec2_container_registery_policies" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_policy" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = aws_iam_policy.ecs_task_execution.arn
+}
+
+data "aws_iam_policy_document" "ecs_task_execution" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "ssm:DescribeParameters"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ssm:GetParameters"
+    ]
+    resources = [
+      aws_ssm_parameter.cms_database_password.arn,
+      aws_ssm_parameter.cms_admin_jwt_secret.arn,
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetObject"
+    ]
+    resources = [
+      "${aws_s3_bucket.cms_medialibrary_bucket.arn}/.env"
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetBucketLocation"
+    ]
+    resources = [
+      "${aws_s3_bucket.cms_medialibrary_bucket.arn}"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "ecs_task_execution" {
+  name   = "CMSTaskExecutionPolicies"
+  path   = "/"
+  policy = data.aws_iam_policy_document.ecs_task_execution.json
+}
+
+resource "aws_iam_role" "task_role" {
+  name               = var.ecs_task_role
+  assume_role_policy = data.aws_iam_policy_document.task_role.json
+}
+
+data "aws_iam_policy_document" "task_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_container_rds_full_access" {
+  role       = aws_iam_role.task_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonRDSFullAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_container_ec2_full_access" {
+  role       = aws_iam_role.task_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2FullAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_container_s3_full_access" {
+  role       = aws_iam_role.task_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+}

--- a/.infrastructure/09_iam_role.tf
+++ b/.infrastructure/09_iam_role.tf
@@ -51,6 +51,10 @@ data "aws_iam_policy_document" "ecs_task_execution" {
     resources = [
       aws_ssm_parameter.cms_database_password.arn,
       aws_ssm_parameter.cms_admin_jwt_secret.arn,
+      aws_ssm_parameter.cms_app_keys.arn,
+      aws_ssm_parameter.cms_api_token_salt.arn,
+      aws_ssm_parameter.cms_transfer_token_salt.arn,
+      aws_ssm_parameter.cms_jwt_secret.arn
     ]
   }
 

--- a/.infrastructure/09_iam_role.tf
+++ b/.infrastructure/09_iam_role.tf
@@ -82,7 +82,7 @@ resource "aws_iam_policy" "ecs_task_execution" {
 }
 
 resource "aws_iam_role" "task_role" {
-  name               = var.ecs_task_role
+  name               = "ecs-task-role"
   assume_role_policy = data.aws_iam_policy_document.task_role.json
 }
 

--- a/.infrastructure/10_iam_access_key_strapi.tf
+++ b/.infrastructure/10_iam_access_key_strapi.tf
@@ -1,0 +1,39 @@
+### Necessary to Strapi for Upload and Download object to/from Media Library S3
+resource "aws_iam_user" "strapi" {
+  name = "Strapi"
+}
+
+resource "aws_iam_access_key" "strapi" {
+  user = aws_iam_user.strapi.name
+}
+
+resource "aws_iam_policy" "upload_image" {
+  name        = "S3UploadImages"
+  path        = "/"
+  description = "Policy to allow to manage files in S3 bucket"
+
+  # Terraform's "jsonencode" function converts a
+  # Terraform expression result to valid JSON syntax.
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "s3:DeleteObject",
+          "s3:GetObject",
+          "s3:GetObjectAttributes",
+          "s3:ListBucket",
+          "s3:PutObject"
+        ]
+        Effect   = "Allow"
+        Resource = format("%s/*", aws_s3_bucket.cms_medialibrary_bucket.arn)
+      },
+    ]
+  })
+}
+
+resource "aws_iam_policy_attachment" "strapi-policy" {
+  name       = "strapi-policy"
+  users      = [aws_iam_user.strapi.name]
+  policy_arn = aws_iam_policy.upload_image.arn
+}

--- a/.infrastructure/98_variables.tf
+++ b/.infrastructure/98_variables.tf
@@ -26,17 +26,12 @@ variable "cms_app_port" {
   default = 1337
 }
 
-variable "fargate_cpu" {
+variable "cms_app_cpu" {
   description = "Fargate instance CPU units to provision (1 vCPU = 1024 CPU units)"
-  default     = "4096" ##### 4 vCPU
+  default     = "1024" ##### 4 vCPU
 }
 
-variable "fargate_memory" {
+variable "cms_app_memory" {
   description = "Fargate instance memory to provision (in MiB)"
-  default     = "16384" ##### 16 GB RAM
-}
-
-variable "ecr_repository" {
-  description = "Repository ECR Name for container image"
-  default     = "strapi"
+  default     = "3072" ##### 16 GB RAM
 }

--- a/.infrastructure/98_variables.tf
+++ b/.infrastructure/98_variables.tf
@@ -28,10 +28,10 @@ variable "cms_app_port" {
 
 variable "cms_app_cpu" {
   description = "Fargate instance CPU units to provision (1 vCPU = 1024 CPU units)"
-  default     = "1024" ##### 4 vCPU
+  default     = "1024" ##### 1 vCPU
 }
 
 variable "cms_app_memory" {
   description = "Fargate instance memory to provision (in MiB)"
-  default     = "3072" ##### 16 GB RAM
+  default     = "3072" ##### 3 GB RAM
 }

--- a/.infrastructure/98_variables.tf
+++ b/.infrastructure/98_variables.tf
@@ -25,3 +25,18 @@ variable "tags" {
 variable "cms_app_port" {
   default = 1337
 }
+
+variable "fargate_cpu" {
+  description = "Fargate instance CPU units to provision (1 vCPU = 1024 CPU units)"
+  default     = "4096" ##### 4 vCPU
+}
+
+variable "fargate_memory" {
+  description = "Fargate instance memory to provision (in MiB)"
+  default     = "16384" ##### 16 GB RAM
+}
+
+variable "ecr_repository" {
+  description = "Repository ECR Name for container image"
+  default     = "strapi"
+}

--- a/.infrastructure/task-definitions/cms_app.json.tpl
+++ b/.infrastructure/task-definitions/cms_app.json.tpl
@@ -4,7 +4,7 @@
     "image": "${image}",
     "portMappings": [
       {
-        "containerPort": "${container_port}"
+        "containerPort": ${container_port}
       }
     ],
     "environment": [

--- a/.infrastructure/task-definitions/cms_app.json.tpl
+++ b/.infrastructure/task-definitions/cms_app.json.tpl
@@ -42,7 +42,7 @@
       },
       {
         "name": "DATABASE_SCHEMA",
-        "value": "send"
+        "value": "public"
       },
       {
         "name": "AWS_REGION",

--- a/.infrastructure/task-definitions/cms_app.json.tpl
+++ b/.infrastructure/task-definitions/cms_app.json.tpl
@@ -25,7 +25,7 @@
         "value": "${db_name}"
       },
       {
-        "name": "BUCKET_NAME",
+        "name": "AWS_BUCKET",
         "value": "${bucket_name}"
       },
       {
@@ -39,6 +39,14 @@
       {
         "name": "DATABASE_PORT",
         "value": "5432"
+      },
+      {
+        "name": "DATABASE_SCHEMA",
+        "value": "send"
+      },
+      {
+        "name": "AWS_REGION",
+        "value": "${aws_region}"
       }
     ],
     "secrets" : [
@@ -49,6 +57,22 @@
       {
         "name": "ADMIN_JWT_SECRET",
         "valueFrom": "${admin_jwt_secret_arn}"
+      },
+      {
+        "name": "APP_KEYS",
+        "valueFrom": "${app_keys}"
+      },
+      {
+        "name": "API_TOKEN_SALT",
+        "valueFrom": "${api_token_salt}"
+      },
+      {
+        "name": "TRANSFER_TOKEN_SALT",
+        "valueFrom": "${transfer_token_salt}"
+      },
+      {
+        "name": "JWT_SECRET",
+        "valueFrom": "${jwt_secret}"
       }
     ]
   }

--- a/.infrastructure/task-definitions/cms_app.json.tpl
+++ b/.infrastructure/task-definitions/cms_app.json.tpl
@@ -47,6 +47,14 @@
       {
         "name": "AWS_REGION",
         "value": "${aws_region}"
+      },
+      {
+        "name": "AWS_ACCESS_KEY_ID",
+        "value": "${access_key_id}"
+      },
+      {
+        "name": "AWS_ACCESS_SECRET",
+        "value": "${access_key_secret}"
       }
     ],
     "secrets" : [

--- a/.infrastructure/task-definitions/cms_app.json.tpl
+++ b/.infrastructure/task-definitions/cms_app.json.tpl
@@ -4,7 +4,7 @@
     "image": "${image}",
     "portMappings": [
       {
-        "containerPort": 1337
+        "containerPort": "${container_port}"
       }
     ],
     "environment": [

--- a/.infrastructure/task-definitions/cms_app.json.tpl
+++ b/.infrastructure/task-definitions/cms_app.json.tpl
@@ -1,0 +1,55 @@
+[
+  {
+    "name": "cms-docker",
+    "image": "${image}",
+    "portMappings": [
+      {
+        "containerPort": 1337
+      }
+    ],
+    "environment": [
+      {
+        "name": "NODE_ENV",
+        "value": "production"
+      },
+      {
+        "name": "DATABASE_CLIENT",
+        "value": "${db_client}"
+      },
+      {
+        "name": "DATABASE_HOST",
+        "value": "${db_host}"
+      },
+      {
+        "name": "DATABASE_NAME",
+        "value": "${db_name}"
+      },
+      {
+        "name": "BUCKET_NAME",
+        "value": "${bucket_name}"
+      },
+      {
+        "name": "DATABASE_USERNAME",
+        "value": "${db_user}"
+      },
+      {
+        "name": "DATABASE_SSL",
+        "value": "false"
+      },
+      {
+        "name": "DATABASE_PORT",
+        "value": "5432"
+      }
+    ],
+    "secrets" : [
+      {
+        "name" : "DATABASE_PASSWORD",
+        "valueFrom" : "${db_password_arn}"
+      },
+      {
+        "name": "ADMIN_JWT_SECRET",
+        "valueFrom": "${admin_jwt_secret_arn}"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Creation of Terraform scripts for the automatic deployment on AWS of ECS Task definition and ECR resources necessary for Strapi.


#### List of Changes
Creation of Terraform scripts for the automatic deployment on AWS of ECS Task definition and ECR resources necessary for Strapi.

#### Motivation and Context
As reported in the [RFC "SV-003 - Architettura Strapi on AWS"](https://pagopa.atlassian.net/wiki/spaces/SV/pages/795771078/SV-003+-+Architettura+Strapi+on+AWS), to host the Strapi instance on the AWS Cloud Provider it is necessary to create the relevant resources using Terraform scripts, such as: Strapi Server (Cluster ECS Fargate), Database RDS Aurora PostgreSQL, Bucket S3 for Media Library, Load Balancer, Role IAM and Secrets SSM)

#### How Has This Been Tested?
Running Terraform scripts on locally PC pointing to a test AWS environment

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
