### PR TITLE
[B2BP-310] Enable coverage on tests

### DIFF
--- a/.changeset/famous-bottles-sin.md
+++ b/.changeset/famous-bottles-sin.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+[B2BP-310] Enable coverage when running `npm test` command

--- a/apps/nextjs-website/package.json
+++ b/apps/nextjs-website/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "compile": "tsc --noEmit",
-    "test": "vitest",
+    "test": "vitest --coverage",
     "lint": "next lint"
   },
   "dependencies": {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Enable coverage report.

> [!WARNING]  
> The `cloudfront-functions` app uses `rewire` to run tests. This dependency is necessary because the AWS runtime doesn't allow the keyword `export`, so we need to use `rewire`.
Unfortunately there is an [open issue with `rewire` that causes a `0%` coverage, even if there are tests](https://github.com/jhnns/rewire/issues/145).

#### List of Changes
<!--- Describe your changes in detail -->
Execute tests generating also the coverage report.
- Enable coverage in `nextjs-website`

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We want to monitor the coverage.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
