### PR TITLE
[B2BP-229] Data structure adjustments

### DIFF
--- a/apps/strapi-cms/src/components/components/cta-button.json
+++ b/apps/strapi-cms/src/components/components/cta-button.json
@@ -40,6 +40,16 @@
     },
     "icon": {
       "type": "string"
+    },
+    "size": {
+      "type": "enumeration",
+      "enum": [
+        "small",
+        "medium",
+        "large"
+      ],
+      "default": "medium",
+      "required": true
     }
   }
 }

--- a/apps/strapi-cms/src/components/sections/editorial.json
+++ b/apps/strapi-cms/src/components/sections/editorial.json
@@ -1,7 +1,8 @@
 {
   "collectionName": "components_sections_editorials",
   "info": {
-    "displayName": "Editorial"
+    "displayName": "Editorial",
+    "description": ""
   },
   "options": {},
   "attributes": {
@@ -17,12 +18,12 @@
       "required": true
     },
     "image": {
-      "allowedTypes": [
-        "images"
-      ],
       "type": "media",
       "multiple": false,
-      "required": true
+      "required": true,
+      "allowedTypes": [
+        "images"
+      ]
     },
     "theme": {
       "type": "enumeration",
@@ -63,6 +64,12 @@
       "repeatable": true,
       "component": "components.cta-button",
       "max": 2
+    },
+    "sectionID": {
+      "type": "string",
+      "regex": "^[a-z]+[a-z\\-]*$",
+      "required": false,
+      "unique": true
     }
   }
 }

--- a/apps/strapi-cms/src/components/sections/feature.json
+++ b/apps/strapi-cms/src/components/sections/feature.json
@@ -34,6 +34,11 @@
       "required": true,
       "max": 4,
       "min": 3
+    },
+    "sectionID": {
+      "type": "string",
+      "regex": "^[a-z]+[a-z\\-]*$",
+      "unique": true
     }
   }
 }

--- a/apps/strapi-cms/src/components/sections/hero.json
+++ b/apps/strapi-cms/src/components/sections/hero.json
@@ -20,18 +20,20 @@
       "max": 2
     },
     "image": {
+      "type": "media",
+      "multiple": false,
+      "required": false,
       "allowedTypes": [
         "images"
-      ],
-      "type": "media",
-      "multiple": false
+      ]
     },
     "background": {
+      "type": "media",
+      "multiple": false,
+      "required": false,
       "allowedTypes": [
         "images"
-      ],
-      "type": "media",
-      "multiple": false
+      ]
     },
     "theme": {
       "type": "enumeration",
@@ -60,6 +62,11 @@
       "type": "boolean",
       "default": true,
       "required": true
+    },
+    "sectionID": {
+      "type": "string",
+      "regex": "^[a-z]+[a-z\\-]*$",
+      "unique": true
     }
   }
 }

--- a/apps/strapi-cms/src/components/sections/how-to.json
+++ b/apps/strapi-cms/src/components/sections/how-to.json
@@ -43,6 +43,11 @@
       "component": "components.step",
       "required": true,
       "min": 2
+    },
+    "sectionID": {
+      "type": "string",
+      "regex": "^[a-z]+[a-z\\-]*$",
+      "unique": true
     }
   }
 }

--- a/apps/strapi-cms/types/generated/components.d.ts
+++ b/apps/strapi-cms/types/generated/components.d.ts
@@ -18,6 +18,9 @@ export interface ComponentsCtaButton extends Schema.Component {
       Attribute.Required &
       Attribute.DefaultTo<'inherit'>;
     icon: Attribute.String;
+    size: Attribute.Enumeration<['small', 'medium', 'large']> &
+      Attribute.Required &
+      Attribute.DefaultTo<'medium'>;
   };
 }
 
@@ -110,6 +113,7 @@ export interface SectionsEditorial extends Schema.Component {
   collectionName: 'components_sections_editorials';
   info: {
     displayName: 'Editorial';
+    description: '';
   };
   attributes: {
     title: Attribute.String & Attribute.Required;
@@ -132,6 +136,7 @@ export interface SectionsEditorial extends Schema.Component {
       Attribute.SetMinMax<{
         max: 2;
       }>;
+    sectionID: Attribute.String & Attribute.Unique;
   };
 }
 
@@ -156,6 +161,7 @@ export interface SectionsFeature extends Schema.Component {
         min: 3;
         max: 4;
       }>;
+    sectionID: Attribute.String & Attribute.Unique;
   };
 }
 
@@ -184,6 +190,7 @@ export interface SectionsHero extends Schema.Component {
     useHoverlay: Attribute.Boolean &
       Attribute.Required &
       Attribute.DefaultTo<true>;
+    sectionID: Attribute.String & Attribute.Unique;
   };
 }
 
@@ -208,6 +215,7 @@ export interface SectionsHowTo extends Schema.Component {
       Attribute.SetMinMax<{
         min: 2;
       }>;
+    sectionID: Attribute.String & Attribute.Unique;
   };
 }
 


### PR DESCRIPTION
Front end (Next) implementation showed the necessity for two extra fields in the data structure:
1. An ID for sections to enable linking inside of a page (like #section-id)
2. A size property for CTA buttons

#### List of Changes
- Added size property to ctaButton component
- Added sectionID property to all sections

#### Motivation and Context
Replicate complete functionality of current SEND website.

#### How Has This Been Tested?
Locally as per README.md

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
