### PR TITLE
[B2BP-495] - Update EC version from 3.1.1 to 3.1.2

### DIFF
--- a/.changeset/orange-plants-double.md
+++ b/.changeset/orange-plants-double.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": minor
+---
+
+Update EC from 3.1.1 to 3.1.2

--- a/apps/nextjs-website/package.json
+++ b/apps/nextjs-website/package.json
@@ -16,7 +16,7 @@
     "@mui/icons-material": "^5.14.14",
     "@mui/material": "^5.14.14",
     "@pagopa/mui-italia": "^1.0.1",
-    "@pagopa/pagopa-editorial-components": "^3.1.1",
+    "@pagopa/pagopa-editorial-components": "^3.1.2",
     "fp-ts": "^2.16.1",
     "html-react-parser": "^5.0.11",
     "io-ts": "^2.2.20",

--- a/package-lock.json
+++ b/package-lock.json
@@ -610,7 +610,7 @@
         "@mui/icons-material": "^5.14.14",
         "@mui/material": "^5.14.14",
         "@pagopa/mui-italia": "^1.0.1",
-        "@pagopa/pagopa-editorial-components": "^3.1.1",
+        "@pagopa/pagopa-editorial-components": "^3.1.2",
         "fp-ts": "^2.16.1",
         "html-react-parser": "^5.0.11",
         "io-ts": "^2.2.20",
@@ -635,9 +635,9 @@
       }
     },
     "apps/nextjs-website/node_modules/@pagopa/pagopa-editorial-components": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@pagopa/pagopa-editorial-components/-/pagopa-editorial-components-3.1.1.tgz",
-      "integrity": "sha512-AP7/NlMFyVQcPmcfgyjjHXdXyko+qMdi6O/fSXb5b00/gtQi4qupmd9YguTSGqSK5yaHBliQxo3aBcE4IqIyvQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@pagopa/pagopa-editorial-components/-/pagopa-editorial-components-3.1.2.tgz",
+      "integrity": "sha512-/omLffTgHMsd5SD9Pu33rUij2061RozzY+ILE40Vr3XmMVX6fLaSOd+oJmc4TFxdWR5hj2YMhmw2SBrjS8OGIg==",
       "dependencies": {
         "@pagopa/mui-italia": "^0.8.12",
         "@testing-library/jest-dom": "^6.1.4",


### PR DESCRIPTION
#### List of Changes
- Updated the "@pagopa/pagopa-editorial-components" package from version 3.1.1 to 3.1.2

#### Motivation and Context
This new version will fix small Ui issues with BannerLink and HowTo components.

#### How Has This Been Tested?
Testing the updated package version involved the following steps:
- Delete node_modules folders from local
- Update from the old to new package version
- Npm install from the root folder

#### Types of changes
- [ ] Chore (nothing changes from a user perspective)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Doesn't need any documentation updates