### PR TITLE
[B2BP-377] - Updating "Editorial-Components" version from 2.1.3 to 2.3.0

### DIFF
--- a/.changeset/slow-geese-accept.md
+++ b/.changeset/slow-geese-accept.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": minor
+---
+
+Update Editorial-Components version from 2.1.3 to 2.2.1

--- a/apps/nextjs-website/package.json
+++ b/apps/nextjs-website/package.json
@@ -16,7 +16,7 @@
     "@mui/icons-material": "^5.14.14",
     "@mui/material": "^5.14.14",
     "@pagopa/mui-italia": "^1.0.1",
-    "@pagopa/pagopa-editorial-components": "^2.1.3",
+    "@pagopa/pagopa-editorial-components": "^2.2.0",
     "fp-ts": "^2.16.1",
     "html-react-parser": "^5.0.11",
     "io-ts": "^2.2.20",

--- a/apps/nextjs-website/package.json
+++ b/apps/nextjs-website/package.json
@@ -16,7 +16,7 @@
     "@mui/icons-material": "^5.14.14",
     "@mui/material": "^5.14.14",
     "@pagopa/mui-italia": "^1.0.1",
-    "@pagopa/pagopa-editorial-components": "^2.2.0",
+    "@pagopa/pagopa-editorial-components": "^2.3.0",
     "fp-ts": "^2.16.1",
     "html-react-parser": "^5.0.11",
     "io-ts": "^2.2.20",

--- a/package-lock.json
+++ b/package-lock.json
@@ -607,7 +607,7 @@
         "@mui/icons-material": "^5.14.14",
         "@mui/material": "^5.14.14",
         "@pagopa/mui-italia": "^1.0.1",
-        "@pagopa/pagopa-editorial-components": "^2.1.3",
+        "@pagopa/pagopa-editorial-components": "^2.2.0",
         "fp-ts": "^2.16.1",
         "html-react-parser": "^5.0.11",
         "io-ts": "^2.2.20",
@@ -631,10 +631,61 @@
         "vitest": "^0.34.6"
       }
     },
