### PR TITLE
[B2BP-412] - Updating "Editorial-Components" version from 2.3.1 to 2.3.4

### DIFF
--- a/apps/nextjs-website/package.json
+++ b/apps/nextjs-website/package.json
@@ -16,7 +16,7 @@
     "@mui/icons-material": "^5.14.14",
     "@mui/material": "^5.14.14",
     "@pagopa/mui-italia": "^1.0.1",
-    "@pagopa/pagopa-editorial-components": "^2.3.1",
+    "@pagopa/pagopa-editorial-components": "^2.3.4",
     "fp-ts": "^2.16.1",
     "html-react-parser": "^5.0.11",
     "io-ts": "^2.2.20",


### PR DESCRIPTION
#### List of Changes
- Updated the "@pagopa/pagopa-editorial-components" package from version 2.3.1 to 2.3.4

#### Motivation and Context
This change is necessary to fix the error about Hydration for Cards component from Editorial-Components.

#### How Has This Been Tested?
Testing the updated package version involved the following steps:
- Delete node_modules folders from local
- Update from the old to new package version
- Npm install from the root folder

#### Types of changes
- [ ] Chore (nothing changes from a user perspective)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Doesn't need any documentation updates