### PR TITLE
[B2BP-273] Prevent homepage from building as a secondary page

### DIFF
--- a/.changeset/brown-needles-sell.md
+++ b/.changeset/brown-needles-sell.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Prevent homepage from building as a secondary page

--- a/apps/nextjs-website/src/app/[...slug]/page.tsx
+++ b/apps/nextjs-website/src/app/[...slug]/page.tsx
@@ -14,7 +14,7 @@ export const generateStaticParams = async (): Promise<Page[]> =>
   // "generateStaticParams"; __return_type__: Promise<readonly Page[]>; }' does
   // not satisfy the constraint '{ __tag__: "generateStaticParams";
   // __return_type__: any[] | Promise<any[]>; }'.
-  [...(await getAllPages())];
+  [...(await getAllPages())].filter((page) => page.slug[0] !== 'homepage');
 
 type PageParams = {
   params: { slug: string[] };

--- a/apps/nextjs-website/src/app/page.tsx
+++ b/apps/nextjs-website/src/app/page.tsx
@@ -2,7 +2,7 @@ import PageSection from '@/components/PageSection/PageSection';
 import { getPageProps } from '@/lib/api';
 
 export default async function Home() {
-  const pageProps = await getPageProps([]);
+  const pageProps = await getPageProps(['homepage']);
   const sections = pageProps?.sections || [];
 
   return <div>{sections.map(PageSection)}</div>;

--- a/apps/nextjs-website/src/lib/__tests__/pages.test.ts
+++ b/apps/nextjs-website/src/lib/__tests__/pages.test.ts
@@ -10,7 +10,7 @@ describe('makePageListFromNavigation', () => {
   it('should return pages list given a navigation with homepage', () => {
     const actual = makePageListFromNavigation([data.homepageNavItem]);
     const expected = [
-      { slug: [], sections: data.homepageNavItem.related.sections },
+      { slug: ['homepage'], sections: data.homepageNavItem.related.sections },
     ];
     expect(actual).toStrictEqual(expected);
   });

--- a/apps/nextjs-website/src/lib/pages.ts
+++ b/apps/nextjs-website/src/lib/pages.ts
@@ -16,9 +16,9 @@ const makeSlugList = (
   if (parent) {
     const parentNav = navigation.find(({ id }) => id === parent.id);
     const parentSlug = parentNav ? makeSlugList(parentNav, navigation) : [];
-    return related.slug !== 'homepage' ? [...parentSlug, related.slug] : [];
+    return [...parentSlug, related.slug];
   } else {
-    return related.slug !== 'homepage' ? [related.slug] : [];
+    return [related.slug];
   }
 };
 


### PR DESCRIPTION
Previous solution gave an error on build.

`Export encountered errors on following paths: /[...slug]/page: /`

This was because getAllPages would return a route with no slug (the homepage), which would then erroneously be passed to generateStaticParams.

#### List of Changes
<!--- Describe your changes in detail -->
- Filtered getAllPages when passing its results to generateStaticParams
- Updated makeSlugList: modifying the homepage's slug from ['homepage'] to [] was made redundant/useless by the above change
- Updated homepage to look for ['homepage'] instead of [] when calling getPageProps

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix to the above mentioned error on build.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested locally.

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
