### PR TITLE
[B2BP-377] - Updating EC version from 2.1.3 to 2.3.1

### DIFF
--- a/.changeset/tidy-lies-warn.md
+++ b/.changeset/tidy-lies-warn.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": minor
+---
+
+Change EC version from 2.1.3 to 2.3.1

--- a/.changeset/tidy-lies-warn.md
+++ b/.changeset/tidy-lies-warn.md
@@ -2,4 +2,4 @@
 "nextjs-website": minor
 ---
 
-Change EC version from 2.1.3 to 2.3.1
+Bump version of `pagopa-editorial-components` from 2.1.3 to 2.3.1

--- a/apps/nextjs-website/package.json
+++ b/apps/nextjs-website/package.json
@@ -16,7 +16,7 @@
     "@mui/icons-material": "^5.14.14",
     "@mui/material": "^5.14.14",
     "@pagopa/mui-italia": "^1.0.1",
-    "@pagopa/pagopa-editorial-components": "^2.1.3",
+    "@pagopa/pagopa-editorial-components": "^2.3.1",
     "fp-ts": "^2.16.1",
     "html-react-parser": "^5.0.11",
     "io-ts": "^2.2.20",

--- a/package-lock.json
+++ b/package-lock.json
@@ -607,7 +607,7 @@
         "@mui/icons-material": "^5.14.14",
         "@mui/material": "^5.14.14",
         "@pagopa/mui-italia": "^1.0.1",
-        "@pagopa/pagopa-editorial-components": "^2.1.3",
+        "@pagopa/pagopa-editorial-components": "^2.3.1",
         "fp-ts": "^2.16.1",
         "html-react-parser": "^5.0.11",
         "io-ts": "^2.2.20",
@@ -631,10 +631,167 @@
         "vitest": "^0.34.6"
       }
     },