+    "apps/nextjs-website/node_modules/@pagopa/pagopa-editorial-components": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@pagopa/pagopa-editorial-components/-/pagopa-editorial-components-2.2.0.tgz",
+      "integrity": "sha512-TQ5GrjnXpQAUKzok7kxrMBDPa4iudogb4Jv6h1mxzGbu74rUVmEtO3yBXeFhO1KHIL3STH2MpmNqwUGAkrIMmw==",
+      "dependencies": {
+        "@pagopa/mui-italia": "^0.8.12",
+        "react-swipeable-views": "^0.14.0",
+        "react-swipeable-views-utils": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=16.10.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
+    "apps/nextjs-website/node_modules/@pagopa/pagopa-editorial-components/node_modules/@pagopa/mui-italia": {
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@pagopa/mui-italia/-/mui-italia-0.8.12.tgz",
+      "integrity": "sha512-Qz0fMf5T3GHp/5g0VLyMR3kUtYnXpjtM3H9Hy5Co776Bi9BSiNLEPgP1svupIyW+RX8xpQD5fohyAmCNhP4qRw==",
+      "dependencies": {
+        "@fontsource/dm-mono": "^4.5.10",
+        "@fontsource/titillium-web": "^4.5.9",
+        "clsx": "^1.2.1",
+        "fp-ts": "^2.12.3",
+        "io-ts": "^2.2.18"
+      },
+      "engines": {
+        "node": ">=14.x",
+        "npm": ">=8.x"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.10.4",
+        "@emotion/styled": "^11.10.4",
+        "@mui/icons-material": "^5.10.9",
+        "@mui/lab": "^5.0.0-alpha.100",
+        "@mui/material": "^5.10.9",
+        "@mui/system": "^5.10.8",
+        "react": "^17.0.0",
+        "react-dom": "^17.0.0"
+      }
+    },
     "apps/nextjs-website/node_modules/@types/node": {
       "version": "20.5.9",
       "dev": true,
       "license": "MIT"
+    },
+    "apps/nextjs-website/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "apps/strapi-cms": {
       "version": "0.0.0",
@@ -3647,53 +3698,6 @@
       }
     },
     "node_modules/@pagopa/mui-italia/node_modules/clsx": {
-      "version": "1.2.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@pagopa/pagopa-editorial-components": {
-      "version": "2.1.3",
-      "dependencies": {
-        "@pagopa/mui-italia": "^0.8.12",
-        "react-swipeable-views": "^0.14.0",
-        "react-swipeable-views-utils": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=16.10.0"
-      },
-      "peerDependencies": {
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
-      }
-    },
-    "node_modules/@pagopa/pagopa-editorial-components/node_modules/@pagopa/mui-italia": {
-      "version": "0.8.12",
-      "license": "MIT",
-      "dependencies": {
-        "@fontsource/dm-mono": "^4.5.10",
-        "@fontsource/titillium-web": "^4.5.9",
-        "clsx": "^1.2.1",
-        "fp-ts": "^2.12.3",
-        "io-ts": "^2.2.18"
-      },
-      "engines": {
-        "node": ">=14.x",
-        "npm": ">=8.x"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.10.4",
-        "@emotion/styled": "^11.10.4",
-        "@mui/icons-material": "^5.10.9",
-        "@mui/lab": "^5.0.0-alpha.100",
-        "@mui/material": "^5.10.9",
-        "@mui/system": "^5.10.8",
-        "react": "^17.0.0",
-        "react-dom": "^17.0.0"
-      }
-    },
-    "node_modules/@pagopa/pagopa-editorial-components/node_modules/clsx": {
       "version": "1.2.1",
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -607,7 +607,7 @@
         "@mui/icons-material": "^5.14.14",
         "@mui/material": "^5.14.14",
         "@pagopa/mui-italia": "^1.0.1",
-        "@pagopa/pagopa-editorial-components": "^2.2.0",
+        "@pagopa/pagopa-editorial-components": "^2.3.0",
         "fp-ts": "^2.16.1",
         "html-react-parser": "^5.0.11",
         "io-ts": "^2.2.20",
@@ -632,11 +632,12 @@
       }
     },
     "apps/nextjs-website/node_modules/@pagopa/pagopa-editorial-components": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@pagopa/pagopa-editorial-components/-/pagopa-editorial-components-2.2.0.tgz",
-      "integrity": "sha512-TQ5GrjnXpQAUKzok7kxrMBDPa4iudogb4Jv6h1mxzGbu74rUVmEtO3yBXeFhO1KHIL3STH2MpmNqwUGAkrIMmw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@pagopa/pagopa-editorial-components/-/pagopa-editorial-components-2.3.0.tgz",
+      "integrity": "sha512-jXuy1r39Gb4FR51/pug/Ke7TgTcMQpOBsEa4ttTv1uIcxK1yMKpIhx6WhYaFKJ00TQh8BIL+amPHTWtlsv93eQ==",
       "dependencies": {
         "@pagopa/mui-italia": "^0.8.12",
+        "@testing-library/jest-dom": "^6.1.4",
         "react-swipeable-views": "^0.14.0",
         "react-swipeable-views-utils": "^0.14.0"
       },
@@ -648,44 +649,10 @@
         "react-dom": "^18.2.0"
       }
     },
-    "apps/nextjs-website/node_modules/@pagopa/pagopa-editorial-components/node_modules/@pagopa/mui-italia": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@pagopa/mui-italia/-/mui-italia-0.8.12.tgz",
-      "integrity": "sha512-Qz0fMf5T3GHp/5g0VLyMR3kUtYnXpjtM3H9Hy5Co776Bi9BSiNLEPgP1svupIyW+RX8xpQD5fohyAmCNhP4qRw==",
-      "dependencies": {
-        "@fontsource/dm-mono": "^4.5.10",
-        "@fontsource/titillium-web": "^4.5.9",
-        "clsx": "^1.2.1",
-        "fp-ts": "^2.12.3",
-        "io-ts": "^2.2.18"
-      },
-      "engines": {
-        "node": ">=14.x",
-        "npm": ">=8.x"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.10.4",
-        "@emotion/styled": "^11.10.4",
-        "@mui/icons-material": "^5.10.9",
-        "@mui/lab": "^5.0.0-alpha.100",
-        "@mui/material": "^5.10.9",
-        "@mui/system": "^5.10.8",
-        "react": "^17.0.0",
-        "react-dom": "^17.0.0"
-      }
-    },
     "apps/nextjs-website/node_modules/@types/node": {
       "version": "20.5.9",
       "dev": true,
       "license": "MIT"
-    },
-    "apps/nextjs-website/node_modules/clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "apps/strapi-cms": {
       "version": "0.0.0",
