### PR TITLE
Revert "[B2BP-397] Prevent caching of fetch response"

### DIFF
--- a/.changeset/breezy-peaches-report.md
+++ b/.changeset/breezy-peaches-report.md
@@ -1,5 +1,0 @@
----
-"nextjs-website": patch
----
-
-Prevent caching of fetch response

--- a/apps/nextjs-website/src/lib/fetch/__tests__/footer.test.ts
+++ b/apps/nextjs-website/src/lib/fetch/__tests__/footer.test.ts
@@ -106,7 +106,6 @@ describe('getFooter', () => {
         headers: {
           Authorization: `Bearer ${config.STRAPI_API_TOKEN}`,
         },
-        cache: 'no-store',
       }
     );
   });

--- a/apps/nextjs-website/src/lib/fetch/__tests__/header.test.ts
+++ b/apps/nextjs-website/src/lib/fetch/__tests__/header.test.ts
@@ -48,7 +48,6 @@ describe('getHeader', () => {
         headers: {
           Authorization: `Bearer ${config.STRAPI_API_TOKEN}`,
         },
-        cache: 'no-store',
       }
     );
   });

--- a/apps/nextjs-website/src/lib/fetch/__tests__/navigation.test.ts
+++ b/apps/nextjs-website/src/lib/fetch/__tests__/navigation.test.ts
@@ -74,7 +74,6 @@ describe('getNavigation', () => {
         headers: {
           Authorization: `Bearer ${config.STRAPI_API_TOKEN}`,
         },
-        cache: 'no-store',
       }
     );
   });

--- a/apps/nextjs-website/src/lib/fetch/__tests__/preHeader.test.ts
+++ b/apps/nextjs-website/src/lib/fetch/__tests__/preHeader.test.ts
@@ -84,7 +84,6 @@ describe('getPreHeader', () => {
         headers: {
           Authorization: `Bearer ${config.STRAPI_API_TOKEN}`,
         },
-        cache: 'no-store',
       }
     );
   });

--- a/apps/nextjs-website/src/lib/fetch/footer.ts
+++ b/apps/nextjs-website/src/lib/fetch/footer.ts
@@ -58,7 +58,6 @@ export const getFooter = ({ config, fetchFun }: AppEnv): Promise<FooterData> =>
         headers: {
           Authorization: `Bearer ${config.STRAPI_API_TOKEN}`,
         },
-        cache: 'no-store',
       }
     ),
     FooterDataCodec

--- a/apps/nextjs-website/src/lib/fetch/header.ts
+++ b/apps/nextjs-website/src/lib/fetch/header.ts
@@ -22,7 +22,6 @@ export const getHeader = ({ config, fetchFun }: AppEnv): Promise<Header> =>
       headers: {
         Authorization: `Bearer ${config.STRAPI_API_TOKEN}`,
       },
-      cache: 'no-store',
     }),
     HeaderDataCodec
   );

--- a/apps/nextjs-website/src/lib/fetch/navigation.ts
+++ b/apps/nextjs-website/src/lib/fetch/navigation.ts
@@ -39,7 +39,6 @@ export const getNavigation = (
         headers: {
           Authorization: `Bearer ${config.STRAPI_API_TOKEN}`,
         },
-        cache: 'no-store',
       }
     ),
     NavigationCodec

--- a/apps/nextjs-website/src/lib/fetch/preHeader.ts
+++ b/apps/nextjs-website/src/lib/fetch/preHeader.ts
@@ -41,7 +41,6 @@ export const getPreHeader = ({
         headers: {
           Authorization: `Bearer ${config.STRAPI_API_TOKEN}`,
         },
-        cache: 'no-store',
       }
     ),
     PreHeaderCodec


### PR DESCRIPTION
Reverts pagopa/b2b-portals#173

Disabling cache creates irregular behaviour in the build process.

NextJS logs the generation of all static files as expected, but it does not actually generate all files.

Which files get generated and which don't seems to be arbitrary.

Note:
Running `npm run dev` does not seem to be affected by this issue: paths are able to be accessed correctly.