### PR TITLE
[B2BP-325] - Add ECS var for strapi retrieve image from cdn

### DIFF
--- a/.infrastructure/07_ecs.tf
+++ b/.infrastructure/07_ecs.tf
@@ -25,7 +25,8 @@ data "template_file" "cms_app" {
     access_key_id        = aws_ssm_parameter.cms_access_key_id.arn
     access_key_secret    = aws_ssm_parameter.cms_access_key_secret.arn
     bucket_full_url      = aws_s3_bucket.cms_medialibrary_bucket.bucket_regional_domain_name
-    cdn_url              = "https://${aws_cloudfront_distribution.cms_medialibrary.domain_name}/"
+    cdn_url              = "https://${aws_cloudfront_distribution.cms_medialibrary.domain_name}"
+    aws_bucket_endpoint  = "https://s3.${var.aws_region}.amazonaws.com"
   }
 }
 

--- a/.infrastructure/task-definitions/cms_app.json.tpl
+++ b/.infrastructure/task-definitions/cms_app.json.tpl
@@ -55,6 +55,10 @@
       {
         "name": "CDN_URL",
         "value": "${cdn_url}"
+      },
+      {
+        "name": "AWS_BUCKET_ENDPOINT",
+        "value": "${aws_bucket_endpoint}"
       }
     ],
     "secrets" : [


### PR DESCRIPTION
Add ECS var "AWS_BUCKET_ENDPOINT" and modify ECS var "CDN_URL" to fix the problem of loading images by strapi via cdn


#### List of Changes
Add ECS var "AWS_BUCKET_ENDPOINT" and modify ECS var "CDN_URL" 

#### Motivation and Context
To fix the problem of loading images by strapi via cdn

#### How Has This Been Tested?
on personal AWS account

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change not requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