@@ -717,6 +684,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.3.tgz",
+      "integrity": "sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ=="
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.1",
@@ -2809,18 +2781,25 @@
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.5.3",
-      "license": "MIT",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
+      "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
       "dependencies": {
-        "@floating-ui/core": "^1.4.2",
-        "@floating-ui/utils": "^0.1.3"
+        "@floating-ui/core": "^1.0.0",
+        "@floating-ui/utils": "^0.2.0"
       }
     },
+    "node_modules/@floating-ui/dom/node_modules/@floating-ui/utils": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
+      "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
+    },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.0.2",
-      "license": "MIT",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
+      "integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
       "dependencies": {
-        "@floating-ui/dom": "^1.5.1"
+        "@floating-ui/dom": "^1.6.1"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -2968,7 +2947,7 @@
     },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
@@ -3133,15 +3112,16 @@
       }
     },
     "node_modules/@mui/base": {
-      "version": "5.0.0-beta.21",
-      "license": "MIT",
+      "version": "5.0.0-beta.36",
+      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.36.tgz",
+      "integrity": "sha512-6A8fYiXgjqTO6pgj31Hc8wm1M3rFYCxDRh09dBVk0L0W4cb2lnurRJa3cAyic6hHY+we1S58OdGYRbKmOsDpGQ==",
       "dependencies": {
-        "@babel/runtime": "^7.23.2",
-        "@floating-ui/react-dom": "^2.0.2",
-        "@mui/types": "^7.2.7",
-        "@mui/utils": "^5.14.15",
+        "@babel/runtime": "^7.23.9",
+        "@floating-ui/react-dom": "^2.0.8",
+        "@mui/types": "^7.2.13",
+        "@mui/utils": "^5.15.9",
         "@popperjs/core": "^2.11.8",
-        "clsx": "^2.0.0",
+        "clsx": "^2.1.0",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -3149,7 +3129,7 @@
       },
       "funding": {
         "type": "opencollective",
-        "url": "https://opencollective.com/mui"
+        "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0",
@@ -3162,12 +3142,24 @@
         }
       }
     },
+    "node_modules/@mui/base/node_modules/@babel/runtime": {
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
+      "integrity": "sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "5.14.15",
-      "license": "MIT",
+      "version": "5.15.10",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.15.10.tgz",
+      "integrity": "sha512-qPv7B+LeMatYuzRjB3hlZUHqinHx/fX4YFBiaS19oC02A1e9JFuDKDvlyRQQ5oRSbJJt0QlaLTlr0IcauVcJRQ==",
       "funding": {
         "type": "opencollective",
-        "url": "https://opencollective.com/mui"
+        "url": "https://opencollective.com/mui-org"
       }
     },
     "node_modules/@mui/icons-material": {
@@ -3194,60 +3186,20 @@
         }
       }
     },
