### PR TITLE
[B2BP-392] Implement SEO NextJS-side

### DIFF
--- a/.changeset/funny-lies-approve.md
+++ b/.changeset/funny-lies-approve.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": minor
+---
+
+Implement SEO

--- a/apps/nextjs-website/src/app/[[...slug]]/page.tsx
+++ b/apps/nextjs-website/src/app/[[...slug]]/page.tsx
@@ -1,5 +1,6 @@
+import { Metadata } from 'next';
 import { Page } from '@/lib/pages';
-import { getAllPages, getPageProps } from '@/lib/api';
+import { getAllPages, getPageProps, getSiteWideSEO } from '@/lib/api';
 import PageSection from '@/components/PageSection/PageSection';
 
 // Dynamic segments not included in generateStaticParams will return a 404.
@@ -16,6 +17,42 @@ export const generateStaticParams = async (): Promise<Page[]> =>
   // __return_type__: any[] | Promise<any[]>; }'.
   [...(await getAllPages())];
 
+export async function generateMetadata({
+  params,
+}: PageParams): Promise<Metadata> {
+  const { slug } = params;
+  // slug is undefined for homepage (apparently due to generateStaticParams)
+  // so we need to convert it back to [] (which is what getAllPages returns and what getPageProps expects)
+  const pageProps = await getPageProps(slug ?? []);
+  if (pageProps === undefined) {
+    return {};
+  }
+
+  const seo = pageProps.seo;
+  const siteWideSEO = await getSiteWideSEO();
+
+  return {
+    title: seo.metaTitle,
+    description: seo.metaDescription,
+    ...(seo.keywords && { keywords: seo.keywords.replaceAll('\n', ', ') }),
+    ...(seo.canonicalURL && {
+      alternates: {
+        canonical: seo.canonicalURL,
+      },
+    }),
+    openGraph: {
+      title: seo.ogTitle ?? seo.metaTitle,
+      description: seo.ogDescription ?? seo.metaDescription,
+      images: siteWideSEO.metaImage.data.attributes.url,
+      type: 'website',
+    },
+    icons: {
+      icon: siteWideSEO.favicon.data.attributes.url,
+      apple: siteWideSEO.appleTouchIcon.data.attributes.url,
+    },
+  };
+}
+
 type PageParams = {
   params: { slug?: string[] };
 };
@@ -25,9 +62,13 @@ const Page = async ({ params }: PageParams) => {
   // slug is undefined for homepage (apparently due to generateStaticParams)
   // so we need to convert it back to [] (which is what getAllPages returns and what getPageProps expects)
   const pageProps = await getPageProps(slug ?? []);
-  const sections = pageProps?.sections || [];
+  if (pageProps === undefined) {
+    return null;
+  }
 
-  return pageProps ? <div>{sections.map(PageSection)}</div> : null;
+  const sections = pageProps.sections;
+
+  return <div>{sections.map(PageSection)}</div>;
 };
 
 export default Page;

--- a/apps/nextjs-website/src/app/layout.tsx
+++ b/apps/nextjs-website/src/app/layout.tsx
@@ -1,15 +1,9 @@
-import type { Metadata } from 'next';
 import { ThemeProvider } from '@mui/system';
 import { theme } from '@pagopa/mui-italia';
 import PreHeader from '@/components/PreHeader';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
 import { getPreHeaderProps, getHeaderProps, getFooterProps } from '@/lib/api';
