### PR TITLE
[B2BP-174] - Terraform SPLIT SecurityGroup ALB

### DIFF
--- a/.infrastructure/03_network.tf
+++ b/.infrastructure/03_network.tf
@@ -49,6 +49,26 @@ resource "aws_security_group" "cms_lb" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# The soft limit of Security Group rule is 60. 
+# The aws_ec2_managed_prefix_list.cloudfront counts as 55 rules
+# For this reason we need to create 2 different Security Group to use the managed_prefix_list.cloudfront for 80 and 1337 port
+resource "aws_security_group" "cms_lb_app_port" {
+  name        = "cms-lb-app-port"
+  description = "Ingress - Load Balancer"
+  vpc_id      = module.vpc.vpc_id
+
   ingress {
     protocol        = "tcp"
     from_port       = var.cms_app_port

--- a/.infrastructure/06_alb.tf
+++ b/.infrastructure/06_alb.tf
@@ -1,7 +1,7 @@
 resource "aws_alb" "cms_load_balancer" {
   name            = "cms-load-balancer"
   subnets         = module.vpc.public_subnets
-  security_groups = [aws_security_group.cms_lb.id,aws_security_group.cms_lb_app_port.id]
+  security_groups = [aws_security_group.cms_lb.id, aws_security_group.cms_lb_app_port.id]
   internal        = false
 }
 

--- a/.infrastructure/06_alb.tf
+++ b/.infrastructure/06_alb.tf
@@ -1,7 +1,7 @@
 resource "aws_alb" "cms_load_balancer" {
   name            = "cms-load-balancer"
   subnets         = module.vpc.public_subnets
-  security_groups = [aws_security_group.cms_lb.id]
+  security_groups = [aws_security_group.cms_lb.id,aws_security_group.cms_lb_app_port.id]
   internal        = false
 }
 


### PR DESCRIPTION
The deployinfra workflow fails with error _"RulesPerSecurityGroupLimitExceeded: The maximum number of rules per security group has been reached."_

This because the max number of (soft limit)Security Group rule is 60. The "aws_ec2_managed_prefix_list.cloudfront" counts as 55 rules. For this reason we need to create 2 different Security Group to use the "managed_prefix_list.cloudfront" for 80 and 1337 port. 

https://aws.amazon.com/it/blogs/networking-and-content-delivery/limit-access-to-your-origins-using-the-aws-managed-prefix-list-for-amazon-cloudfront/

_"if you add one managed prefix list for CloudFront in your Inbound rules. If you want to limit both HTTP and HTTPS requests using the managed prefix list for CloudFront, then you must add two separate rules, which will count as 110 total rules."_


Otherwise, you can request an increase in quota up to 1000 of Rule for Security group by AWS console: https://console.aws.amazon.com/servicequotas/home/services/vpc/quotas/L-0EA8095F


<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Split Security group of ALB in two different Security Group: one for 443 and 80 port and one for 1337 port.

#### Motivation and Context
Creation of Terraform scripts for split ALB Security Group. This because the max number of (soft limit)Security Group rule is 60. The "aws_ec2_managed_prefix_list.cloudfront" counts as 55 rules. For this reason we need to create 2 different Security Group to use the "managed_prefix_list.cloudfront" for 80 and 1337 port.

#### How Has This Been Tested?
On locally

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change not requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
