### PR TITLE
[B2BP-472] - Update EC version from 3.1.0 to 3.1.1

### DIFF
--- a/.changeset/early-jars-float.md
+++ b/.changeset/early-jars-float.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": minor
+---
+
+Updated EC version from 3.1.0 to 3.1.1

--- a/apps/nextjs-website/package.json
+++ b/apps/nextjs-website/package.json
@@ -16,7 +16,7 @@
     "@mui/icons-material": "^5.14.14",
     "@mui/material": "^5.14.14",
     "@pagopa/mui-italia": "^1.0.1",
-    "@pagopa/pagopa-editorial-components": "^3.1.0",
+    "@pagopa/pagopa-editorial-components": "^3.1.1",
     "fp-ts": "^2.16.1",
     "html-react-parser": "^5.0.11",
     "io-ts": "^2.2.20",

--- a/package-lock.json
+++ b/package-lock.json
@@ -607,7 +607,7 @@
         "@mui/icons-material": "^5.14.14",
         "@mui/material": "^5.14.14",
         "@pagopa/mui-italia": "^1.0.1",
-        "@pagopa/pagopa-editorial-components": "^3.1.0",
+        "@pagopa/pagopa-editorial-components": "^3.1.1",
         "fp-ts": "^2.16.1",
         "html-react-parser": "^5.0.11",
         "io-ts": "^2.2.20",
@@ -632,9 +632,9 @@
       }
     },
     "apps/nextjs-website/node_modules/@pagopa/pagopa-editorial-components": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@pagopa/pagopa-editorial-components/-/pagopa-editorial-components-3.1.0.tgz",
-      "integrity": "sha512-wVFV2FS2YDquysW/wM9a/ktP8H53xRTRJ6TTvp1ln90IIF36+/YtglasL7oAHigekr2y9/B+9VXu3Dmq0+LKfg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@pagopa/pagopa-editorial-components/-/pagopa-editorial-components-3.1.1.tgz",
+      "integrity": "sha512-AP7/NlMFyVQcPmcfgyjjHXdXyko+qMdi6O/fSXb5b00/gtQi4qupmd9YguTSGqSK5yaHBliQxo3aBcE4IqIyvQ==",
       "dependencies": {
         "@pagopa/mui-italia": "^0.8.12",
         "@testing-library/jest-dom": "^6.1.4",


### PR DESCRIPTION
#### List of Changes
- Updated the "@pagopa/pagopa-editorial-components" package from version 3.1.0 to 3.1.1

#### Motivation and Context
This new version will fix the "window" error on "Editorial" component from EC

#### How Has This Been Tested?
Testing the updated package version involved the following steps:
- Delete node_modules folders from local
- Update from the old to new package version
- Npm install from the root folder

#### Types of changes
- [ ] Chore (nothing changes from a user perspective)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Doesn't need any documentation updates