-    "node_modules/@mui/lab": {
-      "version": "5.0.0-alpha.150",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.23.2",
-        "@mui/base": "5.0.0-beta.21",
-        "@mui/system": "^5.14.15",
-        "@mui/types": "^7.2.7",
-        "@mui/utils": "^5.14.15",
-        "@mui/x-tree-view": "6.0.0-alpha.1",
-        "clsx": "^2.0.0",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.5.0",
-        "@emotion/styled": "^11.3.0",
-        "@mui/material": ">=5.10.11",
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@mui/material": {
-      "version": "5.14.15",
-      "license": "MIT",
+      "version": "5.15.10",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.15.10.tgz",
+      "integrity": "sha512-YJJGHjwDOucecjDEV5l9ISTCo+l9YeWrho623UajzoHRYxuKUmwrGVYOW4PKwGvCx9SU9oklZnbbi2Clc5XZHw==",
       "dependencies": {
-        "@babel/runtime": "^7.23.2",
-        "@mui/base": "5.0.0-beta.21",
-        "@mui/core-downloads-tracker": "^5.14.15",
-        "@mui/system": "^5.14.15",
-        "@mui/types": "^7.2.7",
-        "@mui/utils": "^5.14.15",
-        "@types/react-transition-group": "^4.4.7",
-        "clsx": "^2.0.0",
-        "csstype": "^3.1.2",
+        "@babel/runtime": "^7.23.9",
+        "@mui/base": "5.0.0-beta.36",
+        "@mui/core-downloads-tracker": "^5.15.10",
+        "@mui/system": "^5.15.9",
+        "@mui/types": "^7.2.13",
+        "@mui/utils": "^5.15.9",
+        "@types/react-transition-group": "^4.4.10",
+        "clsx": "^2.1.0",
+        "csstype": "^3.1.3",
         "prop-types": "^15.8.1",
         "react-is": "^18.2.0",
         "react-transition-group": "^4.4.5"
@@ -3257,7 +3209,7 @@
       },
       "funding": {
         "type": "opencollective",
-        "url": "https://opencollective.com/mui"
+        "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
@@ -3278,12 +3230,24 @@
         }
       }
     },
