### PR TITLE
[B2BP-351] Simplify BannerLink Section

### DIFF
--- a/.changeset/nasty-socks-ring.md
+++ b/.changeset/nasty-socks-ring.md
@@ -1,0 +1,6 @@
+---
+"nextjs-website": minor
+"strapi-cms": minor
+---
+
+Simplify BannerLink Section

--- a/.changeset/wise-walls-give.md
+++ b/.changeset/wise-walls-give.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Style BannerLink

--- a/apps/nextjs-website/src/components/BannerLink.tsx
+++ b/apps/nextjs-website/src/components/BannerLink.tsx
@@ -12,8 +12,10 @@ const makeBannerLinkProps = ({
 }: BannerLinkSection): BannerLinkProps => ({
   ...(decoration && {
     decoration: {
-      url: decoration.url,
+      src: decoration.url,
       alt: decoration.alternativeText,
+      width: '60px',
+      height: '60px',
     },
   }),
   ...(ctaButtons.length > 0 && {

--- a/apps/nextjs-website/src/components/BannerLink.tsx
+++ b/apps/nextjs-website/src/components/BannerLink.tsx
@@ -3,7 +3,7 @@ import { BannerLink as BannerLinkEC } from '@pagopa/pagopa-editorial-components'
 import { BannerLinkProps } from '@pagopa/pagopa-editorial-components/dist/components/BannerLink';
 import { Icon } from '@mui/material';
 import { BannerLinkSection } from '@/lib/fetch/types/PageSection';
-import { formatValidMuiIcon, isValidMuiIcon } from '@/components/Icons';
+import { formatValidMuiIcon } from '@/components/Icons';
 
 const makeBannerLinkProps = ({
   decoration,
@@ -19,19 +19,17 @@ const makeBannerLinkProps = ({
     },
   }),
   ...(ctaButtons.length > 0 && {
-    ctaButtons: ctaButtons.map((ctaBtn) => ({
+    ctaButtons: ctaButtons.map(({ icon, ...ctaBtn }) => ({
       ...ctaBtn,
       color: rest.theme === 'dark' ? 'negative' : 'primary',
-      ...(isValidMuiIcon(ctaBtn.icon) && {
-        startIcon: <Icon>{formatValidMuiIcon(ctaBtn.icon)}</Icon>,
-      }),
+      ...(icon && { startIcon: <Icon>{formatValidMuiIcon(icon)}</Icon> }),
     })),
   }),
   ...rest,
 });
 
 const BannerLink = (props: BannerLinkSection) => (
-  <section>
+  <section id={props.sectionID || undefined}>
     <BannerLinkEC {...makeBannerLinkProps(props)} />
   </section>
 );

--- a/apps/nextjs-website/src/lib/fetch/types/PageSection.ts
+++ b/apps/nextjs-website/src/lib/fetch/types/PageSection.ts
@@ -1,5 +1,5 @@
 import * as t from 'io-ts';
-import { CTAButtonSchema, CTAButtonSimpleCodec } from './CTAButton';
+import { CTAButtonSimpleCodec } from './CTAButton';
 import { ImageDataCodec } from './StrapiImage';
 
 const HeroSectionCodec = t.strict({
@@ -127,9 +127,9 @@ const BannerLinkSectionCodec = t.strict({
   title: t.string,
   body: t.string,
   theme: t.union([t.literal('light'), t.literal('dark')]),
-  reverse: t.boolean,
-  ctaButtons: t.array(CTAButtonSchema),
+  ctaButtons: t.array(CTAButtonSimpleCodec),
   decoration: t.union([ImageDataCodec, t.null]),
+  sectionID: t.union([t.string, t.null]),
 });
 
 export const PageSectionCodec = t.union([

--- a/apps/strapi-cms/src/components/sections/banner-link.json
+++ b/apps/strapi-cms/src/components/sections/banner-link.json
@@ -10,17 +10,6 @@
       "type": "string",
       "required": true
     },
-    "reverse": {
-      "type": "boolean",
-      "default": false,
-      "required": true
-    },
-    "ctaButtons": {
-      "type": "component",
-      "repeatable": true,
-      "component": "components.cta-button",
-      "max": 2
-    },
     "theme": {
       "type": "enumeration",
       "enum": [
@@ -41,6 +30,16 @@
     "body": {
       "type": "text",
       "required": true
+    },
+    "ctaButtons": {
+      "type": "component",
+      "repeatable": true,
+      "component": "components.cta-button-simple",
+      "max": 2
+    },
+    "sectionID": {
+      "type": "string",
+      "regex": "^[a-z]+[a-z\\-]*$"
     }
   }
 }


### PR DESCRIPTION
Depends on #169 

Simplified BannerLink Section structure based on the requirements of the SEND website.

#### List of Changes
<!--- Describe your changes in detail -->
Strapi
- `reverse`: Had no effect. Removed.
- `ctaButtons`: Replaced `CTAButton` with `CTAButton_Simple`.
- `sectionID`: Added field.

NextJS
- Adapted types and parsing to reflect Strapi updates
- Utilized `sectionID`

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Better CMS UX and more solid data parsing.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested locally + Unit tested.

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
