### PR TITLE
[B2BP-401] Rename ExtractNoticeIDFromOneTrustURL to extractNoticeIDFromOneTrustURL

### DIFF
--- a/apps/nextjs-website/src/components/OneTrust.tsx
+++ b/apps/nextjs-website/src/components/OneTrust.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useEffect } from 'react';
 import { Box } from '@mui/material';
-import { ExtractNoticeIDFromOneTrustURL } from '@/lib/oneTrust';
+import { extractNoticeIDFromOneTrustURL } from '@/lib/oneTrust';
 import { OneTrustSectionProps } from '@/lib/fetch/types/PageSection';
 
 // Declare OneTrust object created by otnotice-1.0.min.js
@@ -20,7 +20,7 @@ const OneTrustSection = (props: OneTrustSectionProps) => {
   const { oneTrustNoticeURL } = props;
   // Extrapolate notice ID and build the ID of the div to be populated
   // akin to how otnotice-1.0.min.js does
-  const divID = `otnotice-${ExtractNoticeIDFromOneTrustURL(oneTrustNoticeURL)}`;
+  const divID = `otnotice-${extractNoticeIDFromOneTrustURL(oneTrustNoticeURL)}`;
 
   // eslint-disable-next-line functional/no-return-void
   useEffect(() => {

--- a/apps/nextjs-website/src/lib/__tests__/oneTrust.test.ts
+++ b/apps/nextjs-website/src/lib/__tests__/oneTrust.test.ts
@@ -1,31 +1,31 @@
 import { describe, it, expect } from 'vitest';
-import { ExtractNoticeIDFromOneTrustURL } from '../oneTrust';
+import { extractNoticeIDFromOneTrustURL } from '../oneTrust';
 
-describe('ExtractNoticeIDFromOneTrustURL', () => {
+describe('extractNoticeIDFromOneTrustURL', () => {
   it('should extract the notice ID from a valid URL', () => {
-    const actual = ExtractNoticeIDFromOneTrustURL(
+    const actual = extractNoticeIDFromOneTrustURL(
       'https://valid-url-example.onetrust.com/client-id/service-id/draft/noticeID.json'
     );
     expect(actual).toStrictEqual('noticeID');
   });
   it('should return null from a non-OneTrust URL', () => {
-    const actual = ExtractNoticeIDFromOneTrustURL(
+    const actual = extractNoticeIDFromOneTrustURL(
       'https://non-onetrust.com-url-example.othersite.com/fake.onetrust.com/service-id/draft/noticeID.json'
     );
     expect(actual).toBeNull();
   });
   it('should return null from a URL that does not point to a .json file', () => {
-    const actual = ExtractNoticeIDFromOneTrustURL(
+    const actual = extractNoticeIDFromOneTrustURL(
       'https://no-json-url-example.onetrust.com/client-id/service-id/draft/noticeID'
     );
     expect(actual).toBeNull();
   });
   it('should return null from an invalid URL', () => {
-    const actual = ExtractNoticeIDFromOneTrustURL('not-a-url');
+    const actual = extractNoticeIDFromOneTrustURL('not-a-url');
     expect(actual).toBeNull();
   });
   it('should only accept https URLs', () => {
-    const actual = ExtractNoticeIDFromOneTrustURL(
+    const actual = extractNoticeIDFromOneTrustURL(
       'http://unsafe-but-valid-url-example.onetrust.com/client-id/service-id/draft/noticeID.json'
     );
     expect(actual).toBeNull();

--- a/apps/nextjs-website/src/lib/oneTrust.ts
+++ b/apps/nextjs-website/src/lib/oneTrust.ts
@@ -1,4 +1,4 @@
-export const ExtractNoticeIDFromOneTrustURL = (
+export const extractNoticeIDFromOneTrustURL = (
   OTNoticeURLString: string
 ): string | null => {
   // Check that given URL comes from onetrust.com and points to a .json file as it should before parsing


### PR DESCRIPTION
As per title.

This was made to standardize the function's name by using camel case like every other function like it.

There was an attempt to move `OneTrust` declaration to `lib/OneTrust.ts` as suggested here, but the page would not work.
Seems like the declaration needs to be client-side.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested locally.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