-    "node_modules/@mui/private-theming": {
-      "version": "5.14.15",
-      "license": "MIT",
+    "node_modules/@mui/material/node_modules/@babel/runtime": {
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
+      "integrity": "sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==",
       "dependencies": {
-        "@babel/runtime": "^7.23.2",
-        "@mui/utils": "^5.14.15",
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@mui/private-theming": {
+      "version": "5.15.9",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.15.9.tgz",
+      "integrity": "sha512-/aMJlDOxOTAXyp4F2rIukW1O0anodAMCkv1DfBh/z9vaKHY3bd5fFf42wmP+0GRmwMinC5aWPpNfHXOED1fEtg==",
+      "dependencies": {
+        "@babel/runtime": "^7.23.9",
+        "@mui/utils": "^5.15.9",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -3291,7 +3255,7 @@
       },
       "funding": {
         "type": "opencollective",
-        "url": "https://opencollective.com/mui"
+        "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0",
@@ -3303,13 +3267,25 @@
         }
       }
     },
-    "node_modules/@mui/styled-engine": {
-      "version": "5.14.15",
-      "license": "MIT",
+    "node_modules/@mui/private-theming/node_modules/@babel/runtime": {
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
+      "integrity": "sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==",
       "dependencies": {
-        "@babel/runtime": "^7.23.2",
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@mui/styled-engine": {
+      "version": "5.15.9",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.15.9.tgz",
+      "integrity": "sha512-NRKtYkL5PZDH7dEmaLEIiipd3mxNnQSO+Yo8rFNBNptY8wzQnQ+VjayTq39qH7Sast5cwHKYFusUrQyD+SS4Og==",
+      "dependencies": {
+        "@babel/runtime": "^7.23.9",
         "@emotion/cache": "^11.11.0",
-        "csstype": "^3.1.2",
+        "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -3317,7 +3293,7 @@
       },
       "funding": {
         "type": "opencollective",
-        "url": "https://opencollective.com/mui"
+        "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
         "@emotion/react": "^11.4.1",
@@ -3333,17 +3309,29 @@
         }
       }
     },
-    "node_modules/@mui/system": {
-      "version": "5.14.15",
-      "license": "MIT",
+    "node_modules/@mui/styled-engine/node_modules/@babel/runtime": {
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
+      "integrity": "sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==",
       "dependencies": {
-        "@babel/runtime": "^7.23.2",
-        "@mui/private-theming": "^5.14.15",
-        "@mui/styled-engine": "^5.14.15",
-        "@mui/types": "^7.2.7",
-        "@mui/utils": "^5.14.15",
-        "clsx": "^2.0.0",
-        "csstype": "^3.1.2",
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@mui/system": {
+      "version": "5.15.9",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.15.9.tgz",
+      "integrity": "sha512-SxkaaZ8jsnIJ77bBXttfG//LUf6nTfOcaOuIgItqfHv60ZCQy/Hu7moaob35kBb+guxVJnoSZ+7vQJrA/E7pKg==",
+      "dependencies": {
+        "@babel/runtime": "^7.23.9",
+        "@mui/private-theming": "^5.15.9",
+        "@mui/styled-engine": "^5.15.9",
+        "@mui/types": "^7.2.13",
+        "@mui/utils": "^5.15.9",
+        "clsx": "^2.1.0",
+        "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -3351,7 +3339,7 @@
       },
       "funding": {
         "type": "opencollective",
-        "url": "https://opencollective.com/mui"
+        "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
@@ -3371,9 +3359,21 @@
         }
       }
     },
+    "node_modules/@mui/system/node_modules/@babel/runtime": {
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
+      "integrity": "sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@mui/types": {
-      "version": "7.2.7",
-      "license": "MIT",
+      "version": "7.2.13",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.13.tgz",
+      "integrity": "sha512-qP9OgacN62s+l8rdDhSFRe05HWtLLJ5TGclC9I1+tQngbssu0m2dmFZs+Px53AcOs9fD7TbYd4gc9AXzVqO/+g==",
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0"
       },
@@ -3384,11 +3384,12 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "5.14.15",
-      "license": "MIT",
+      "version": "5.15.9",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.15.9.tgz",
+      "integrity": "sha512-yDYfr61bCYUz1QtwvpqYy/3687Z8/nS4zv7lv/ih/6ZFGMl1iolEvxRmR84v2lOYxlds+kq1IVYbXxDKh8Z9sg==",
       "dependencies": {
-        "@babel/runtime": "^7.23.2",
-        "@types/prop-types": "^15.7.8",
+        "@babel/runtime": "^7.23.9",
+        "@types/prop-types": "^15.7.11",
         "prop-types": "^15.8.1",
         "react-is": "^18.2.0"
       },
@@ -3397,7 +3398,7 @@
       },
       "funding": {
         "type": "opencollective",
-        "url": "https://opencollective.com/mui"
+        "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0",
@@ -3409,33 +3410,15 @@
         }
       }
     },
-    "node_modules/@mui/x-tree-view": {
-      "version": "6.0.0-alpha.1",
-      "license": "MIT",
-      "peer": true,
+    "node_modules/@mui/utils/node_modules/@babel/runtime": {
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
+      "integrity": "sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==",
       "dependencies": {
-        "@babel/runtime": "^7.22.6",
-        "@mui/utils": "^5.14.3",
-        "@types/react-transition-group": "^4.4.6",
-        "clsx": "^2.0.0",
-        "prop-types": "^15.8.1",
-        "react-transition-group": "^4.4.5"
+        "regenerator-runtime": "^0.14.0"
       },
       "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.9.0",
-        "@emotion/styled": "^11.8.1",
-        "@mui/base": "^5.0.0-alpha.87",
-        "@mui/material": "^5.8.6",
-        "@mui/system": "^5.8.0",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@next/env": {
@@ -3814,7 +3797,8 @@
     },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -4714,7 +4698,7 @@
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@sindresorhus/is": {
@@ -7224,6 +7208,111 @@
         "node": ">=10"
       }
     },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.4.2.tgz",
