### PR TITLE
[B2BP-167] Casted getAllPages value to remove readonly for generateStaticParams

### DIFF
--- a/apps/nextjs-website/src/app/[...slug]/page.tsx
+++ b/apps/nextjs-website/src/app/[...slug]/page.tsx
@@ -1,4 +1,5 @@
 import { getAllPages } from '@/lib/api';
+import { Page } from '@/lib/pages';
 
 // Dynamic segments not included in generateStaticParams will return a 404.
 // more: https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#dynamicparams
@@ -6,7 +7,7 @@ export const dynamicParams = false;
 
 // Statically generate routes at build time instead of on-demand at request time.
 // more: https://nextjs.org/docs/app/building-your-application/routing/dynamic-routes#generating-static-params
-export const generateStaticParams = () => getAllPages();
+export const generateStaticParams = () => getAllPages() as Promise<Page[]>;
 
 type PageParams = {
   params: { slug: string[] };


### PR DESCRIPTION
Quick fix of a type mismatch inside /nextjs-website7src/app/[...slug]/page.tsx

#### List of Changes
- Casted the return value of getAllPages from Promise<ReadonlyArray<Page>> to Promise<Page[]>

#### Motivation and Context
Fix the following error
`
.next/types/app/[...slug]/page.ts(37,98): error TS2344: Type '{ __tag__: "generateStaticParams"; __return_type__: Promise<readonly Page[]>; }' does not satisfy the constraint '{ __tag__: "generateStaticParams"; __return_type__: any[] | Promise<any[]>; }'.
  Types of property '__return_type__' are incompatible.
    Type 'Promise<readonly Page[]>' is not assignable to type 'any[] | Promise<any[]>'.
      Type 'Promise<readonly Page[]>' is not assignable to type 'Promise<any[]>'.
        The type 'readonly Page[]' is 'readonly' and cannot be assigned to the mutable type 'any[]'.
`

#### How Has This Been Tested?
Reran successfully using `npm run dev`

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
