### PR TITLE
[B2BP-471] Create DB schema, if it doesn't exist, before running server

### DIFF
--- a/.changeset/great-cups-brush.md
+++ b/.changeset/great-cups-brush.md
@@ -1,0 +1,5 @@
+---
+"strapi-cms": minor
+---
+
+Create DB schema, if it doesn't exist, before running server

--- a/apps/strapi-cms/package.json
+++ b/apps/strapi-cms/package.json
@@ -17,6 +17,7 @@
     "strapi": "strapi"
   },
   "devDependencies": {
+    "@types/pg": "^8.11.2",
     "eslint": "^8.50.0",
     "eslint-config-custom": "*",
     "shx": "^0.3.4",

--- a/apps/strapi-cms/src/index.ts
+++ b/apps/strapi-cms/src/index.ts
@@ -1,1 +1,22 @@
-export default {};
+import { Client } from 'pg';
+/* eslint-disable functional/no-expression-statements */
+
+export default {
+  register: async (): Promise<void> => {
+    const client = new Client({
+      application_name: 'strapi',
+      database: process.env['DATABASE_NAME'],
+      host: process.env['DATABASE_HOST'],
+      password: process.env['DATABASE_PASSWORD'],
+      port: Number(process.env['DATABASE_PORT']),
+      query_timeout: 5000,
+      statement_timeout: 5000,
+      user: process.env['DATABASE_USERNAME'],
+    });
+    await client.connect();
+    await client.query(
+      `CREATE SCHEMA IF NOT EXISTS ${process.env['DATABASE_SCHEMA']};`
+    );
+    await client.end();
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -703,6 +703,7 @@
         "strapi-plugin-update-static-content": "^1.0.8"
       },
       "devDependencies": {
+        "@types/pg": "^8.11.2",
         "eslint": "^8.50.0",
         "eslint-config-custom": "*",
         "shx": "^0.3.4",
@@ -7668,6 +7669,74 @@
     "node_modules/@types/parse-json": {
       "version": "4.0.1",
       "license": "MIT"
+    },
+    "node_modules/@types/pg": {
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.11.2.tgz",
+      "integrity": "sha512-G2Mjygf2jFMU/9hCaTYxJrwdObdcnuQde1gndooZSOHsNSaCehAuwc7EIuSA34Do8Jx2yZ19KtvW8P0j4EuUXw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^4.0.1"
+      }
+    },
+    "node_modules/@types/pg/node_modules/pg-types": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-4.0.2.tgz",
+      "integrity": "sha512-cRL3JpS3lKMGsKaWndugWQoLOCoP+Cic8oseVcbr0qhPzYD5DWXK+RZ9LY9wxRf7RQia4SCwQlXk0q6FCPrVng==",
+      "dev": true,
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "pg-numeric": "1.0.2",
+        "postgres-array": "~3.0.1",
+        "postgres-bytea": "~3.0.0",
+        "postgres-date": "~2.1.0",
+        "postgres-interval": "^3.0.0",
+        "postgres-range": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@types/pg/node_modules/postgres-array": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.2.tgz",
+      "integrity": "sha512-6faShkdFugNQCLwucjPcY5ARoW1SlbnrZjmGl0IrrqewpvxvhSLHimCVzqeuULCbG0fQv7Dtk1yDbG3xv7Veog==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@types/pg/node_modules/postgres-bytea": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-3.0.0.tgz",
+      "integrity": "sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==",
+      "dev": true,
+      "dependencies": {
+        "obuf": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@types/pg/node_modules/postgres-date": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-2.1.0.tgz",
+      "integrity": "sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@types/pg/node_modules/postgres-interval": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-3.0.0.tgz",
+      "integrity": "sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.11",
@@ -17741,7 +17810,8 @@
     },
     "node_modules/pg": {
       "version": "8.11.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.3.tgz",
+      "integrity": "sha512-+9iuvG8QfaaUrrph+kpF24cXkH1YOOUeArRNYIxq1viYHZagBxrTno7cecY1Fa44tJeZvaoG+Djpkc3JwehN5g==",
       "dependencies": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",
@@ -17780,6 +17850,15 @@
       "license": "ISC",
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-numeric": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pg-numeric/-/pg-numeric-1.0.2.tgz",
+      "integrity": "sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/pg-pool": {
@@ -18222,6 +18301,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/postgres-range": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.4.tgz",
+      "integrity": "sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==",
+      "dev": true
     },
     "node_modules/prebuild-install": {
       "version": "7.1.1",


### PR DESCRIPTION
As per title.

Solution as described in [RFC SV-011](https://pagopa.atlassian.net/wiki/spaces/SV/pages/831619365/SV-011+Come+creare+schema+PostgreSQL+per+nuovi+clienti)

#### List of Changes
<!--- Describe your changes in detail -->
- Used [Strapi's `register` lifecycle function](https://docs.strapi.io/dev-docs/configurations/functions#register) to create schema before the server starts

Strapi will now create the schema found in the environment variable `DATABASE_SCHEMA` if it doesn't already exist.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Simpler and safer creation of new tenants.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested locally.
It also works with the `configrestore` command added recently, creating an otherwise empty DB that contains the full UI configuration.

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