+      "integrity": "sha512-CzqH0AFymEMG48CpzXFriYYkOjk6ZGPCLMhW9e9jg3KMCn5OfJecF8GtGW7yGfR/IgCe3SX8BSwjdzI6BBbZLw==",
+      "dependencies": {
+        "@adobe/css-tools": "^4.3.2",
+        "@babel/runtime": "^7.9.2",
+        "aria-query": "^5.0.0",
+        "chalk": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "lodash": "^4.17.15",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@jest/globals": ">= 28",
+        "@types/bun": "latest",
+        "@types/jest": ">= 28",
+        "jest": ">= 28",
+        "vitest": ">= 0.32"
+      },
+      "peerDependenciesMeta": {
+        "@jest/globals": {
+          "optional": true
+        },
+        "@types/bun": {
+          "optional": true
+        },
+        "@types/jest": {
+          "optional": true
+        },
+        "jest": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@types/argparse": {
       "version": "1.0.38",
       "license": "MIT"
@@ -7261,12 +7350,12 @@
     },
     "node_modules/@types/chai": {
       "version": "4.3.10",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/chai-subset": {
       "version": "1.3.5",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "*"
@@ -7471,8 +7560,9 @@
       "license": "MIT"
     },
     "node_modules/@types/prop-types": {
-      "version": "15.7.9",
-      "license": "MIT"
+      "version": "15.7.11",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
+      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng=="
     },
     "node_modules/@types/qs": {
       "version": "6.9.9",
@@ -7500,8 +7590,9 @@
       }
     },
     "node_modules/@types/react-transition-group": {
-      "version": "4.4.8",
-      "license": "MIT",
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.10.tgz",
+      "integrity": "sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==",
       "dependencies": {
         "@types/react": "*"
       }
@@ -7856,7 +7947,7 @@
     },
     "node_modules/@vitest/expect": {
       "version": "0.34.6",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/spy": "0.34.6",
@@ -7869,7 +7960,7 @@
     },
     "node_modules/@vitest/runner": {
       "version": "0.34.6",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/utils": "0.34.6",
@@ -7882,7 +7973,7 @@
     },
     "node_modules/@vitest/runner/node_modules/p-limit": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^1.0.0"
