### PR TITLE
[B2BP-338] - Add ECS var for PAT token GitHub Strapi

### DIFF
--- a/.infrastructure/04_secrets.tf
+++ b/.infrastructure/04_secrets.tf
@@ -81,3 +81,15 @@ resource "aws_ssm_parameter" "cms_access_key_secret" {
   type  = "SecureString"
   value = aws_iam_access_key.strapi.secret
 }
+
+resource "random_password" "cms_github_pat" {
+  length           = 16
+  special          = true
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+}
+
+resource "aws_ssm_parameter" "cms_github_pat" {
+  name  = "/cms/github_pat"
+  type  = "SecureString"
+  value = random_password.cms_github_pat.result
+}

--- a/.infrastructure/07_ecs.tf
+++ b/.infrastructure/07_ecs.tf
@@ -27,6 +27,11 @@ data "template_file" "cms_app" {
     bucket_full_url      = aws_s3_bucket.cms_medialibrary_bucket.bucket_regional_domain_name
     cdn_url              = "https://${aws_cloudfront_distribution.cms_medialibrary.domain_name}"
     aws_bucket_endpoint  = "https://s3.${var.aws_region}.amazonaws.com"
+    repo_owner           = "pagopa"
+    repo_name            = "b2b-portals"
+    workflow_id          = "deploy_website.yaml"
+    target_branch        = "main"
+    github_pat           = aws_ssm_parameter.cms_github_pat.arn
   }
 }
 

--- a/.infrastructure/task-definitions/cms_app.json.tpl
+++ b/.infrastructure/task-definitions/cms_app.json.tpl
@@ -59,6 +59,22 @@
       {
         "name": "AWS_BUCKET_ENDPOINT",
         "value": "${aws_bucket_endpoint}"
+      },
+      {
+        "name": "REPO_OWNER",
+        "value": "${repo_owner}"
+      },
+      {
+        "name": "REPO_NAME",
+        "value": "${repo_name}"
+      },
+      {
+        "name": "WORKFLOW_ID",
+        "value": "${workflow_id}"
+      },
+      {
+        "name": "TARGET_BRANCH",
+        "value": "${target_branch}"
       }
     ],
     "secrets" : [
@@ -93,6 +109,10 @@
       {
         "name": "AWS_ACCESS_SECRET",
         "valueFrom": "${access_key_secret}"
+      },
+      {
+        "name": "GITHUB_PAT",
+        "valueFrom": "${github_pat}"
       }
     ]
   }


### PR DESCRIPTION
Add new env var for ECS Task definition for deploy static site from Strapi to GitHub:
GITHUB_PAT
REPO_OWNER
REPO_NAME
WORKFLOW_ID
TARGET_BRANCH

@datalek: you need to create the PAT on GitHub and modify the "/cms/github_pat" secret in the AWS ParameterStore with the PAT value obtained

#### List of Changes
Add new env var for ECS Task definition for deploy static site from Strapi to GitHub:
GITHUB_PAT
REPO_OWNER
REPO_NAME
WORKFLOW_ID
TARGET_BRANCH

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
on AWS test account

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change not requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
