### PR TITLE
[B2BP-195] Added Single Types for PreHeader, Header and Footer.

### DIFF
--- a/apps/strapi-cms/src/api/footer/content-types/footer/schema.json
+++ b/apps/strapi-cms/src/api/footer/content-types/footer/schema.json
@@ -1,0 +1,50 @@
+{
+  "kind": "singleType",
+  "collectionName": "footers",
+  "info": {
+    "singularName": "footer",
+    "pluralName": "footers",
+    "displayName": "Footer",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "legalInfo": {
+      "type": "richtext",
+      "required": true
+    },
+    "companyLink": {
+      "type": "component",
+      "repeatable": false,
+      "component": "components.link",
+      "required": true
+    },
+    "links_aboutUs": {
+      "type": "component",
+      "repeatable": false,
+      "component": "components.link-group",
+      "required": true
+    },
+    "links_followUs": {
+      "type": "component",
+      "repeatable": false,
+      "component": "components.link-group",
+      "required": true
+    },
+    "links_resources": {
+      "type": "component",
+      "repeatable": false,
+      "component": "components.link-group",
+      "required": true
+    },
+    "links_services": {
+      "type": "component",
+      "repeatable": false,
+      "component": "components.link-group",
+      "required": true
+    }
+  }
+}

--- a/apps/strapi-cms/src/api/footer/content-types/footer/schema.json
+++ b/apps/strapi-cms/src/api/footer/content-types/footer/schema.json
@@ -45,6 +45,11 @@
       "repeatable": false,
       "component": "components.link-group",
       "required": true
+    },
+    "showFundedByNextGenerationEULogo": {
+      "type": "boolean",
+      "default": false,
+      "required": true
     }
   }
 }

