### PR TITLE
[B2BP-291] Format Footer's socialLinks attributes to remove warnings

### DIFF
--- a/.changeset/hungry-kids-complain.md
+++ b/.changeset/hungry-kids-complain.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Format socialLinks attributes to remove warnings

--- a/apps/nextjs-website/src/components/Footer.tsx
+++ b/apps/nextjs-website/src/components/Footer.tsx
@@ -47,10 +47,16 @@ const makeFooterProps = ({
         linkType: 'internal', // unused
         ...link,
       })),
-      socialLinks: links_followUs.socialLinks.map((link) => ({
-        linkType: 'internal', // unused
-        ...link,
-      })),
+      socialLinks: links_followUs.socialLinks.map(
+        ({ icon, href, ariaLabel }) => ({
+          icon,
+          href,
+          linktype: 'external', // default
+          'aria-label': ariaLabel,
+          // above conversion is needed because social icons just pass through all props other than icon
+          // this means we need to format them as if they were HTML attributes
+        })
+      ),
     },
   },
   languages: [


### PR DESCRIPTION
The `socialLinks` attribute passes through any prop other than icon.
This caused warnings such as "Invalid ARIA attribute `ariaLabel`. Did you mean `aria-label`?"

#### List of Changes
<!--- Describe your changes in detail -->
Formatted props of socialLinks to be acceptable HTML attributes:
- linkType --> linktype
- ariaLabel --> aria-label

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Remove warnings + accessibility and SEO

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested locally.

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
