### PR TITLE
[B2BP-242] Fetch page data from server

### DIFF
--- a/apps/nextjs-website/src/app/[...slug]/page.tsx
+++ b/apps/nextjs-website/src/app/[...slug]/page.tsx
@@ -1,4 +1,5 @@
 import { getAllPages } from '@/lib/api';
+import { Page } from '@/lib/pages';
 
 // Dynamic segments not included in generateStaticParams will return a 404.
 // more: https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#dynamicparams
@@ -6,7 +7,7 @@ export const dynamicParams = false;
 
 // Statically generate routes at build time instead of on-demand at request time.
 // more: https://nextjs.org/docs/app/building-your-application/routing/dynamic-routes#generating-static-params
-export const generateStaticParams = () => getAllPages();
+export const generateStaticParams = () => getAllPages() as Promise<Page[]>;
 
 type PageParams = {
   params: { slug: string[] };

--- a/apps/nextjs-website/src/app/[...slug]/page.tsx
+++ b/apps/nextjs-website/src/app/[...slug]/page.tsx
@@ -1,4 +1,4 @@
-import { getAllPages } from '@/lib/api';
+import { getAllPages, getPageProps } from '@/lib/api';
 import { Page } from '@/lib/pages';
 
 // Dynamic segments not included in generateStaticParams will return a 404.
@@ -13,11 +13,22 @@ type PageParams = {
   params: { slug: string[] };
 };
 
-const Page = ({ params }: PageParams) => {
+const Page = async ({ params }: PageParams) => {
   const { slug } = params;
+  const allPages = await getAllPages(); // Gets result directly from internal cache
+
+  const pageID = allPages.filter(
+    (page) => slug.join('') === page.slug.join('')
+  )[0]?.id;
+  if (!pageID) {
+    return null;
+  }
+
+  const pageProps = await getPageProps(pageID);
   return (
     <div>
       <p>This is the page {slug.join('/')}</p>
+      <p>These are my props {JSON.stringify(pageProps)}</p>
     </div>
   );
 };

--- a/apps/nextjs-website/src/app/page.tsx
+++ b/apps/nextjs-website/src/app/page.tsx
@@ -1,12 +1,18 @@
-'use client';
-import { Hero } from '@pagopa/pagopa-editorial-components';
+import { getAllPages, getPageProps } from '@/lib/api';
 
-export default function Home() {
+export default async function Home() {
+  const allPages = await getAllPages(); // Gets result directly from internal cache
+
+  const pageID = allPages.filter((page) => '' === page.slug.join(''))[0]?.id;
+  if (!pageID) {
+    return null;
+  }
+
+  const pageProps = await getPageProps(pageID);
   return (
-    <main>
-      <div>
-        <Hero title={'Hello World!'} />
-      </div>
-    </main>
+    <div>
+      <p>This is the Home page</p>
+      <p>These are my props {JSON.stringify(pageProps)}</p>
+    </div>
   );
 }

--- a/apps/nextjs-website/src/lib/__tests__/pages.test.ts
+++ b/apps/nextjs-website/src/lib/__tests__/pages.test.ts
@@ -7,6 +7,10 @@ const parentNavItem = {
   title: 'Parent',
   path: 'parent',
   parent: null,
+  related: {
+    id: 2,
+    slug: 'parent',
+  },
 };
 const childNavItem = {
   order: 1,
@@ -14,6 +18,10 @@ const childNavItem = {
   title: 'Child',
   path: 'child',
   parent: parentNavItem,
+  related: {
+    id: 3,
+    slug: 'child',
+  },
 };
 
 describe('makePageListFromNavigation', () => {
@@ -23,7 +31,14 @@ describe('makePageListFromNavigation', () => {
   });
   it('should return pages list given a navigation with homepage', () => {
     const actual = makePageListFromNavigation([
-      { order: 1, id: 1, title: 'Home', path: '/', parent: null },
+      {
+        order: 1,
+        id: 1,
+        title: 'Home',
+        path: '/',
+        parent: null,
+        related: { id: 1, slug: '/' },
+      },
     ]);
     const expected = [{ slug: [] }];
     expect(actual).toStrictEqual(expected);

--- a/apps/nextjs-website/src/lib/api.ts
+++ b/apps/nextjs-website/src/lib/api.ts
@@ -4,6 +4,7 @@ import * as E from 'fp-ts/lib/Either';
 import { Page, makePageListFromNavigation } from './pages';
 import { getNavigation } from './fetch/navigation';
 import { PreHeader, getPreHeader } from './fetch/preHeader';
+import { Components, getComponents } from './fetch/components';
 import { makeAppEnv } from '@/AppEnv';
 
 // create AppEnv given process env
@@ -30,3 +31,13 @@ export const getPreHeaderProps = async (): Promise<
   } = await getPreHeader(appEnv);
   return attributes;
 };
+
+// Return ComponentsProps for a specific page ID
+export const getComponentsProps = async (
+  idprops: number
+): Promise<Components> =>
+  getComponents({
+    config: appEnv.config,
+    fetchFun: appEnv.fetchFun,
+    id: idprops,
+  });

--- a/apps/nextjs-website/src/lib/api.ts
+++ b/apps/nextjs-website/src/lib/api.ts
@@ -4,7 +4,7 @@ import * as E from 'fp-ts/lib/Either';
 import { Page, makePageListFromNavigation } from './pages';
 import { getNavigation } from './fetch/navigation';
 import { PreHeader, getPreHeader } from './fetch/preHeader';
-import { Components, getComponents } from './fetch/components';
+import { PageData, getPage } from './fetch/page';
 import { makeAppEnv } from '@/AppEnv';
 
 // create AppEnv given process env
@@ -32,12 +32,16 @@ export const getPreHeaderProps = async (): Promise<
   return attributes;
 };
 
-// Return ComponentsProps for a specific page ID
-export const getComponentsProps = async (
-  idprops: number
-): Promise<Components> =>
-  getComponents({
+// Return PageProps for a specific page ID
+export const getPageProps = async (
+  pageID: number
+): Promise<PageData['data']['attributes']> => {
+  const {
+    data: { attributes },
+  } = await getPage({
     config: appEnv.config,
     fetchFun: appEnv.fetchFun,
-    id: idprops,
+    id: pageID,
   });
+  return attributes;
+};

--- a/apps/nextjs-website/src/lib/fetch/components.ts
+++ b/apps/nextjs-website/src/lib/fetch/components.ts
@@ -1,0 +1,41 @@
+import * as t from 'io-ts';
+import { extractFromResponse } from './extractFromResponse';
+import { AppEnv } from '@/AppEnv';
+
+const AttributesCodec = t.strict({
+  slug: t.string,
+  sections: t.array(
+    t.strict({
+      id: t.number,
+      __component: t.string,
+    })
+  ),
+});
+
+const ComponentsCodec = t.strict({
+  data: t.strict({
+    id: t.number,
+    attributes: AttributesCodec,
+  }),
+});
+
+// Types
+export type Components = t.TypeOf<typeof ComponentsCodec>;
+
+export const getComponents = ({
+  config,
+  fetchFun,
+  id,
+}: Readonly<AppEnv & { readonly id: number }>): Promise<Readonly<Components>> =>
+  extractFromResponse(
+    fetchFun(
+      `${config.STRAPI_API_BASE_URL}/api/pages/${id}?populate[sections][populate][0]=ctaButtons,image,background,items,link,steps`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${config.STRAPI_API_TOKEN}`,
+        },
+      }
+    ),
+    ComponentsCodec
+  );

--- a/apps/nextjs-website/src/lib/fetch/navigation.ts
+++ b/apps/nextjs-website/src/lib/fetch/navigation.ts
@@ -13,6 +13,10 @@ const NavItemCodec = t.intersection([
   ParentCodec,
   t.strict({
     parent: t.union([ParentCodec, t.null]),
+    related: t.strict({
+      id: t.number,
+      slug: t.string,
+    }),
   }),
 ]);
 const NavigationCodec = t.readonlyArray(NavItemCodec);

--- a/apps/nextjs-website/src/lib/fetch/page.ts
+++ b/apps/nextjs-website/src/lib/fetch/page.ts
@@ -2,31 +2,26 @@ import * as t from 'io-ts';
 import { extractFromResponse } from './extractFromResponse';
 import { AppEnv } from '@/AppEnv';
 
-const AttributesCodec = t.strict({
-  slug: t.string,
-  sections: t.array(
-    t.strict({
-      id: t.number,
-      __component: t.string,
-    })
-  ),
-});
-
-const ComponentsCodec = t.strict({
+const PageCodec = t.strict({
   data: t.strict({
-    id: t.number,
-    attributes: AttributesCodec,
+    attributes: t.strict({
+      sections: t.array(
+        t.strict({
+          __component: t.string,
+        })
+      ),
+    }),
   }),
 });
 
 // Types
-export type Components = t.TypeOf<typeof ComponentsCodec>;
+export type PageData = t.TypeOf<typeof PageCodec>;
 
-export const getComponents = ({
+export const getPage = ({
   config,
   fetchFun,
   id,
-}: Readonly<AppEnv & { readonly id: number }>): Promise<Readonly<Components>> =>
+}: AppEnv & { readonly id: number }): Promise<Readonly<PageData>> =>
   extractFromResponse(
     fetchFun(
       `${config.STRAPI_API_BASE_URL}/api/pages/${id}?populate[sections][populate][0]=ctaButtons,image,background,items,link,steps`,
@@ -37,5 +32,5 @@ export const getComponents = ({
         },
       }
     ),
-    ComponentsCodec
+    PageCodec
   );

--- a/apps/nextjs-website/src/lib/pages.ts
+++ b/apps/nextjs-website/src/lib/pages.ts
@@ -4,6 +4,7 @@ import { Navigation } from './fetch/navigation';
 
 export type Page = {
   readonly slug: ReadonlyArray<string>;
+  readonly id: number;
 };
 
 const makeSlugList = (
@@ -25,5 +26,8 @@ export const makePageListFromNavigation = (
 ): ReadonlyArray<Page> =>
   pipe(
     navigation,
-    RA.map((item) => ({ slug: makeSlugList(item, navigation) }))
+    RA.map((item) => ({
+      slug: makeSlugList(item, navigation),
+      id: item.related.id,
+    }))
   );

--- a/apps/strapi-cms/src/api/page/content-types/page/schema.json
+++ b/apps/strapi-cms/src/api/page/content-types/page/schema.json
@@ -19,7 +19,7 @@
     },
     "slug": {
       "type": "string",
-      "regex": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+      "regex": "^(?:[a-z0-9]+(?:-[a-z0-9]+)*|\\/)$",
       "required": true,
       "unique": true
     },


### PR DESCRIPTION
This PR adds fetching for each generated page separately.

Note: generateStaticParams only passes parameters if they are present in the URL (in our case this does NOT include the page's ID), because of this, to get the ID needed to fetch data for each single page, we are calling getAllPages inside of each one.

This would normally make a bunch of unwanted requests to the server, this does not happen however, thanks to NextJS internal cache which allows us to call the Strapi server only on the first fetch and subsequently retrieve the result from cache.

#### List of Changes
- Added fetching for Home Page
- Added fetching for dynamically generated pages

Also, on Strapi's side, the regex validating the slug field of the page has been updated to allow for one special case to be able to distinguish the home page from others. We are currently using the slug '/' to indicate the home page.

#### Motivation and Context
Fetching data needed to render pages.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested locally.
Automatic tests will be added once we flesh out the page data's structure more.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
