### PR TITLE
[B2BP-115] - Workflow Deploy CMS fix for automatic Deploy on Push

### DIFF
--- a/.github/workflows/deploy_cms.yaml
+++ b/.github/workflows/deploy_cms.yaml
@@ -7,14 +7,6 @@ on:
         paths:
           - 'apps/strapi-cms/**'
           - '.github/workflows/deploy_cms.yaml'
-        inputs:
-          environment:
-            description: 'The environment used as target'
-            type: choice
-            required: true
-            default: prod
-            options:
-              - prod
 
   workflow_dispatch:
     inputs:
@@ -47,7 +39,7 @@ jobs:
     name: Build and push CMS image
     runs-on: ubuntu-latest
     continue-on-error: false
-    environment: ${{ inputs.environment }}
+   # environment: ${{ inputs.environment }}
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
       id-token: write

--- a/.github/workflows/deploy_cms.yaml
+++ b/.github/workflows/deploy_cms.yaml
@@ -17,13 +17,6 @@ on:
         type: choice
         options:
           - warning
-      environment:
-        description: 'The environment used as target'
-        type: choice
-        required: true
-        default: prod
-        options:
-          - prod
 
 defaults:
   run:

--- a/.github/workflows/deploy_cms.yaml
+++ b/.github/workflows/deploy_cms.yaml
@@ -2,7 +2,7 @@ name: Deploy CMS
 
 on:
   push:
-        branches: ['main']
+        branches: ['workflow-github-deploy-cms-modify-role-to-assume']
         # Run only if there are at least one change matching the following paths
         paths:
           - 'apps/strapi-cms/**'

--- a/.github/workflows/deploy_cms.yaml
+++ b/.github/workflows/deploy_cms.yaml
@@ -2,7 +2,7 @@ name: Deploy CMS
 
 on:
   push:
-        branches: ['workflow-github-deploy-cms-modify-role-to-assume']
+        branches: ['main']
         # Run only if there are at least one change matching the following paths
         paths:
           - 'apps/strapi-cms/**'

--- a/.github/workflows/deploy_cms.yaml
+++ b/.github/workflows/deploy_cms.yaml
@@ -53,7 +53,7 @@ jobs:
         uses: ./.github/actions/configure-aws-credentials
         with:
           aws_region: ${{ env.AWS_REGION || 'eu-south-1' }}
-          role_to_assume: ${{ secrets.IAM_ROLE_DEPLOY_CMS }}
+          role-to-assume: ${{ secrets.IAM_ROLE_DEPLOY_CMS }}
 
       - name: Login to Amazon ECR
         id: login-ecr

--- a/.github/workflows/deploy_cms.yaml
+++ b/.github/workflows/deploy_cms.yaml
@@ -39,6 +39,10 @@ jobs:
     name: Build and push CMS image
     runs-on: ubuntu-latest
     continue-on-error: false
+    strategy:
+      matrix:
+        environment: [ 'prod' ]
+    environment: ${{ matrix.environment }}
    # environment: ${{ inputs.environment }}
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:

--- a/.github/workflows/deploy_cms.yaml
+++ b/.github/workflows/deploy_cms.yaml
@@ -44,6 +44,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      pull-requests: write
 
     steps:
       - name: Checkout
@@ -53,7 +54,7 @@ jobs:
         uses: ./.github/actions/configure-aws-credentials
         with:
           aws_region: ${{ env.AWS_REGION || 'eu-south-1' }}
-          role-to-assume: ${{ secrets.IAM_ROLE_DEPLOY_CMS }}
+          role_to_assume: ${{ secrets.IAM_ROLE_DEPLOY_CMS }}
 
       - name: Login to Amazon ECR
         id: login-ecr

--- a/.github/workflows/deploy_cms.yaml
+++ b/.github/workflows/deploy_cms.yaml
@@ -43,11 +43,11 @@ jobs:
       matrix:
         environment: [ 'prod' ]
     environment: ${{ matrix.environment }}
-   # environment: ${{ inputs.environment }}
+    # environment: ${{ inputs.environment }}
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
-    permissions:
-      id-token: write
-      contents: read
+    #permissions:
+    #  id-token: write
+    #  contents: read
 
     steps:
       - name: Checkout

--- a/.github/workflows/deploy_cms.yaml
+++ b/.github/workflows/deploy_cms.yaml
@@ -43,12 +43,7 @@ jobs:
       matrix:
         environment: [ 'prod' ]
     environment: ${{ matrix.environment }}
-    # environment: ${{ inputs.environment }}
-    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
-    #permissions:
-    #  id-token: write
-    #  contents: read
-
+    
     steps:
       - name: Checkout
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0

--- a/.github/workflows/deploy_cms.yaml
+++ b/.github/workflows/deploy_cms.yaml
@@ -7,6 +7,14 @@ on:
         paths:
           - 'apps/strapi-cms/**'
           - '.github/workflows/deploy_cms.yaml'
+        inputs:
+          environment:
+            description: 'The environment used as target'
+            type: choice
+            required: true
+            default: prod
+            options:
+              - prod
 
   workflow_dispatch:
     inputs:
@@ -44,7 +52,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
-      pull-requests: write
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Fix on Workflow GitHub "deploy_cms" for push trigger: when someone merge a pull request or push on main branch, the workflow "deploy_cms" terminate in error because the environment value=prod is not passed and the workflow does not take  the role needed to authenticate to AWS

#### List of Changes
Workflow file "deploy_cms.yaml"

#### Motivation and Context
 when someone merge a pull request or push on main, the workflow "deploy_cms" terminate in error because the environment value=prod is not passed and the workflow does not take  the role needed to authenticate to AWS

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change not requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