+    "apps/nextjs-website/node_modules/@pagopa/pagopa-editorial-components": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@pagopa/pagopa-editorial-components/-/pagopa-editorial-components-2.3.1.tgz",
+      "integrity": "sha512-hBaZHl94+UOksnwE52fIF2baZRfHAu1vM56OJCVuM12Q1wBSsUFrJsJ5rn98D1ahxE7gWlKIMPcYZ8paAPVZKQ==",
+      "dependencies": {
+        "@pagopa/mui-italia": "^0.8.12",
+        "@testing-library/jest-dom": "^6.1.4",
+        "react-swipeable-views": "^0.14.0",
+        "react-swipeable-views-utils": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=16.10.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
+    "apps/nextjs-website/node_modules/@pagopa/pagopa-editorial-components/node_modules/@pagopa/mui-italia": {
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@pagopa/mui-italia/-/mui-italia-0.8.12.tgz",
+      "integrity": "sha512-Qz0fMf5T3GHp/5g0VLyMR3kUtYnXpjtM3H9Hy5Co776Bi9BSiNLEPgP1svupIyW+RX8xpQD5fohyAmCNhP4qRw==",
+      "dependencies": {
+        "@fontsource/dm-mono": "^4.5.10",
+        "@fontsource/titillium-web": "^4.5.9",
+        "clsx": "^1.2.1",
+        "fp-ts": "^2.12.3",
+        "io-ts": "^2.2.18"
+      },
+      "engines": {
+        "node": ">=14.x",
+        "npm": ">=8.x"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.10.4",
+        "@emotion/styled": "^11.10.4",
+        "@mui/icons-material": "^5.10.9",
+        "@mui/lab": "^5.0.0-alpha.100",
+        "@mui/material": "^5.10.9",
+        "@mui/system": "^5.10.8",
+        "react": "^17.0.0",
+        "react-dom": "^17.0.0"
+      }
+    },
+    "apps/nextjs-website/node_modules/@pagopa/pagopa-editorial-components/node_modules/@testing-library/jest-dom": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.4.2.tgz",
+      "integrity": "sha512-CzqH0AFymEMG48CpzXFriYYkOjk6ZGPCLMhW9e9jg3KMCn5OfJecF8GtGW7yGfR/IgCe3SX8BSwjdzI6BBbZLw==",
+      "dependencies": {
+        "@adobe/css-tools": "^4.3.2",
+        "@babel/runtime": "^7.9.2",
+        "aria-query": "^5.0.0",
+        "chalk": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "lodash": "^4.17.15",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@jest/globals": ">= 28",
+        "@types/bun": "latest",
+        "@types/jest": ">= 28",
+        "jest": ">= 28",
+        "vitest": ">= 0.32"
+      },
+      "peerDependenciesMeta": {
+        "@jest/globals": {
+          "optional": true
+        },
+        "@types/bun": {
+          "optional": true
+        },
+        "@types/jest": {
+          "optional": true
+        },
+        "jest": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
     "apps/nextjs-website/node_modules/@types/node": {
       "version": "20.5.9",
       "dev": true,
       "license": "MIT"
+    },
+    "apps/nextjs-website/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "apps/nextjs-website/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "apps/nextjs-website/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "apps/nextjs-website/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "apps/nextjs-website/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "apps/nextjs-website/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "apps/nextjs-website/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "apps/strapi-cms": {
       "version": "0.0.0",
@@ -666,6 +823,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.3.tgz",
+      "integrity": "sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ=="
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.1",
@@ -2917,7 +3079,7 @@
     },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
@@ -3647,53 +3809,6 @@
       }
     },
     "node_modules/@pagopa/mui-italia/node_modules/clsx": {
-      "version": "1.2.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@pagopa/pagopa-editorial-components": {
-      "version": "2.1.3",
-      "dependencies": {
-        "@pagopa/mui-italia": "^0.8.12",
-        "react-swipeable-views": "^0.14.0",
-        "react-swipeable-views-utils": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=16.10.0"
-      },
-      "peerDependencies": {
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
-      }
-    },
-    "node_modules/@pagopa/pagopa-editorial-components/node_modules/@pagopa/mui-italia": {
-      "version": "0.8.12",
-      "license": "MIT",
-      "dependencies": {
-        "@fontsource/dm-mono": "^4.5.10",
-        "@fontsource/titillium-web": "^4.5.9",
-        "clsx": "^1.2.1",
-        "fp-ts": "^2.12.3",
-        "io-ts": "^2.2.18"
-      },
-      "engines": {
-        "node": ">=14.x",
-        "npm": ">=8.x"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.10.4",
-        "@emotion/styled": "^11.10.4",
-        "@mui/icons-material": "^5.10.9",
-        "@mui/lab": "^5.0.0-alpha.100",
-        "@mui/material": "^5.10.9",
-        "@mui/system": "^5.10.8",
-        "react": "^17.0.0",
-        "react-dom": "^17.0.0"
-      }
-    },
-    "node_modules/@pagopa/pagopa-editorial-components/node_modules/clsx": {
       "version": "1.2.1",
       "license": "MIT",
       "engines": {
@@ -4710,7 +4825,7 @@
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@sindresorhus/is": {
@@ -7257,12 +7372,12 @@
     },
     "node_modules/@types/chai": {
       "version": "4.3.10",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/chai-subset": {
       "version": "1.3.5",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "*"
@@ -7852,7 +7967,7 @@
     },
     "node_modules/@vitest/expect": {
       "version": "0.34.6",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/spy": "0.34.6",
@@ -7865,7 +7980,7 @@
     },
     "node_modules/@vitest/runner": {
       "version": "0.34.6",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/utils": "0.34.6",
@@ -7878,7 +7993,7 @@
     },
     "node_modules/@vitest/runner/node_modules/p-limit": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^1.0.0"
@@ -7892,7 +8007,7 @@
     },
     "node_modules/@vitest/runner/node_modules/yocto-queue": {
       "version": "1.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.20"
@@ -7903,7 +8018,7 @@
     },
     "node_modules/@vitest/snapshot": {
       "version": "0.34.6",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "magic-string": "^0.30.1",
@@ -7916,7 +8031,7 @@
     },
     "node_modules/@vitest/spy": {
       "version": "0.34.6",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tinyspy": "^2.1.1"
@@ -7927,7 +8042,7 @@
     },
     "node_modules/@vitest/utils": {
       "version": "0.34.6",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "diff-sequences": "^29.4.3",
@@ -8140,7 +8255,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
       "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -8323,7 +8438,6 @@
     },
     "node_modules/aria-query": {
       "version": "5.3.0",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "dequal": "^2.0.3"
@@ -8509,7 +8623,7 @@
     },
     "node_modules/assertion-error": {
       "version": "1.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -9111,7 +9225,7 @@
     },
     "node_modules/cac": {
       "version": "6.7.14",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9260,7 +9374,7 @@
     },
     "node_modules/chai": {
       "version": "4.3.10",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "assertion-error": "^1.1.0",
@@ -9347,7 +9461,7 @@
     },
     "node_modules/check-error": {
       "version": "1.0.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "get-func-name": "^2.0.2"
@@ -10174,6 +10288,11 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "license": "MIT",
@@ -10314,7 +10433,7 @@
     },
     "node_modules/deep-eql": {
       "version": "4.1.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "type-detect": "^4.0.0"
@@ -10488,7 +10607,6 @@
     },
     "node_modules/dequal": {
       "version": "2.0.3",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -10534,7 +10652,7 @@
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -10589,6 +10707,11 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
@@ -13117,7 +13240,7 @@
     },
     "node_modules/get-func-name": {
       "version": "2.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -15105,7 +15228,7 @@
     },
     "node_modules/jsonc-parser": {
       "version": "3.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/jsonfile": {
@@ -15622,7 +15745,7 @@
     },
     "node_modules/local-pkg": {
       "version": "0.4.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -15784,7 +15907,7 @@
     },
     "node_modules/loupe": {
       "version": "2.3.7",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "get-func-name": "^2.0.1"
@@ -15831,7 +15954,7 @@
     },
     "node_modules/magic-string": {
       "version": "0.30.5",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
@@ -16152,7 +16275,6 @@
     },
     "node_modules/min-indent": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -16321,7 +16443,7 @@
     },
     "node_modules/mlly": {
       "version": "1.4.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.10.0",
@@ -17510,12 +17632,12 @@
     },
     "node_modules/pathe": {
       "version": "1.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/pathval": {
       "version": "1.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -17637,7 +17759,7 @@
     },
     "node_modules/pkg-types": {
       "version": "1.0.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "jsonc-parser": "^3.2.0",
@@ -18143,7 +18265,7 @@
     },
     "node_modules/pretty-format": {
       "version": "29.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.6.3",
@@ -18156,7 +18278,7 @@
     },
     "node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -18908,7 +19030,6 @@
     },
     "node_modules/redent": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "indent-string": "^4.0.0",
@@ -19849,7 +19970,7 @@
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/signal-exit": {
@@ -20400,7 +20521,7 @@
     },
     "node_modules/stackback": {
       "version": "0.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/stackframe": {
@@ -20894,7 +21015,6 @@
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "min-indent": "^1.0.0"
@@ -20916,7 +21036,7 @@
     },
     "node_modules/strip-literal": {
       "version": "1.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.10.0"
@@ -21296,12 +21416,12 @@
     },
     "node_modules/tinybench": {
       "version": "2.5.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/tinypool": {
       "version": "0.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -21309,7 +21429,7 @@
     },
     "node_modules/tinyspy": {
       "version": "2.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -21585,7 +21705,7 @@
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -21693,7 +21813,7 @@
     },
     "node_modules/ufo": {
       "version": "1.3.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/uglify-js": {
@@ -22097,7 +22217,7 @@
     },
     "node_modules/vite-node": {
       "version": "0.34.6",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
@@ -22480,7 +22600,7 @@
     },
     "node_modules/vite-node/node_modules/esbuild": {
       "version": "0.18.20",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -22516,7 +22636,7 @@
     },
     "node_modules/vite-node/node_modules/postcss": {
       "version": "8.4.31",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -22550,7 +22670,7 @@
     },
     "node_modules/vite-node/node_modules/vite": {
       "version": "4.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.18.10",
@@ -22604,7 +22724,7 @@
     },
     "node_modules/vitest": {
       "version": "0.34.6",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^4.3.5",
@@ -23031,7 +23151,7 @@
     },
     "node_modules/vitest/node_modules/@types/node": {
       "version": "20.9.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -23039,7 +23159,7 @@
     },
     "node_modules/vitest/node_modules/esbuild": {
       "version": "0.18.20",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -23075,7 +23195,7 @@
     },
     "node_modules/vitest/node_modules/postcss": {
       "version": "8.4.31",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -23102,12 +23222,12 @@
     },
     "node_modules/vitest/node_modules/undici-types": {
       "version": "5.26.5",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/vitest/node_modules/vite": {
       "version": "4.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.18.10",
@@ -23704,7 +23824,7 @@
     },
     "node_modules/why-is-node-running": {
       "version": "2.2.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "siginfo": "^2.0.0",


### PR DESCRIPTION
#### List of Changes
- Updated the "@pagopa/pagopa-editorial-components" package from version 2.1.3 to 2.3.1

#### Motivation and Context
This change is necessary to incorporate the latest enhancements, bug fixes, and features provided by the new version of the "@pagopa/pagopa-editorial-components" package (from 2.1.3 to 2.3.1). By staying up-to-date with the latest package version, we ensure that our system benefits from improved performance, security patches, and additional functionality. Also this will import missing components from the previous version

#### How Has This Been Tested?
Testing the updated package version involved the following steps:
- Delete node_modules folders from local
- Update from the old to new package version
- Npm install from the root folder

#### Types of changes
- [ ] Chore (nothing changes from a user perspective)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Doesn't need any documentation updates