### PR TITLE
[B2BP-174] - Terraform modify SecurityGroup ALB

### DIFF
--- a/.infrastructure/03_network.tf
+++ b/.infrastructure/03_network.tf
@@ -25,6 +25,11 @@ module "vpc" {
 ### AWS Security Group ###
 # Traffic to the DB should only come from ECS
 # Traffic to the ECS cluster should only come from the ALB
+
+data "aws_ec2_managed_prefix_list" "cloudfront" {   #For retrieve the Prefix_list_id of CloudFront
+ name = "com.amazonaws.global.cloudfront.origin-facing"
+}
+
 resource "aws_security_group" "cms_lb" {
   name        = "cms-lb"
   description = "Ingress - Load Balancer"
@@ -34,7 +39,7 @@ resource "aws_security_group" "cms_lb" {
     protocol    = "tcp"
     from_port   = 80
     to_port     = 80
-    cidr_blocks = ["0.0.0.0/0"]
+    prefix_list_ids = [data.aws_ec2_managed_prefix_list.cloudfront.id]
   }
 
   ingress {
@@ -48,7 +53,7 @@ resource "aws_security_group" "cms_lb" {
     protocol    = "tcp"
     from_port   = var.cms_app_port
     to_port     = var.cms_app_port
-    cidr_blocks = ["0.0.0.0/0"]
+    prefix_list_ids = [data.aws_ec2_managed_prefix_list.cloudfront.id]
   }
 
   egress {
@@ -56,6 +61,10 @@ resource "aws_security_group" "cms_lb" {
     to_port     = 0
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }
 

--- a/.infrastructure/03_network.tf
+++ b/.infrastructure/03_network.tf
@@ -26,8 +26,8 @@ module "vpc" {
 # Traffic to the DB should only come from ECS
 # Traffic to the ECS cluster should only come from the ALB
 
-data "aws_ec2_managed_prefix_list" "cloudfront" {   #For retrieve the Prefix_list_id of CloudFront
- name = "com.amazonaws.global.cloudfront.origin-facing"
+data "aws_ec2_managed_prefix_list" "cloudfront" { #For retrieve the Prefix_list_id of CloudFront
+  name = "com.amazonaws.global.cloudfront.origin-facing"
 }
 
 resource "aws_security_group" "cms_lb" {
@@ -36,9 +36,9 @@ resource "aws_security_group" "cms_lb" {
   vpc_id      = module.vpc.vpc_id
 
   ingress {
-    protocol    = "tcp"
-    from_port   = 80
-    to_port     = 80
+    protocol        = "tcp"
+    from_port       = 80
+    to_port         = 80
     prefix_list_ids = [data.aws_ec2_managed_prefix_list.cloudfront.id]
   }
 
@@ -50,9 +50,9 @@ resource "aws_security_group" "cms_lb" {
   }
 
   ingress {
-    protocol    = "tcp"
-    from_port   = var.cms_app_port
-    to_port     = var.cms_app_port
+    protocol        = "tcp"
+    from_port       = var.cms_app_port
+    to_port         = var.cms_app_port
     prefix_list_ids = [data.aws_ec2_managed_prefix_list.cloudfront.id]
   }
 


### PR DESCRIPTION
Creation of Terraform scripts for modify ALB Security Group, so that it is reachable only from CloudFront on HTTP:80

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Creation of Terraform scripts for modify ALB Security Group, so that it is reachable only from CloudFront on HTTP:80

#### Motivation and Context
As reported in the [RFC "SV-003 - Architettura Strapi on AWS"](https://pagopa.atlassian.net/wiki/spaces/SV/pages/795771078/SV-003+-+Architettura+Strapi+on+AWS), to host the Strapi instance on the AWS Cloud Provider it is necessary to create the relevant resources using Terraform scripts, such as: Strapi Server (Cluster ECS Fargate), Database RDS Aurora PostgreSQL, Bucket S3 for Media Library, Load Balancer, Role IAM and Secrets SSM)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change not requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