--- a/apps/strapi-cms/src/api/footer/controllers/footer.ts
+++ b/apps/strapi-cms/src/api/footer/controllers/footer.ts
@@ -1,0 +1,7 @@
+/**
+ * footer controller
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::footer.footer');

--- a/apps/strapi-cms/src/api/footer/routes/footer.ts
+++ b/apps/strapi-cms/src/api/footer/routes/footer.ts
@@ -1,0 +1,7 @@
+/**
+ * footer router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::footer.footer');

--- a/apps/strapi-cms/src/api/footer/services/footer.ts
+++ b/apps/strapi-cms/src/api/footer/services/footer.ts
@@ -1,0 +1,7 @@
+/**
+ * footer service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::footer.footer');

--- a/apps/strapi-cms/src/api/header/content-types/header/schema.json
+++ b/apps/strapi-cms/src/api/header/content-types/header/schema.json
@@ -21,16 +21,6 @@
       "default": false,
       "required": true
     },
-    "primaryButton": {
-      "type": "component",
-      "repeatable": false,
-      "component": "components.cta-button"
-    },
-    "secondaryButton": {
-      "type": "component",
-      "repeatable": false,
-      "component": "components.cta-button"
-    },
     "avatar": {
       "type": "media",
       "multiple": false,
@@ -43,6 +33,21 @@
       "type": "boolean",
       "default": false,
       "required": true
+    },
+    "theme": {
+      "type": "enumeration",
+      "enum": [
+        "light",
+        "dark"
+      ],
+      "default": "light",
+      "required": true
+    },
+    "ctaButtons": {
+      "type": "component",
+      "repeatable": true,
+      "component": "components.cta-button",
+      "max": 2
     }
   }
 }

--- a/apps/strapi-cms/src/api/header/content-types/header/schema.json
+++ b/apps/strapi-cms/src/api/header/content-types/header/schema.json
@@ -1,0 +1,48 @@
+{
+  "kind": "singleType",
+  "collectionName": "headers",
+  "info": {
+    "singularName": "header",
+    "pluralName": "headers",
+    "displayName": "Header",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "productName": {
+      "type": "string",
+      "required": true
+    },
+    "beta": {
+      "type": "boolean",
+      "default": false,
+      "required": true
+    },
+    "primaryButton": {
+      "type": "component",
+      "repeatable": false,
+      "component": "components.cta-button"
+    },
+    "secondaryButton": {
+      "type": "component",
+      "repeatable": false,
+      "component": "components.cta-button"
+    },
+    "avatar": {
+      "type": "media",
+      "multiple": false,
+      "required": false,
+      "allowedTypes": [
+        "images"
+      ]
+    },
+    "reverse": {
+      "type": "boolean",
+      "default": false,
+      "required": true
+    }
+  }
+}

--- a/apps/strapi-cms/src/api/header/controllers/header.ts
+++ b/apps/strapi-cms/src/api/header/controllers/header.ts
@@ -1,0 +1,7 @@
+/**
+ * header controller
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::header.header');

--- a/apps/strapi-cms/src/api/header/routes/header.ts
+++ b/apps/strapi-cms/src/api/header/routes/header.ts
@@ -1,0 +1,7 @@
+/**
+ * header router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::header.header');

--- a/apps/strapi-cms/src/api/header/services/header.ts
+++ b/apps/strapi-cms/src/api/header/services/header.ts
@@ -1,0 +1,7 @@
+/**
+ * header service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::header.header');

--- a/apps/strapi-cms/src/api/pre-header/content-types/pre-header/schema.json
+++ b/apps/strapi-cms/src/api/pre-header/content-types/pre-header/schema.json
@@ -1,0 +1,37 @@
+{
+  "kind": "singleType",
+  "collectionName": "pre_headers",
+  "info": {
+    "singularName": "pre-header",
+    "pluralName": "pre-headers",
+    "displayName": "PreHeader",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "theme": {
+      "type": "enumeration",
+      "enum": [
+        "light",
+        "dark"
+      ],
+      "default": "light",
+      "required": true
+    },
+    "leftCTAButton": {
+      "type": "component",
+      "repeatable": false,
+      "component": "components.cta-button",
+      "required": false
+    },
+    "rightCTAButton": {
+      "type": "component",
+      "repeatable": false,
+      "component": "components.cta-button",
+      "required": false
+    }
+  }
+}

--- a/apps/strapi-cms/src/api/pre-header/content-types/pre-header/schema.json
+++ b/apps/strapi-cms/src/api/pre-header/content-types/pre-header/schema.json
@@ -12,26 +12,15 @@
   },
   "pluginOptions": {},
   "attributes": {
-    "theme": {
-      "type": "enumeration",
-      "enum": [
-        "light",
-        "dark"
-      ],
-      "default": "light",
-      "required": true
-    },
-    "leftCTAButton": {
+    "leftCtas": {
       "type": "component",
       "repeatable": false,
-      "component": "components.cta-button",
-      "required": false
+      "component": "components.cta-group"
     },
-    "rightCTAButton": {
+    "rightCtas": {
       "type": "component",
       "repeatable": false,
-      "component": "components.cta-button",
-      "required": false
+      "component": "components.cta-group"
     }
   }
 }

--- a/apps/strapi-cms/src/api/pre-header/controllers/pre-header.ts
+++ b/apps/strapi-cms/src/api/pre-header/controllers/pre-header.ts
@@ -1,0 +1,7 @@
+/**
+ * pre-header controller
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::pre-header.pre-header');

--- a/apps/strapi-cms/src/api/pre-header/routes/pre-header.ts
+++ b/apps/strapi-cms/src/api/pre-header/routes/pre-header.ts
@@ -1,0 +1,7 @@
+/**
+ * pre-header router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::pre-header.pre-header');

--- a/apps/strapi-cms/src/api/pre-header/services/pre-header.ts
+++ b/apps/strapi-cms/src/api/pre-header/services/pre-header.ts
@@ -1,0 +1,7 @@
+/**
+ * pre-header service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::pre-header.pre-header');

--- a/apps/strapi-cms/src/components/components/cta-button.json
+++ b/apps/strapi-cms/src/components/components/cta-button.json
@@ -1,7 +1,8 @@
 {
   "collectionName": "components_components_cta_buttons",
   "info": {
-    "displayName": "CTAButton"
+    "displayName": "CTAButton",
+    "description": ""
   },
   "options": {},
   "attributes": {
@@ -36,6 +37,9 @@
       ],
       "default": "inherit",
       "required": true
+    },
+    "icon": {
+      "type": "string"
     }
   }
 }

--- a/apps/strapi-cms/src/components/components/cta-button.json
+++ b/apps/strapi-cms/src/components/components/cta-button.json
@@ -1,0 +1,41 @@
+{
+  "collectionName": "components_components_cta_buttons",
+  "info": {
+    "displayName": "CTAButton"
+  },
+  "options": {},
+  "attributes": {
+    "text": {
+      "type": "string",
+      "required": true
+    },
+    "href": {
+      "type": "string",
+      "required": true
+    },
+    "variant": {
+      "type": "enumeration",
+      "enum": [
+        "text",
+        "contained",
+        "outlined"
+      ],
+      "default": "text",
+      "required": true
+    },
+    "color": {
+      "type": "enumeration",
+      "enum": [
+        "inherit",
+        "primary",
+        "secondary",
+        "success",
+        "error",
+        "info",
+        "warning"
+      ],
+      "default": "inherit",
+      "required": true
+    }
+  }
+}

--- a/apps/strapi-cms/src/components/components/cta-group.json
+++ b/apps/strapi-cms/src/components/components/cta-group.json
@@ -1,0 +1,28 @@
+{
+  "collectionName": "components_components_cta_groups",
+  "info": {
+    "displayName": "CTAGroup"
+  },
+  "options": {},
+  "attributes": {
+    "ctaButtons": {
+      "type": "component",
+      "repeatable": true,
+      "component": "components.cta-button"
+    },
+    "reverse": {
+      "type": "boolean",
+      "default": false,
+      "required": true
+    },
+    "theme": {
+      "type": "enumeration",
+      "enum": [
+        "light",
+        "dark"
+      ],
+      "default": "light",
+      "required": true
+    }
+  }
+}

--- a/apps/strapi-cms/src/components/components/link-group.json
+++ b/apps/strapi-cms/src/components/components/link-group.json
@@ -1,0 +1,18 @@
+{
+  "collectionName": "components_components_link_groups",
+  "info": {
+    "displayName": "linkGroup"
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "links": {
+      "type": "component",
+      "repeatable": true,
+      "component": "components.link",
+      "required": true
+    }
+  }
+}

--- a/apps/strapi-cms/src/components/components/link.json
+++ b/apps/strapi-cms/src/components/components/link.json
@@ -1,0 +1,35 @@
+{
+  "collectionName": "components_components_links",
+  "info": {
+    "displayName": "Link",
+    "icon": "link",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "text": {
+      "type": "string"
+    },
+    "href": {
+      "type": "string",
+      "required": true
+    },
+    "linkType": {
+      "type": "enumeration",
+      "enum": [
+        "internal",
+        "external",
+        "wrapper",
+        "social"
+      ],
+      "default": "internal",
+      "required": true
+    },
+    "ariaLabel": {
+      "type": "string"
+    },
+    "icon": {
+      "type": "string"
+    }
+  }
+}

--- a/apps/strapi-cms/types/generated/components.d.ts
+++ b/apps/strapi-cms/types/generated/components.d.ts
@@ -1,5 +1,61 @@
 import type { Schema, Attribute } from '@strapi/strapi';
 
+export interface ComponentsCtaButton extends Schema.Component {
+  collectionName: 'components_components_cta_buttons';
+  info: {
+    displayName: 'CTAButton';
+  };
+  attributes: {
+    text: Attribute.String & Attribute.Required;
+    href: Attribute.String & Attribute.Required;
+    variant: Attribute.Enumeration<['text', 'contained', 'outlined']> &
+      Attribute.Required &
+      Attribute.DefaultTo<'text'>;
+    color: Attribute.Enumeration<
+      ['inherit', 'primary', 'secondary', 'success', 'error', 'info', 'warning']
+    > &
+      Attribute.Required &
+      Attribute.DefaultTo<'inherit'>;
+  };
+}
+
+export interface ComponentsLinkGroup extends Schema.Component {
+  collectionName: 'components_components_link_groups';
+  info: {
+    displayName: 'linkGroup';
+  };
+  attributes: {
+    title: Attribute.String;
+    links: Attribute.Component<'components.link', true> & Attribute.Required;
+  };
+}
+
+export interface ComponentsLink extends Schema.Component {
+  collectionName: 'components_components_links';
+  info: {
+    displayName: 'Link';
+    icon: 'link';
+    description: '';
+  };
+  attributes: {
+    text: Attribute.String;
+    href: Attribute.String & Attribute.Required;
+    linkType: Attribute.Enumeration<
+      ['internal', 'external', 'wrapper', 'social']
+    > &
+      Attribute.Required &
+      Attribute.DefaultTo<'internal'>;
+    ariaLabel: Attribute.String;
+    icon: Attribute.String;
+  };
+}
+
 declare module '@strapi/strapi' {
-  export module Shared {}
+  export module Shared {
+    export interface Components {
+      'components.cta-button': ComponentsCtaButton;
+      'components.link-group': ComponentsLinkGroup;
+      'components.link': ComponentsLink;
+    }
+  }
 }

--- a/apps/strapi-cms/types/generated/components.d.ts
+++ b/apps/strapi-cms/types/generated/components.d.ts
@@ -4,6 +4,7 @@ export interface ComponentsCtaButton extends Schema.Component {
   collectionName: 'components_components_cta_buttons';
   info: {
     displayName: 'CTAButton';
+    description: '';
   };
   attributes: {
     text: Attribute.String & Attribute.Required;
@@ -16,6 +17,23 @@ export interface ComponentsCtaButton extends Schema.Component {
     > &
       Attribute.Required &
       Attribute.DefaultTo<'inherit'>;
+    icon: Attribute.String;
+  };
+}
+
+export interface ComponentsCtaGroup extends Schema.Component {
+  collectionName: 'components_components_cta_groups';
+  info: {
+    displayName: 'CTAGroup';
+  };
+  attributes: {
+    ctaButtons: Attribute.Component<'components.cta-button', true>;
+    reverse: Attribute.Boolean &
+      Attribute.Required &
+      Attribute.DefaultTo<false>;
+    theme: Attribute.Enumeration<['light', 'dark']> &
+      Attribute.Required &
+      Attribute.DefaultTo<'light'>;
   };
 }
 
@@ -50,12 +68,42 @@ export interface ComponentsLink extends Schema.Component {
   };
 }
 
+export interface SectionsHero extends Schema.Component {
+  collectionName: 'components_sections_heroes';
+  info: {
+    displayName: 'Hero';
+    description: '';
+  };
+  attributes: {
+    title: Attribute.String & Attribute.Required;
+    subtitle: Attribute.RichText;
+    ctaButtons: Attribute.Component<'components.cta-button', true> &
+      Attribute.SetMinMax<{
+        max: 2;
+      }>;
+    image: Attribute.Media;
+    background: Attribute.Media;
+    theme: Attribute.Enumeration<['light', 'dark']> &
+      Attribute.Required &
+      Attribute.DefaultTo<'light'>;
+    inverse: Attribute.Boolean & Attribute.DefaultTo<false>;
+    size: Attribute.Enumeration<['small', 'big']> &
+      Attribute.Required &
+      Attribute.DefaultTo<'small'>;
+    useHoverlay: Attribute.Boolean &
+      Attribute.Required &
+      Attribute.DefaultTo<true>;
+  };
+}
+
 declare module '@strapi/strapi' {
   export module Shared {
     export interface Components {
       'components.cta-button': ComponentsCtaButton;
+      'components.cta-group': ComponentsCtaGroup;
       'components.link-group': ComponentsLinkGroup;
       'components.link': ComponentsLink;
+      'sections.hero': SectionsHero;
     }
   }
 }

--- a/apps/strapi-cms/types/generated/components.d.ts
+++ b/apps/strapi-cms/types/generated/components.d.ts
@@ -68,34 +68,6 @@ export interface ComponentsLink extends Schema.Component {
   };
 }
 
-export interface SectionsHero extends Schema.Component {
-  collectionName: 'components_sections_heroes';
-  info: {
-    displayName: 'Hero';
-    description: '';
-  };
-  attributes: {
-    title: Attribute.String & Attribute.Required;
-    subtitle: Attribute.RichText;
-    ctaButtons: Attribute.Component<'components.cta-button', true> &
-      Attribute.SetMinMax<{
-        max: 2;
-      }>;
-    image: Attribute.Media;
-    background: Attribute.Media;
-    theme: Attribute.Enumeration<['light', 'dark']> &
-      Attribute.Required &
-      Attribute.DefaultTo<'light'>;
-    inverse: Attribute.Boolean & Attribute.DefaultTo<false>;
-    size: Attribute.Enumeration<['small', 'big']> &
-      Attribute.Required &
-      Attribute.DefaultTo<'small'>;
-    useHoverlay: Attribute.Boolean &
-      Attribute.Required &
-      Attribute.DefaultTo<true>;
-  };
-}
-
 declare module '@strapi/strapi' {
   export module Shared {
     export interface Components {
@@ -103,7 +75,6 @@ declare module '@strapi/strapi' {
       'components.cta-group': ComponentsCtaGroup;
       'components.link-group': ComponentsLinkGroup;
       'components.link': ComponentsLink;
-      'sections.hero': SectionsHero;
     }
   }
 }

--- a/apps/strapi-cms/types/generated/contentTypes.d.ts
+++ b/apps/strapi-cms/types/generated/contentTypes.d.ts
@@ -908,6 +908,9 @@ export interface ApiFooterFooter extends Schema.SingleType {
       Attribute.Required;
     links_services: Attribute.Component<'components.link-group'> &
       Attribute.Required;
+    showFundedByNextGenerationEULogo: Attribute.Boolean &
+      Attribute.Required &
+      Attribute.DefaultTo<false>;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     createdBy: Attribute.Relation<
@@ -939,12 +942,17 @@ export interface ApiHeaderHeader extends Schema.SingleType {
   attributes: {
     productName: Attribute.String & Attribute.Required;
     beta: Attribute.Boolean & Attribute.Required & Attribute.DefaultTo<false>;
-    primaryButton: Attribute.Component<'components.cta-button'>;
-    secondaryButton: Attribute.Component<'components.cta-button'>;
     avatar: Attribute.Media;
     reverse: Attribute.Boolean &
       Attribute.Required &
       Attribute.DefaultTo<false>;
+    theme: Attribute.Enumeration<['light', 'dark']> &
+      Attribute.Required &
+      Attribute.DefaultTo<'light'>;
+    ctaButtons: Attribute.Component<'components.cta-button', true> &
+      Attribute.SetMinMax<{
+        max: 2;
+      }>;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     createdBy: Attribute.Relation<
@@ -998,11 +1006,8 @@ export interface ApiPreHeaderPreHeader extends Schema.SingleType {
     draftAndPublish: false;
   };
   attributes: {
-    theme: Attribute.Enumeration<['light', 'dark']> &
-      Attribute.Required &
-      Attribute.DefaultTo<'light'>;
-    leftCTAButton: Attribute.Component<'components.cta-button'>;
-    rightCTAButton: Attribute.Component<'components.cta-button'>;
+    leftCtas: Attribute.Component<'components.cta-group'>;
+    rightCtas: Attribute.Component<'components.cta-group'>;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     createdBy: Attribute.Relation<

--- a/apps/strapi-cms/types/generated/contentTypes.d.ts
+++ b/apps/strapi-cms/types/generated/contentTypes.d.ts
@@ -361,30 +361,6 @@ export interface AdminTransferTokenPermission extends Schema.CollectionType {
   };
 }
 
-export interface ApiPagePage extends Schema.CollectionType {
-  collectionName: 'pages';
-  info: {
-    singularName: 'page';
-    pluralName: 'pages';
-    displayName: 'Pagine';
-    description: '';
-  };
-  options: {
-    draftAndPublish: true;
-  };
-  attributes: {
-    name: Attribute.String & Attribute.Required & Attribute.Private;
-    slug: Attribute.String & Attribute.Required & Attribute.Unique;
-    createdAt: Attribute.DateTime;
-    updatedAt: Attribute.DateTime;
-    publishedAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<'api::page.page', 'oneToOne', 'admin::user'> &
-      Attribute.Private;
-    updatedBy: Attribute.Relation<'api::page.page', 'oneToOne', 'admin::user'> &
-      Attribute.Private;
-  };
-}
-
 export interface PluginUploadFile extends Schema.CollectionType {
   collectionName: 'files';
   info: {
@@ -910,6 +886,140 @@ export interface PluginNavigationNavigationsItemsRelated
   };
 }
 
+export interface ApiFooterFooter extends Schema.SingleType {
+  collectionName: 'footers';
+  info: {
+    singularName: 'footer';
+    pluralName: 'footers';
+    displayName: 'Footer';
+    description: '';
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  attributes: {
+    legalInfo: Attribute.RichText & Attribute.Required;
+    companyLink: Attribute.Component<'components.link'> & Attribute.Required;
+    links_aboutUs: Attribute.Component<'components.link-group'> &
+      Attribute.Required;
+    links_followUs: Attribute.Component<'components.link-group'> &
+      Attribute.Required;
+    links_resources: Attribute.Component<'components.link-group'> &
+      Attribute.Required;
+    links_services: Attribute.Component<'components.link-group'> &
+      Attribute.Required;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::footer.footer',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::footer.footer',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiHeaderHeader extends Schema.SingleType {
+  collectionName: 'headers';
+  info: {
+    singularName: 'header';
+    pluralName: 'headers';
+    displayName: 'Header';
+    description: '';
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  attributes: {
+    productName: Attribute.String & Attribute.Required;
+    beta: Attribute.Boolean & Attribute.Required & Attribute.DefaultTo<false>;
+    primaryButton: Attribute.Component<'components.cta-button'>;
+    secondaryButton: Attribute.Component<'components.cta-button'>;
+    avatar: Attribute.Media;
+    reverse: Attribute.Boolean &
+      Attribute.Required &
+      Attribute.DefaultTo<false>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::header.header',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::header.header',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiPagePage extends Schema.CollectionType {
+  collectionName: 'pages';
+  info: {
+    singularName: 'page';
+    pluralName: 'pages';
+    displayName: 'Pagine';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    name: Attribute.String & Attribute.Required & Attribute.Private;
+    slug: Attribute.String & Attribute.Required & Attribute.Unique;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<'api::page.page', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<'api::page.page', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+  };
+}
+
+export interface ApiPreHeaderPreHeader extends Schema.SingleType {
+  collectionName: 'pre_headers';
+  info: {
+    singularName: 'pre-header';
+    pluralName: 'pre-headers';
+    displayName: 'PreHeader';
+    description: '';
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  attributes: {
+    theme: Attribute.Enumeration<['light', 'dark']> &
+      Attribute.Required &
+      Attribute.DefaultTo<'light'>;
+    leftCTAButton: Attribute.Component<'components.cta-button'>;
+    rightCTAButton: Attribute.Component<'components.cta-button'>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::pre-header.pre-header',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::pre-header.pre-header',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
 declare module '@strapi/strapi' {
   export module Shared {
     export interface ContentTypes {
@@ -920,7 +1030,6 @@ declare module '@strapi/strapi' {
       'admin::api-token-permission': AdminApiTokenPermission;
       'admin::transfer-token': AdminTransferToken;
       'admin::transfer-token-permission': AdminTransferTokenPermission;
-      'api::page.page': ApiPagePage;
       'plugin::upload.file': PluginUploadFile;
       'plugin::upload.folder': PluginUploadFolder;
       'plugin::i18n.locale': PluginI18NLocale;
@@ -931,6 +1040,10 @@ declare module '@strapi/strapi' {
       'plugin::navigation.navigation': PluginNavigationNavigation;
       'plugin::navigation.navigation-item': PluginNavigationNavigationItem;
       'plugin::navigation.navigations-items-related': PluginNavigationNavigationsItemsRelated;
+      'api::footer.footer': ApiFooterFooter;
+      'api::header.header': ApiHeaderHeader;
+      'api::page.page': ApiPagePage;
+      'api::pre-header.pre-header': ApiPreHeaderPreHeader;
     }
   }
 }


### PR DESCRIPTION
This PR adds site-wide elements (Single Types) and the components needed for them to the Strapi CMS data structure.

The data's shape is based on the [Figma designs](https://www.figma.com/file/6Hn7Wxmvg6eCSqsMrIP7VU/CMS---UI-Components-%26-Templates?type=design&node-id=1-18544&mode=design&t=djDIr74ofFOmLCDR-0) and on the props requested by the [editorial components](https://pagopa.github.io/pagopa-editorial-components/?path=/docs/preheader-light--docs).

#### List of Changes
- Added PreHeader
- Added Header
- Added Footer
- Added CTAGroup component (used in PreHeader)
- Added CTAButton component (used in CTAGroup and Header)
- Added LinkGroup component (used in Footer)
- Added Link component (used in Footer and LinkGroup)

#### Motivation and Context
The data structure allows CMS users to define the respective elements to be rendered by Next.

#### How Has This Been Tested?
The data structure was used to fully render a page via NextJS.
Strapi and Next connected with no issues and Next was able to render everything as expected.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
