### PR TITLE
[B2BP-175] - Terraform set port ALB

### DIFF
--- a/.infrastructure/06_alb.tf
+++ b/.infrastructure/06_alb.tf
@@ -26,6 +26,7 @@ resource "aws_alb_target_group" "cms" {
 # Redirect all traffic from the ALB to the target group
 resource "aws_alb_listener" "front_end" {
   load_balancer_arn = aws_alb.cms_load_balancer.id
+  port              = 80
 
   default_action {
     target_group_arn = aws_alb_target_group.cms.id


### PR DESCRIPTION
Creation of Terraform scripts for the automatic deployment on AWS of resources necessary for Strapi.

#### List of Changes
Set port ALB Listener to 80 for communication with CloudFront:
FLOW:  Users ----HTTPS 443 ---> CloudFront-----HTTP 80 ---> ALB Listener ----forward HTTP---> TargetGroup ECS ----MappingPort 80:1337---> Container STRAPI

#### Motivation and Context
Set port ALB Listener to 80 for communication with CloudFront

#### How Has This Been Tested?
Running Terraform scripts on locally PC pointing to a test AWS environment

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change not requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
