### PR TITLE
[B2BP-397] Prevent caching of fetch response

### DIFF
--- a/.changeset/breezy-peaches-report.md
+++ b/.changeset/breezy-peaches-report.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Prevent caching of fetch response

--- a/apps/nextjs-website/src/lib/fetch/__tests__/footer.test.ts
+++ b/apps/nextjs-website/src/lib/fetch/__tests__/footer.test.ts
@@ -106,6 +106,7 @@ describe('getFooter', () => {
         headers: {
           Authorization: `Bearer ${config.STRAPI_API_TOKEN}`,
         },
+        cache: 'no-store',
       }
     );
   });

--- a/apps/nextjs-website/src/lib/fetch/__tests__/header.test.ts
+++ b/apps/nextjs-website/src/lib/fetch/__tests__/header.test.ts
@@ -48,6 +48,7 @@ describe('getHeader', () => {
         headers: {
           Authorization: `Bearer ${config.STRAPI_API_TOKEN}`,
         },
+        cache: 'no-store',
       }
     );
   });

--- a/apps/nextjs-website/src/lib/fetch/__tests__/navigation.test.ts
+++ b/apps/nextjs-website/src/lib/fetch/__tests__/navigation.test.ts
@@ -74,6 +74,7 @@ describe('getNavigation', () => {
         headers: {
           Authorization: `Bearer ${config.STRAPI_API_TOKEN}`,
         },
+        cache: 'no-store',
       }
     );
   });

--- a/apps/nextjs-website/src/lib/fetch/__tests__/preHeader.test.ts
+++ b/apps/nextjs-website/src/lib/fetch/__tests__/preHeader.test.ts
@@ -84,6 +84,7 @@ describe('getPreHeader', () => {
         headers: {
           Authorization: `Bearer ${config.STRAPI_API_TOKEN}`,
         },
+        cache: 'no-store',
       }
     );
   });

--- a/apps/nextjs-website/src/lib/fetch/footer.ts
+++ b/apps/nextjs-website/src/lib/fetch/footer.ts
@@ -58,6 +58,7 @@ export const getFooter = ({ config, fetchFun }: AppEnv): Promise<FooterData> =>
         headers: {
           Authorization: `Bearer ${config.STRAPI_API_TOKEN}`,
         },
+        cache: 'no-store',
       }
     ),
     FooterDataCodec

--- a/apps/nextjs-website/src/lib/fetch/header.ts
+++ b/apps/nextjs-website/src/lib/fetch/header.ts
@@ -22,6 +22,7 @@ export const getHeader = ({ config, fetchFun }: AppEnv): Promise<Header> =>
       headers: {
         Authorization: `Bearer ${config.STRAPI_API_TOKEN}`,
       },
+      cache: 'no-store',
     }),
     HeaderDataCodec
   );

--- a/apps/nextjs-website/src/lib/fetch/navigation.ts
+++ b/apps/nextjs-website/src/lib/fetch/navigation.ts
@@ -39,6 +39,7 @@ export const getNavigation = (
         headers: {
           Authorization: `Bearer ${config.STRAPI_API_TOKEN}`,
         },
+        cache: 'no-store',
       }
     ),
     NavigationCodec

--- a/apps/nextjs-website/src/lib/fetch/preHeader.ts
+++ b/apps/nextjs-website/src/lib/fetch/preHeader.ts
@@ -41,6 +41,7 @@ export const getPreHeader = ({
         headers: {
           Authorization: `Bearer ${config.STRAPI_API_TOKEN}`,
         },
+        cache: 'no-store',
       }
     ),
     PreHeaderCodec


### PR DESCRIPTION
An issue has emerged which lead us to believe NextJS is using stale cached data when building static websites.

Briefly put: Next seems to only generate totally new pages and update the homepage.
This creates inconsistencies in the deployed static website for any page that is not the homepage.

One possible culprit is [the code starting at the following line](https://github.com/pagopa/b2b-portals/blob/76351936af50bac2ee602ce5ea121cb0c1117179/.github/actions/deploy/action.yaml#L39), which seems to make it so NextJS always builds from cache, unless there's been some changes in the source code itself (which won't happen when a common CMS user updates data).

This PR prevents NextJS default caching behaviour in an attempt to solve the issue, forgoing cached data entirely from one build to the next.

#### List of Changes
<!--- Describe your changes in detail -->
- Added the `cache: 'no-store'` option to all fetch function calls in NextJS

Note:
This change should not affect the number of calls to the Strapi API made during a single build as that's not what NextJS cache is for.
The process that prevents duplicate calls to the same URL during a single build is called [memoization](https://nextjs.org/docs/app/building-your-application/caching#request-memoization). It is a feature of React and is not affected by the `cache` option.


#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Solving bug [B2BP-397](https://pagopa.atlassian.net/browse/B2BP-397)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested locally. Behaviour changes as expected.
Needs to be tested in a production or production-like environment.

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.


[B2BP-397]: https://pagopa.atlassian.net/browse/B2BP-397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