### PR TITLE
[B2BP-279] Implemented Home page as a Strapi Single Type

### DIFF
--- a/apps/nextjs-website/src/app/page.tsx
+++ b/apps/nextjs-website/src/app/page.tsx
@@ -1,11 +1,13 @@
-'use client';
-import { Hero } from '@pagopa/pagopa-editorial-components';
+import { getHomeProps } from '@/lib/api';
 
-export default function Home() {
+export default async function Home() {
+  const homeProps = await getHomeProps();
+
   return (
     <main>
       <div>
-        <Hero title={'Hello World!'} />
+        <p>This is the Home page</p>
+        <p>These are my props {JSON.stringify(homeProps)}</p>
       </div>
     </main>
   );

--- a/apps/nextjs-website/src/lib/__tests__/home.test.ts
+++ b/apps/nextjs-website/src/lib/__tests__/home.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { makeHeaderProps } from '../header';
+import { Header } from '../fetch/header';
+import * as data from '../fetch/__tests__/data';
+
+const header: Header = {
+  data: {
+    attributes: {
+      theme: 'light',
+      avatar: {
+        data: {
+          attributes: {
+            url: 'path/to/avatar.jpg',
+            alternativeText: 'Alt text',
+          },
+        },
+      },
+      beta: true,
+      reverse: false,
+      productName: 'aProductName',
+      ctaButtons: [
+        {
+          text: 'Primary',
+          href: 'primary.com',
+          variant: 'contained',
+          color: 'inherit',
+        },
+      ],
+    },
+  },
+};
+
+describe('makeHeaderProps', () => {
+  it('should return header props with avatar when avatar is present', () => {
+    const navigation = [data.parentNavItem, data.childNavItem];
+    const actual = makeHeaderProps(navigation, header);
+    const expected = {
+      theme: 'light',
+      avatar: {
+        src: 'path/to/avatar.jpg',
+      },
+      beta: true,
+      reverse: false,
+      product: {
+        name: 'aProductName',
+        href: '/',
+      },
+      ctaButtons: header.data.attributes.ctaButtons,
+      menu: [
+        {
+          href: '/parent',
+          label: 'Parent',
+          theme: 'light',
+          items: [
+            {
+              href: '/parent/child',
+              label: 'Child',
+            },
+          ],
+        },
+      ],
+    };
+    expect(actual).toStrictEqual(expected);
+  });
+});

--- a/apps/nextjs-website/src/lib/__tests__/pages.test.ts
+++ b/apps/nextjs-website/src/lib/__tests__/pages.test.ts
@@ -7,11 +7,6 @@ describe('makePageListFromNavigation', () => {
     const actual = makePageListFromNavigation([]);
     expect(actual).toStrictEqual([]);
   });
-  it('should return pages list given a navigation with homepage', () => {
-    const actual = makePageListFromNavigation([data.homepageNavItem]);
-    const expected = [{ slug: [] }];
-    expect(actual).toStrictEqual(expected);
-  });
   it('should return pages list given a navigation with parent', () => {
     const navigation = [data.parentNavItem, data.childNavItem];
     const actual = makePageListFromNavigation(navigation);

--- a/apps/nextjs-website/src/lib/api.ts
+++ b/apps/nextjs-website/src/lib/api.ts
@@ -9,6 +9,7 @@ import { getFooter } from './fetch/footer';
 import { getHeader } from './fetch/header';
 import { makeHeaderProps } from './header';
 import { FooterProps, makeFooterProps } from './footer';
+import { HomeData, getHome } from './fetch/home';
 import { makeAppEnv } from '@/AppEnv';
 
 // create AppEnv given process env
@@ -45,4 +46,16 @@ export const getHeaderProps = async (): Promise<HeaderProps> => {
 export const getFooterProps = async (): Promise<FooterProps> => {
   const footer = await getFooter(appEnv);
   return makeFooterProps(footer);
+};
+
+export const getHomeProps = async (): Promise<
+  HomeData['data']['attributes']
+> => {
+  const {
+    data: { attributes },
+  } = await getHome({
+    config: appEnv.config,
+    fetchFun: appEnv.fetchFun,
+  });
+  return attributes;
 };

--- a/apps/nextjs-website/src/lib/fetch/__tests__/home.test.ts
+++ b/apps/nextjs-website/src/lib/fetch/__tests__/home.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest';
+import { getHome } from '../home';
+
+const makeTestAppEnv = () => {
+  const config = {
+    STRAPI_API_TOKEN: 'aStrapiToken',
+    STRAPI_API_BASE_URL: 'aStrapiApiBaseUrl',
+  };
+  const fetchMock = vi.fn(fetch);
+  const appEnv = { config, fetchFun: fetchMock };
+  return { appEnv, fetchMock };
+};
+
+// Response will be expanded when we fetch actual data
+const homeResponse = {
+  data: {
+    attributes: {
+      sections: [
+        {
+          __component: 'sections.hero',
+        },
+        {
+          __component: 'sections.editorial',
+        },
+        {
+          __component: 'sections.editorial',
+        },
+      ],
+    },
+  },
+};
+
+describe('getHome', () => {
+  it('should call /api/home type GET', async () => {
+    const { appEnv, fetchMock } = makeTestAppEnv();
+    const { config } = appEnv;
+
+    fetchMock.mockResolvedValueOnce({
+      json: () => Promise.resolve(homeResponse),
+    } as unknown as Response);
+
+    await getHome(appEnv);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${config.STRAPI_API_BASE_URL}/api/home/?populate[sections][populate][0]=ctaButtons,image,background,items,link,steps`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${config.STRAPI_API_TOKEN}`,
+        },
+      }
+    );
+  });
+
+  it('should parse header without error', async () => {
+    const { appEnv, fetchMock } = makeTestAppEnv();
+
+    fetchMock.mockResolvedValueOnce({
+      json: () => Promise.resolve(homeResponse),
+    } as unknown as Response);
+
+    const actual = getHome(appEnv);
+
+    expect(await actual).toStrictEqual(homeResponse);
+  });
+});

--- a/apps/nextjs-website/src/lib/fetch/home.ts
+++ b/apps/nextjs-website/src/lib/fetch/home.ts
@@ -1,0 +1,33 @@
+import * as t from 'io-ts';
+import { extractFromResponse } from './extractFromResponse';
+import { AppEnv } from '@/AppEnv';
+
+// This codec is only temporary, we will probably use the PageCodec once it's merged into main
+const HomeDataCodec = t.strict({
+  data: t.strict({
+    attributes: t.strict({
+      sections: t.array(
+        t.strict({
+          __component: t.string,
+        })
+      ),
+    }),
+  }),
+});
+
+// Types
+export type HomeData = t.TypeOf<typeof HomeDataCodec>;
+
+export const getHome = ({ config, fetchFun }: AppEnv): Promise<HomeData> =>
+  extractFromResponse(
+    fetchFun(
+      `${config.STRAPI_API_BASE_URL}/api/home/?populate[sections][populate][0]=ctaButtons,image,background,items,link,steps`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${config.STRAPI_API_TOKEN}`,
+        },
+      }
+    ),
+    HomeDataCodec
+  );

--- a/apps/nextjs-website/src/lib/pages.ts
+++ b/apps/nextjs-website/src/lib/pages.ts
@@ -14,9 +14,9 @@ const makeSlugList = (
   if (parent) {
     const parentNav = navigation.find(({ id }) => id === parent.id);
     const parentSlug = parentNav ? makeSlugList(parentNav, navigation) : [];
-    return path !== '/' ? [...parentSlug, path] : [];
+    return [...parentSlug, path];
   } else {
-    return path !== '/' ? [path] : [];
+    return [path];
   }
 };
 

--- a/apps/strapi-cms/src/api/home/content-types/home/schema.json
+++ b/apps/strapi-cms/src/api/home/content-types/home/schema.json
@@ -1,0 +1,27 @@
+{
+  "kind": "singleType",
+  "collectionName": "homes",
+  "info": {
+    "singularName": "home",
+    "pluralName": "homes",
+    "displayName": "Home",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "sections": {
+      "type": "dynamiczone",
+      "components": [
+        "sections.editorial",
+        "sections.feature",
+        "sections.hero",
+        "sections.how-to"
+      ],
+      "required": true,
+      "min": 1
+    }
+  }
+}

--- a/apps/strapi-cms/src/api/home/controllers/home.ts
+++ b/apps/strapi-cms/src/api/home/controllers/home.ts
@@ -1,0 +1,7 @@
+/**
+ * home controller
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::home.home');

--- a/apps/strapi-cms/src/api/home/routes/home.ts
+++ b/apps/strapi-cms/src/api/home/routes/home.ts
@@ -1,0 +1,7 @@
+/**
+ * home router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::home.home');

--- a/apps/strapi-cms/src/api/home/services/home.ts
+++ b/apps/strapi-cms/src/api/home/services/home.ts
@@ -1,0 +1,7 @@
+/**
+ * home service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::home.home');


### PR DESCRIPTION
The homepage is currently implemented as one of the many pages of the website.

This brings some issues:
- If we allow a page's slug to be empty or '/' to accomodate for the home, we open the door to any number of pages having an empty or '/' slug (which is an issue)
- On static build, NextJS is unable to render a page with slug '/' as it would need to create a /.html file (invalid name). This would be solvable by filtering out the home however, so it's a secondary issue
- We have no certainty that the user will include a home page at all

#### List of Changes
<!--- Describe your changes in detail -->
To solve the above problems the Home page is being implemented as a Single Type in this PR (akin to how Header, PreHeader and Footer work), more specifically:
- Added Home as a Single Type to Strapi
- Fetched home data using its own API URL
- Removed filtering of homepage from pages.ts and pages.test.ts since the homepage is no longer among normal pages

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Solves above issues and strongly reduces the user's ability for errors.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Local and unit tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
