### PR TITLE
[B2BP-481] Img to next/image warning fix

### DIFF
--- a/.changeset/forty-elephants-deny.md
+++ b/.changeset/forty-elephants-deny.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": minor
+---
+
+Change from <img> to <image> from next/images package on Editorial component

--- a/apps/nextjs-website/next.config.js
+++ b/apps/nextjs-website/next.config.js
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
     output: 'export',
+    images: {
+        unoptimized: true,
+    },
 }
 
 module.exports = nextConfig

--- a/apps/nextjs-website/src/components/Editorial.tsx
+++ b/apps/nextjs-website/src/components/Editorial.tsx
@@ -20,11 +20,10 @@ const makeEditorialProps = ({
   image: (
     <Image
       src={image.url}
-      width={500}
-      height={500}
-      layout='responsive'
-      unoptimized={true}
-      alt={image.alternativeText ?? 'no alt'}
+      alt={image.alternativeText ?? ''}
+      // Needed by Image, will be overwritten
+      width={0}
+      height={0}
     />
   ),
   ...(ctaButtons &&

--- a/apps/nextjs-website/src/components/Editorial.tsx
+++ b/apps/nextjs-website/src/components/Editorial.tsx
@@ -2,6 +2,7 @@
 import { Editorial as EditorialEC } from '@pagopa/pagopa-editorial-components';
 import { EditorialProps } from '@pagopa/pagopa-editorial-components/dist/components/Editorial';
 import { Stack } from '@mui/material';
+import Image from 'next/image';
 import MarkdownRenderer from './MarkdownRenderer';
 import { EditorialSection } from '@/lib/fetch/types/PageSection';
 import Icon from '@/components/Icon';
@@ -16,7 +17,16 @@ const makeEditorialProps = ({
 }: EditorialSection): EditorialProps => ({
   ...(eyelet && { eyelet }),
   body: MarkdownRenderer({ markdown: body, variant: 'body2' }),
-  image: <img src={image.url} alt={image.alternativeText ?? undefined} />,
+  image: (
+    <Image
+      src={`http://localhost:1337${image.url}`}
+      width={500}
+      height={500}
+      layout='responsive'
+      unoptimized={true}
+      alt={image.alternativeText ?? 'no alt'}
+    />
+  ),
   ...(ctaButtons &&
     ctaButtons.length > 0 && {
       ctaButtons: ctaButtons.map(({ icon, ...ctaBtn }) => ({
@@ -43,6 +53,7 @@ const Editorial = (props: EditorialSection) => {
           },
           img: {
             maxHeight: 490,
+            width: '100%',
           },
           '.MuiTypography-root': {
             color: themeColor,

--- a/apps/nextjs-website/src/components/Editorial.tsx
+++ b/apps/nextjs-website/src/components/Editorial.tsx
@@ -19,7 +19,7 @@ const makeEditorialProps = ({
   body: MarkdownRenderer({ markdown: body, variant: 'body2' }),
   image: (
     <Image
-      src={`http://localhost:1337${image.url}`}
+      src={image.url}
       width={500}
       height={500}
       layout='responsive'


### PR DESCRIPTION
#### List of Changes
- Converted img to next/image on Editorial.tsx file
- Added unoptimized: true to next.config.js
- Updated style

#### Motivation and Context
This PR will fix the warning about the "Using `<img>` could result in slower LCP and higher bandwidth". The result is to use "Image" from Next.JS in order to fix the warning. The unoptimized config was necessary due to "Image Optimization using the default loader is not compatible with `{ output: 'export' }`" so from the official Next.JS docs the solution of unoptimized images were implemented

#### How Has This Been Tested?
Tested in local. To test, change this row

```src={image.url}```

into this row

```src={`http://localhost:1337${image.url}`}```

#### Types of changes
- [ ] Chore (nothing changes by a user perspective)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Doesn't need any documentation update.