-
-export const metadata: Metadata = {
-  title: 'Page',
-  description: 'New Page Created',
-};
 
 export default async function RootLayout({
   children,

--- a/apps/nextjs-website/src/app/manifest.ts
+++ b/apps/nextjs-website/src/app/manifest.ts
@@ -1,0 +1,31 @@
+import { MetadataRoute } from 'next';
+import { getSiteWideSEO } from '@/lib/api';
+
+export default async function manifest(): Promise<MetadataRoute.Manifest> {
+  const {
+    manifest: { name, shortName },
+    favicon,
+  } = await getSiteWideSEO();
+
+  return {
+    name,
+    short_name: shortName,
+
+    // Currently unused, leaving as a comment to discuss its usage at a later date
+    // description: 'Next.js App',
+
+    // Currently hardcoded values taken from SEND's website
+    // They will be made dynamic if necessary
+    start_url: '/',
+    display: 'minimal-ui',
+    background_color: '#FFFFFF',
+    theme_color: '#0073E6',
+    icons: [
+      {
+        src: favicon.data.attributes.url,
+        sizes: `${favicon.data.attributes.width}x${favicon.data.attributes.height}`,
+        type: favicon.data.attributes.mime,
+      },
+    ],
+  };
+}

--- a/apps/nextjs-website/src/lib/__tests__/pages.test.ts
+++ b/apps/nextjs-website/src/lib/__tests__/pages.test.ts
@@ -10,7 +10,11 @@ describe('makePageListFromNavigation', () => {
   it('should return pages list given a navigation with homepage', () => {
     const actual = makePageListFromNavigation([data.homepageNavItem]);
     const expected = [
-      { slug: [], sections: data.homepageNavItem.related.sections },
+      {
+        slug: [],
+        sections: data.homepageNavItem.related.sections,
+        seo: data.homepageNavItem.related.seo,
+      },
     ];
     expect(actual).toStrictEqual(expected);
   });
@@ -21,10 +25,12 @@ describe('makePageListFromNavigation', () => {
       {
         slug: [data.parentNavItem.related.slug],
         sections: data.parentNavItem.related.sections,
+        seo: data.parentNavItem.related.seo,
       },
       {
         slug: [data.parentNavItem.related.slug, data.childNavItem.related.slug],
         sections: data.childNavItem.related.sections,
+        seo: data.childNavItem.related.seo,
       },
     ];
     expect(actual).toStrictEqual(expected);

--- a/apps/nextjs-website/src/lib/api.ts
+++ b/apps/nextjs-website/src/lib/api.ts
@@ -7,6 +7,7 @@ import { PreHeader, getPreHeader } from './fetch/preHeader';
 import { FooterData, getFooter } from './fetch/footer';
 import { getHeader } from './fetch/header';
 import { HeaderWithNavigation, makeHeaderWithNavigation } from './header';
+import { SiteWideSEO, fetchSiteWideSEO } from './fetch/siteWideSEO';
 import { makeAppEnv } from '@/AppEnv';
 
 // create AppEnv given process env
@@ -55,4 +56,13 @@ export const getPageProps = async (
 ): Promise<Page | undefined> => {
   const allPages = await getAllPages();
   return allPages.find((page) => slug.toString() === page.slug.toString());
+};
+
+export const getSiteWideSEO = async (): Promise<
+  SiteWideSEO['data']['attributes']
+> => {
+  const {
+    data: { attributes },
+  } = await fetchSiteWideSEO(appEnv);
+  return attributes;
 };

--- a/apps/nextjs-website/src/lib/fetch/__tests__/data.ts
+++ b/apps/nextjs-website/src/lib/fetch/__tests__/data.ts
@@ -8,6 +8,14 @@ export const homepageNavItem: Navigation[0] = {
   menuAttached: false,
   related: {
     slug: 'homepage',
+    seo: {
+      metaTitle: 'SEND - PagoPA',
+      metaDescription: 'Homepage description',
+      keywords: 'homepage1\nhomepage2\nhomepage3',
+      canonicalURL: 'https://dsf3knok9k0v5.cloudfront.net/homepage-canonical',
+      ogTitle: 'Homepage og title',
+      ogDescription: 'Homepage og description',
+    },
     sections: [
       {
         __component: 'sections.hero',
@@ -33,12 +41,23 @@ export const parentNavItem: Navigation[0] = {
   menuAttached: true,
   related: {
     slug: 'parent',
+    seo: {
+      metaTitle: 'SEND - Parent',
+      metaDescription: 'Parent description',
+      keywords: 'parent1\nparent2\nparent3',
+      canonicalURL: 'https://dsf3knok9k0v5.cloudfront.net/parent-canonical',
+      ogTitle: 'Parent og title',
+      ogDescription: 'Parent og description',
+    },
     sections: [
       {
         __component: 'sections.editorial',
         image: {
           url: 'someUrl',
           alternativeText: null,
+          width: 1000,
+          height: 1000,
+          mime: 'image/jpeg',
         },
         ctaButtons: [],
         sectionID: null,
@@ -62,6 +81,14 @@ export const childNavItem: Navigation[0] = {
   menuAttached: true,
   related: {
     slug: 'child',
+    seo: {
+      metaTitle: 'SEND - Child',
+      metaDescription: 'Child description',
+      keywords: 'child1\nchild2\nchild3',
+      canonicalURL: 'https://dsf3knok9k0v5.cloudfront.net/child-canonical',
+      ogTitle: 'Child og title',
+      ogDescription: 'Child og description',
+    },
     sections: [
       {
         __component: 'sections.hero',

--- a/apps/nextjs-website/src/lib/fetch/__tests__/navigation.test.ts
+++ b/apps/nextjs-website/src/lib/fetch/__tests__/navigation.test.ts
@@ -37,6 +37,16 @@ const navigationResponse = [
       navigationItemId: 1,
       createdBy: {},
       updatedBy: {},
+      seo: {
+        id: 1,
+        metaTitle: 'SEND - Test SEO',
+        metaDescription:
+          'Demo demo demo demo demo demo demo demo demo demo demo demo',
+        keywords: 'keyword1\nkeyword2\nkeyword3',
+        canonicalURL: 'https://dsf3knok9k0v5.cloudfront.net/seo-test-canonical',
+        ogTitle: 'Titling for the og',
+        ogDescription: 'Description for the og',
+      },
       sections: [
         {
           __component: 'sections.hero',
@@ -68,7 +78,7 @@ describe('getNavigation', () => {
     await getNavigation('main-menu', appEnv);
 
     expect(fetchMock).toHaveBeenCalledWith(
-      `${config.STRAPI_API_BASE_URL}/api/navigation/render/main-menu?type=FLAT&populate[sections][populate][0]=ctaButtons&populate[sections][populate][1]=image&populate[sections][populate][2]=background&populate[sections][populate][3]=items&populate[sections][populate][4]=link&populate[sections][populate][5]=steps&populate[sections][populate][6]=accordionItems&populate[sections][populate][7]=decoration`,
+      `${config.STRAPI_API_BASE_URL}/api/navigation/render/main-menu?type=FLAT&populate[seo][populate][0]=*&populate[sections][populate][0]=ctaButtons&populate[sections][populate][1]=image&populate[sections][populate][2]=background&populate[sections][populate][3]=items&populate[sections][populate][4]=link&populate[sections][populate][5]=steps&populate[sections][populate][6]=accordionItems&populate[sections][populate][7]=decoration`,
       {
         method: 'GET',
         headers: {
@@ -94,6 +104,16 @@ describe('getNavigation', () => {
         title: 'Homepage',
         related: {
           slug: 'homepage',
+          seo: {
+            metaTitle: 'SEND - Test SEO',
+            metaDescription:
+              'Demo demo demo demo demo demo demo demo demo demo demo demo',
+            keywords: 'keyword1\nkeyword2\nkeyword3',
+            canonicalURL:
+              'https://dsf3knok9k0v5.cloudfront.net/seo-test-canonical',
+            ogTitle: 'Titling for the og',
+            ogDescription: 'Description for the og',
+          },
           sections: [
             {
               __component: 'sections.hero',

--- a/apps/nextjs-website/src/lib/fetch/__tests__/siteWideSEO.test.ts
+++ b/apps/nextjs-website/src/lib/fetch/__tests__/siteWideSEO.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fetchSiteWideSEO } from '../siteWideSEO';
+
+const makeTestAppEnv = () => {
+  const config = {
+    STRAPI_API_TOKEN: 'aStrapiToken',
+    STRAPI_API_BASE_URL: 'aStrapiApiBaseUrl',
+  };
+  const fetchMock = vi.fn(fetch);
+  const appEnv = { config, fetchFun: fetchMock };
+  return { appEnv, fetchMock };
+};
+
+// response example
+const siteWideSEOResponse = {
+  data: {
+    attributes: {
+      metaImage: {
+        data: {
+          attributes: {
+            alternativeText: null,
+            width: 1568,
+            height: 1504,
+            mime: 'image/jpeg',
+            url: '/uploads/THE_cool_guy_768eb95435.jpg',
+          },
+        },
+      },
+      favicon: {
+        data: {
+          attributes: {
+            alternativeText: null,
+            width: 1568,
+            height: 1504,
+            mime: 'image/jpeg',
+            url: '/uploads/THE_cool_guy_768eb95435.jpg',
+          },
+        },
+      },
+      appleTouchIcon: {
+        data: {
+          attributes: {
+            alternativeText: null,
+            width: 2880,
+            height: 1440,
+            mime: 'image/png',
+            url: '/uploads/hero_home_background_969783a4a7.png',
+          },
+        },
+      },
+      manifest: {
+        name: 'SEND-PagoPA - Servizio di Notifiche Digitali',
+        shortName: 'SEND-PagoPA',
+      },
+    },
+  },
+};
+
+describe('fetchSiteWideSEO', () => {
+  it('should call /api/general type GET', async () => {
+    const { appEnv, fetchMock } = makeTestAppEnv();
+    const { config } = appEnv;
+
+    fetchMock.mockResolvedValueOnce({
+      json: () => Promise.resolve(siteWideSEOResponse),
+    } as unknown as Response);
+
+    await fetchSiteWideSEO(appEnv);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${config.STRAPI_API_BASE_URL}/api/general?populate=metaImage,favicon,appleTouchIcon,manifest`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${config.STRAPI_API_TOKEN}`,
+        },
+      }
+    );
+  });
+
+  it('should parse siteWideSEO without error', async () => {
+    const { appEnv, fetchMock } = makeTestAppEnv();
+
+    fetchMock.mockResolvedValueOnce({
+      json: () => Promise.resolve(siteWideSEOResponse),
+    } as unknown as Response);
+
+    const actual = fetchSiteWideSEO(appEnv);
+
+    expect(await actual).toStrictEqual(siteWideSEOResponse);
+  });
+});

--- a/apps/nextjs-website/src/lib/fetch/navigation.ts
+++ b/apps/nextjs-website/src/lib/fetch/navigation.ts
@@ -1,6 +1,7 @@
 import * as t from 'io-ts';
 import { extractFromResponse } from './extractFromResponse';
 import { PageSectionCodec } from './types/PageSection';
+import { PageSEOCodec } from './types/SEO';
 import { AppEnv } from '@/AppEnv';
 
 // Codec
@@ -17,6 +18,7 @@ const NavItemCodec = t.intersection([
     parent: t.union([ParentCodec, t.null]),
     related: t.strict({
       slug: t.string,
+      seo: PageSEOCodec,
       sections: t.array(PageSectionCodec),
     }),
   }),
@@ -33,7 +35,7 @@ export const getNavigation = (
   extractFromResponse(
     fetchFun(
       // All query parameters in the following URL indicate specific fields that would not otherwise be automatically returned by Strapi
-      `${config.STRAPI_API_BASE_URL}/api/navigation/render/${menuName}?type=FLAT&populate[sections][populate][0]=ctaButtons&populate[sections][populate][1]=image&populate[sections][populate][2]=background&populate[sections][populate][3]=items&populate[sections][populate][4]=link&populate[sections][populate][5]=steps&populate[sections][populate][6]=accordionItems&populate[sections][populate][7]=decoration`,
+      `${config.STRAPI_API_BASE_URL}/api/navigation/render/${menuName}?type=FLAT&populate[seo][populate][0]=*&populate[sections][populate][0]=ctaButtons&populate[sections][populate][1]=image&populate[sections][populate][2]=background&populate[sections][populate][3]=items&populate[sections][populate][4]=link&populate[sections][populate][5]=steps&populate[sections][populate][6]=accordionItems&populate[sections][populate][7]=decoration`,
       {
         method: 'GET',
         headers: {

--- a/apps/nextjs-website/src/lib/fetch/siteWideSEO.ts
+++ b/apps/nextjs-website/src/lib/fetch/siteWideSEO.ts
@@ -1,0 +1,37 @@
+import * as t from 'io-ts';
+import { extractFromResponse } from './extractFromResponse';
+import { StrapiImageRequiredSchema } from './types/StrapiImage';
+import { AppEnv } from '@/AppEnv';
+
+const SiteWideSEOCodec = t.strict({
+  data: t.strict({
+    attributes: t.strict({
+      metaImage: StrapiImageRequiredSchema,
+      favicon: StrapiImageRequiredSchema,
+      appleTouchIcon: StrapiImageRequiredSchema,
+      manifest: t.strict({
+        name: t.string,
+        shortName: t.string,
+      }),
+    }),
+  }),
+});
+
+export type SiteWideSEO = t.TypeOf<typeof SiteWideSEOCodec>;
+
+export const fetchSiteWideSEO = ({
+  config,
+  fetchFun,
+}: AppEnv): Promise<SiteWideSEO> =>
+  extractFromResponse(
+    fetchFun(
+      `${config.STRAPI_API_BASE_URL}/api/general?populate=metaImage,favicon,appleTouchIcon,manifest`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${config.STRAPI_API_TOKEN}`,
+        },
+      }
+    ),
+    SiteWideSEOCodec
+  );

--- a/apps/nextjs-website/src/lib/fetch/types/SEO.ts
+++ b/apps/nextjs-website/src/lib/fetch/types/SEO.ts
@@ -1,0 +1,12 @@
+import * as t from 'io-ts';
+
+export const PageSEOCodec = t.strict({
+  metaTitle: t.string,
+  metaDescription: t.string,
+  keywords: t.union([t.string, t.null]),
+  canonicalURL: t.union([t.string, t.null]),
+  ogTitle: t.union([t.string, t.null]),
+  ogDescription: t.union([t.string, t.null]),
+});
+
+export type PageSEO = t.TypeOf<typeof PageSEOCodec>;

--- a/apps/nextjs-website/src/lib/fetch/types/StrapiImage.ts
+++ b/apps/nextjs-website/src/lib/fetch/types/StrapiImage.ts
@@ -3,6 +3,9 @@ import * as t from 'io-ts';
 export const ImageDataCodec = t.strict({
   alternativeText: t.union([t.string, t.null]),
   url: t.string,
+  width: t.number,
+  height: t.number,
+  mime: t.string,
 });
 
 export const StrapiImageSchema = t.strict({
@@ -12,6 +15,12 @@ export const StrapiImageSchema = t.strict({
     }),
     t.null,
   ]),
+});
+
+export const StrapiImageRequiredSchema = t.strict({
+  data: t.strict({
+    attributes: ImageDataCodec,
+  }),
 });
 
 export type Image = t.TypeOf<typeof StrapiImageSchema>;

--- a/apps/nextjs-website/src/lib/pages.ts
+++ b/apps/nextjs-website/src/lib/pages.ts
@@ -1,13 +1,13 @@
 import { pipe } from 'fp-ts/lib/function';
 import * as RA from 'fp-ts/lib/ReadonlyArray';
 import { Navigation } from './fetch/navigation';
-import { PageSection } from './fetch/types/PageSection';
 import { PageSEO } from './fetch/types/SEO';
+import { PageSection } from './fetch/types/PageSection';
 
 export type Page = {
   readonly slug: ReadonlyArray<string>;
-  readonly sections: ReadonlyArray<PageSection>;
   readonly seo: PageSEO;
+  readonly sections: ReadonlyArray<PageSection>;
 };
 
 const makeSlugList = (

--- a/apps/nextjs-website/src/lib/pages.ts
+++ b/apps/nextjs-website/src/lib/pages.ts
@@ -31,7 +31,7 @@ export const makePageListFromNavigation = (
     navigation,
     RA.map((item) => ({
       slug: makeSlugList(item, navigation),
-      sections: item.related.sections,
       seo: item.related.seo,
+      sections: item.related.sections,
     }))
   );

--- a/apps/nextjs-website/src/lib/pages.ts
+++ b/apps/nextjs-website/src/lib/pages.ts
@@ -2,10 +2,12 @@ import { pipe } from 'fp-ts/lib/function';
 import * as RA from 'fp-ts/lib/ReadonlyArray';
 import { Navigation } from './fetch/navigation';
 import { PageSection } from './fetch/types/PageSection';
+import { PageSEO } from './fetch/types/SEO';
 
 export type Page = {
   readonly slug: ReadonlyArray<string>;
   readonly sections: ReadonlyArray<PageSection>;
+  readonly seo: PageSEO;
 };
 
 const makeSlugList = (
@@ -30,5 +32,6 @@ export const makePageListFromNavigation = (
     RA.map((item) => ({
       slug: makeSlugList(item, navigation),
       sections: item.related.sections,
+      seo: item.related.seo,
     }))
   );


### PR DESCRIPTION
Implementing SEO NextJS-side based on [RFC SV-015](https://pagopa.atlassian.net/wiki/spaces/SV/pages/931627186/SV-015+Requisiti+di+SEO) and PR #183 

#### List of Changes
<!--- Describe your changes in detail -->
- Fetch `siteWideSEO`
- Populate `seo` field when fetching pages
- Add `generateMetaData` to `[[slug]]/page.tsx`
- Add `manifest.ts`
- Update `ImageDataCodec` to allow new fields needed for SEO (specifically manifest generation)
- Add + Update tests

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Adding SEO to static websites.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested locally.

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