@@ -7896,7 +7987,7 @@
     },
     "node_modules/@vitest/runner/node_modules/yocto-queue": {
       "version": "1.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.20"
@@ -7907,7 +7998,7 @@
     },
     "node_modules/@vitest/snapshot": {
       "version": "0.34.6",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "magic-string": "^0.30.1",
@@ -7920,7 +8011,7 @@
     },
     "node_modules/@vitest/spy": {
       "version": "0.34.6",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tinyspy": "^2.1.1"
@@ -7931,7 +8022,7 @@
     },
     "node_modules/@vitest/utils": {
       "version": "0.34.6",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "diff-sequences": "^29.4.3",
@@ -8144,7 +8235,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
       "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -8327,7 +8418,6 @@
     },
     "node_modules/aria-query": {
       "version": "5.3.0",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "dequal": "^2.0.3"
@@ -8513,7 +8603,7 @@
     },
     "node_modules/assertion-error": {
       "version": "1.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -9115,7 +9205,7 @@
     },
     "node_modules/cac": {
       "version": "6.7.14",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9264,7 +9354,7 @@
     },
     "node_modules/chai": {
       "version": "4.3.10",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "assertion-error": "^1.1.0",
@@ -9351,7 +9441,7 @@
     },
     "node_modules/check-error": {
       "version": "1.0.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "get-func-name": "^2.0.2"
@@ -9630,8 +9720,9 @@
       "link": true
     },
     "node_modules/clsx": {
-      "version": "2.0.0",
-      "license": "MIT",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
+      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
       "engines": {
         "node": ">=6"
       }
@@ -10178,6 +10269,11 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "license": "MIT",
@@ -10189,8 +10285,9 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.2",
-      "license": "MIT"
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/csv": {
       "version": "5.5.3",
@@ -10318,7 +10415,7 @@
     },
     "node_modules/deep-eql": {
       "version": "4.1.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "type-detect": "^4.0.0"
@@ -10492,7 +10589,6 @@
     },
     "node_modules/dequal": {
       "version": "2.0.3",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -10538,7 +10634,7 @@
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -10593,6 +10689,11 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
@@ -13121,7 +13222,7 @@
     },
     "node_modules/get-func-name": {
       "version": "2.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -15109,7 +15210,7 @@
     },
     "node_modules/jsonc-parser": {
       "version": "3.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/jsonfile": {
@@ -15194,7 +15295,8 @@
     },
     "node_modules/keycode": {
       "version": "2.2.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.1.tgz",
+      "integrity": "sha512-Rdgz9Hl9Iv4QKi8b0OlCRQEzp4AgVxyCtz5S/+VIHezDmrDhkp2N2TqBWOLz0/gbeREXOOiI9/4b8BY9uw2vFg=="
     },
     "node_modules/keygrip": {
       "version": "1.1.0",
@@ -15626,7 +15728,7 @@
     },
     "node_modules/local-pkg": {
       "version": "0.4.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -15788,7 +15890,7 @@
     },
     "node_modules/loupe": {
       "version": "2.3.7",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "get-func-name": "^2.0.1"
@@ -15835,7 +15937,7 @@
     },
     "node_modules/magic-string": {
       "version": "0.30.5",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
@@ -16156,7 +16258,6 @@
     },
     "node_modules/min-indent": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -16325,7 +16426,7 @@
     },
     "node_modules/mlly": {
       "version": "1.4.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.10.0",
@@ -17514,12 +17615,12 @@
     },
     "node_modules/pathe": {
       "version": "1.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/pathval": {
       "version": "1.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -17641,7 +17742,7 @@
     },
     "node_modules/pkg-types": {
       "version": "1.0.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "jsonc-parser": "^3.2.0",
@@ -18147,7 +18248,7 @@
     },
     "node_modules/pretty-format": {
       "version": "29.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.6.3",
@@ -18160,7 +18261,7 @@
     },
     "node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -18436,7 +18537,8 @@
     },
     "node_modules/react-event-listener": {
       "version": "0.6.6",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.6.6.tgz",
+      "integrity": "sha512-+hCNqfy7o9wvO6UgjqFmBzARJS7qrNoda0VqzvOuioEpoEXKutiKuv92dSz6kP7rYLmyHPyYNLesi5t/aH1gfw==",
       "dependencies": {
         "@babel/runtime": "^7.2.0",
         "prop-types": "^15.6.0",
@@ -18709,7 +18811,8 @@
     },
     "node_modules/react-swipeable-views": {
       "version": "0.14.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/react-swipeable-views/-/react-swipeable-views-0.14.0.tgz",
+      "integrity": "sha512-wrTT6bi2nC3JbmyNAsPXffUXLn0DVT9SbbcFr36gKpbaCgEp7rX/OFxsu5hPc/NBsUhHyoSRGvwqJNNrWTwCww==",
       "dependencies": {
         "@babel/runtime": "7.0.0",
         "prop-types": "^15.5.4",
@@ -18726,7 +18829,8 @@
     },
     "node_modules/react-swipeable-views-core": {
       "version": "0.14.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/react-swipeable-views-core/-/react-swipeable-views-core-0.14.0.tgz",
+      "integrity": "sha512-0W/e9uPweNEOSPjmYtuKSC/SvKKg1sfo+WtPdnxeLF3t2L82h7jjszuOHz9C23fzkvLfdgkaOmcbAxE9w2GEjA==",
       "dependencies": {
         "@babel/runtime": "7.0.0",
         "warning": "^4.0.1"
@@ -18737,18 +18841,21 @@
     },
     "node_modules/react-swipeable-views-core/node_modules/@babel/runtime": {
       "version": "7.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0.tgz",
+      "integrity": "sha512-7hGhzlcmg01CvH1EHdSPVXYX1aJ8KCEyz6I9xYIi/asDtzBPMyMhVibhM/K6g/5qnKBwjZtp10bNZIEFTRW1MA==",
       "dependencies": {
         "regenerator-runtime": "^0.12.0"
       }
     },
     "node_modules/react-swipeable-views-core/node_modules/regenerator-runtime": {
       "version": "0.12.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
     },
     "node_modules/react-swipeable-views-utils": {
       "version": "0.14.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/react-swipeable-views-utils/-/react-swipeable-views-utils-0.14.0.tgz",
+      "integrity": "sha512-W+fXBOsDqgFK1/g7MzRMVcDurp3LqO3ksC8UgInh2P/tKgb5DusuuB1geKHFc6o1wKl+4oyER4Zh3Lxmr8xbXA==",
       "dependencies": {
         "@babel/runtime": "7.0.0",
         "keycode": "^2.1.7",
@@ -18763,25 +18870,29 @@
     },
     "node_modules/react-swipeable-views-utils/node_modules/@babel/runtime": {
       "version": "7.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0.tgz",
+      "integrity": "sha512-7hGhzlcmg01CvH1EHdSPVXYX1aJ8KCEyz6I9xYIi/asDtzBPMyMhVibhM/K6g/5qnKBwjZtp10bNZIEFTRW1MA==",
       "dependencies": {
         "regenerator-runtime": "^0.12.0"
       }
     },
     "node_modules/react-swipeable-views-utils/node_modules/regenerator-runtime": {
       "version": "0.12.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
     },
     "node_modules/react-swipeable-views/node_modules/@babel/runtime": {
       "version": "7.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0.tgz",
+      "integrity": "sha512-7hGhzlcmg01CvH1EHdSPVXYX1aJ8KCEyz6I9xYIi/asDtzBPMyMhVibhM/K6g/5qnKBwjZtp10bNZIEFTRW1MA==",
       "dependencies": {
         "regenerator-runtime": "^0.12.0"
       }
     },
     "node_modules/react-swipeable-views/node_modules/regenerator-runtime": {
       "version": "0.12.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
     },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
@@ -18912,7 +19023,6 @@
     },
     "node_modules/redent": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "indent-string": "^4.0.0",
@@ -19735,7 +19845,8 @@
     },
     "node_modules/shallow-equal": {
       "version": "1.2.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
+      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA=="
     },
     "node_modules/shallowequal": {
       "version": "1.1.0",
@@ -19853,7 +19964,7 @@
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/signal-exit": {
@@ -20404,7 +20515,7 @@
     },
     "node_modules/stackback": {
       "version": "0.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/stackframe": {
@@ -20898,7 +21009,6 @@
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "min-indent": "^1.0.0"
@@ -20920,7 +21030,7 @@
     },
     "node_modules/strip-literal": {
       "version": "1.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.10.0"
@@ -21300,12 +21410,12 @@
     },
     "node_modules/tinybench": {
       "version": "2.5.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/tinypool": {
       "version": "0.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -21313,7 +21423,7 @@
     },
     "node_modules/tinyspy": {
       "version": "2.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -21589,7 +21699,7 @@
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -21697,7 +21807,7 @@
     },
     "node_modules/ufo": {
       "version": "1.3.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/uglify-js": {
@@ -22101,7 +22211,7 @@
     },
     "node_modules/vite-node": {
       "version": "0.34.6",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
@@ -22484,7 +22594,7 @@
     },
     "node_modules/vite-node/node_modules/esbuild": {
       "version": "0.18.20",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -22520,7 +22630,7 @@
     },
     "node_modules/vite-node/node_modules/postcss": {
       "version": "8.4.31",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -22554,7 +22664,7 @@
     },
     "node_modules/vite-node/node_modules/vite": {
       "version": "4.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.18.10",
@@ -22608,7 +22718,7 @@
     },
     "node_modules/vitest": {
       "version": "0.34.6",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^4.3.5",
@@ -23035,7 +23145,7 @@
     },
     "node_modules/vitest/node_modules/@types/node": {
       "version": "20.9.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -23043,7 +23153,7 @@
     },
     "node_modules/vitest/node_modules/esbuild": {
       "version": "0.18.20",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -23079,7 +23189,7 @@
     },
     "node_modules/vitest/node_modules/postcss": {
       "version": "8.4.31",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -23106,12 +23216,12 @@
     },
     "node_modules/vitest/node_modules/undici-types": {
       "version": "5.26.5",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/vitest/node_modules/vite": {
       "version": "4.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.18.10",
@@ -23169,7 +23279,8 @@
     },
     "node_modules/warning": {
       "version": "4.0.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
@@ -23708,7 +23819,7 @@
     },
     "node_modules/why-is-node-running": {
       "version": "2.2.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "siginfo": "^2.0.0",


### PR DESCRIPTION
#### List of Changes
- Updated the "@pagopa/pagopa-editorial-components" package from version 2.1.3 to 2.3.0

#### Motivation and Context
This change is necessary to incorporate the latest enhancements, bug fixes, and features provided by the new version of the "@pagopa/pagopa-editorial-components" package (from 2.1.3 to 2.3.0). By staying up-to-date with the latest package version, we ensure that our system benefits from improved performance, security patches, and additional functionality.

#### How Has This Been Tested?
Testing the updated package version involved the following steps:
- Delete node_modules folders from local
- Update from the old to new package version
- Npm install from the root folder

#### Types of changes
- [ ] Chore (nothing changes from a user perspective)
- [] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Doesn't need any documentation updates