### PR TITLE
[B2BP-513] - Update EC version from 3.1.2 to 4.0.0

### DIFF
--- a/.changeset/bright-flies-act.md
+++ b/.changeset/bright-flies-act.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": minor
+---
+
+Update EC from 3.1.2 to 4.0.0

--- a/.changeset/fair-trains-invite.md
+++ b/.changeset/fair-trains-invite.md
@@ -1,6 +1,0 @@
----
-"nextjs-website": minor
-"strapi-cms": minor
----
-
-Adapt to EC version 4.0.0

--- a/.changeset/fair-trains-invite.md
+++ b/.changeset/fair-trains-invite.md
@@ -3,4 +3,4 @@
 "strapi-cms": minor
 ---
 
-Adapt to EC version 3.2.0
+Adapt to EC version 4.0.0

--- a/.changeset/fair-trains-invite.md
+++ b/.changeset/fair-trains-invite.md
@@ -1,0 +1,6 @@
+---
+"nextjs-website": minor
+"strapi-cms": minor
+---
+
+Adapt to EC version 3.2.0

--- a/.changeset/mean-seals-give.md
+++ b/.changeset/mean-seals-give.md
@@ -1,0 +1,5 @@
+---
+"strapi-cms": minor
+---
+
+Update strapi with new size for 'Hero' component and add new functionality for the new 'Editorial' component badges

--- a/apps/nextjs-website/package.json
+++ b/apps/nextjs-website/package.json
@@ -16,7 +16,7 @@
     "@mui/icons-material": "^5.14.14",
     "@mui/material": "^5.14.14",
     "@pagopa/mui-italia": "^1.0.1",
-    "@pagopa/pagopa-editorial-components": "^3.1.2",
+    "@pagopa/pagopa-editorial-components": "^3.2.0",
     "fp-ts": "^2.16.1",
     "html-react-parser": "^5.0.11",
     "io-ts": "^2.2.20",

--- a/apps/nextjs-website/package.json
+++ b/apps/nextjs-website/package.json
@@ -16,7 +16,7 @@
     "@mui/icons-material": "^5.14.14",
     "@mui/material": "^5.14.14",
     "@pagopa/mui-italia": "^1.0.1",
-    "@pagopa/pagopa-editorial-components": "^3.2.0",
+    "@pagopa/pagopa-editorial-components": "^4.0.0",
     "fp-ts": "^2.16.1",
     "html-react-parser": "^5.0.11",
     "io-ts": "^2.2.20",

--- a/apps/nextjs-website/src/components/Editorial.tsx
+++ b/apps/nextjs-website/src/components/Editorial.tsx
@@ -13,6 +13,7 @@ const makeEditorialProps = ({
   body,
   image,
   ctaButtons,
+  storeButtons,
   ...rest
 }: EditorialSection): EditorialProps => ({
   ...(eyelet && { eyelet }),
@@ -34,6 +35,12 @@ const makeEditorialProps = ({
         ...(icon && { startIcon: Icon(icon) }),
       })),
     }),
+  ...(storeButtons && {
+    storeButtons: {
+      ...(storeButtons.hrefGoogle && { hrefGoogle: storeButtons.hrefGoogle }),
+      ...(storeButtons.hrefApple && { hrefApple: storeButtons.hrefApple }),
+    },
+  }),
   ...rest,
 });
 

--- a/apps/nextjs-website/src/lib/fetch/__tests__/data.ts
+++ b/apps/nextjs-website/src/lib/fetch/__tests__/data.ts
@@ -68,6 +68,7 @@ export const parentNavItem: Navigation[0] = {
         pattern: 'dots',
         reversed: false,
         width: 'standard',
+        storeButtons: null,
       },
     ],
   },

--- a/apps/nextjs-website/src/lib/fetch/__tests__/navigation.test.ts
+++ b/apps/nextjs-website/src/lib/fetch/__tests__/navigation.test.ts
@@ -78,7 +78,7 @@ describe('getNavigation', () => {
     await getNavigation('main-menu', appEnv);
 
     expect(fetchMock).toHaveBeenCalledWith(
-      `${config.STRAPI_API_BASE_URL}/api/navigation/render/main-menu?type=FLAT&populate[seo][populate][0]=metaTitle&populate[sections][populate][0]=ctaButtons&populate[sections][populate][1]=image&populate[sections][populate][2]=background&populate[sections][populate][3]=items.links&populate[sections][populate][4]=link&populate[sections][populate][5]=steps&populate[sections][populate][6]=accordionItems&populate[sections][populate][7]=decoration`,
+      `${config.STRAPI_API_BASE_URL}/api/navigation/render/main-menu?type=FLAT&populate[seo][populate][0]=metaTitle&populate[sections][populate][0]=ctaButtons&populate[sections][populate][1]=image&populate[sections][populate][2]=background&populate[sections][populate][3]=items.links&populate[sections][populate][4]=link&populate[sections][populate][5]=steps&populate[sections][populate][6]=accordionItems&populate[sections][populate][7]=decoration&populate[sections][populate][8]=storeButtons`,
       {
         method: 'GET',
         headers: {

--- a/apps/nextjs-website/src/lib/fetch/navigation.ts
+++ b/apps/nextjs-website/src/lib/fetch/navigation.ts
@@ -35,7 +35,7 @@ export const getNavigation = (
   extractFromResponse(
     fetchFun(
       // All query parameters in the following URL indicate specific fields that would not otherwise be automatically returned by Strapi
-      `${config.STRAPI_API_BASE_URL}/api/navigation/render/${menuName}?type=FLAT&populate[seo][populate][0]=metaTitle&populate[sections][populate][0]=ctaButtons&populate[sections][populate][1]=image&populate[sections][populate][2]=background&populate[sections][populate][3]=items.links&populate[sections][populate][4]=link&populate[sections][populate][5]=steps&populate[sections][populate][6]=accordionItems&populate[sections][populate][7]=decoration`,
+      `${config.STRAPI_API_BASE_URL}/api/navigation/render/${menuName}?type=FLAT&populate[seo][populate][0]=metaTitle&populate[sections][populate][0]=ctaButtons&populate[sections][populate][1]=image&populate[sections][populate][2]=background&populate[sections][populate][3]=items.links&populate[sections][populate][4]=link&populate[sections][populate][5]=steps&populate[sections][populate][6]=accordionItems&populate[sections][populate][7]=decoration&populate[sections][populate][8]=storeButtons`,
       {
         method: 'GET',
         headers: {

--- a/apps/nextjs-website/src/lib/fetch/types/PageSection.ts
+++ b/apps/nextjs-website/src/lib/fetch/types/PageSection.ts
@@ -14,12 +14,18 @@ const HeroSectionCodec = t.strict({
   inverse: t.boolean,
   size: t.keyof({
     small: null,
+    medium: null,
     big: null,
   }),
   sectionID: t.union([t.string, t.null]),
   image: t.union([ImageDataCodec, t.null]),
   background: t.union([ImageDataCodec, t.null]),
   ctaButtons: t.array(CTAButtonSimpleCodec),
+});
+
+const StoreButtonsCodec = t.strict({
+  hrefGoogle: t.union([t.string, t.null]),
+  hrefApple: t.union([t.string, t.null]),
 });
 
 const EditorialSectionCodec = t.strict({
@@ -42,6 +48,7 @@ const EditorialSectionCodec = t.strict({
   sectionID: t.union([t.string, t.null]),
   image: ImageDataCodec,
   ctaButtons: t.array(CTAButtonSimpleCodec),
+  storeButtons: t.union([StoreButtonsCodec, t.null]),
 });
 
 const AccordionSectionCodec = t.strict({

--- a/apps/strapi-cms/src/components/components/store-buttons.json
+++ b/apps/strapi-cms/src/components/components/store-buttons.json
@@ -1,0 +1,15 @@
+{
+  "collectionName": "components_components_store_buttons",
+  "info": {
+    "displayName": "StoreButtons"
+  },
+  "options": {},
+  "attributes": {
+    "hrefGoogle": {
+      "type": "string"
+    },
+    "hrefApple": {
+      "type": "string"
+    }
+  }
+}

--- a/apps/strapi-cms/src/components/sections/editorial.json
+++ b/apps/strapi-cms/src/components/sections/editorial.json
@@ -70,6 +70,11 @@
       "repeatable": true,
       "component": "components.cta-button-simple",
       "max": 2
+    },
+    "storeButtons": {
+      "type": "component",
+      "repeatable": false,
+      "component": "components.store-buttons"
     }
   }
 }

--- a/apps/strapi-cms/src/components/sections/hero.json
+++ b/apps/strapi-cms/src/components/sections/hero.json
@@ -47,6 +47,7 @@
       "type": "enumeration",
       "enum": [
         "small",
+        "medium",
         "big"
       ],
       "default": "small",

--- a/package-lock.json
+++ b/package-lock.json
@@ -211,7 +211,7 @@
         "@mui/icons-material": "^5.14.14",
         "@mui/material": "^5.14.14",
         "@pagopa/mui-italia": "^1.0.1",
-        "@pagopa/pagopa-editorial-components": "^3.2.0",
+        "@pagopa/pagopa-editorial-components": "^4.0.0",
         "fp-ts": "^2.16.1",
         "html-react-parser": "^5.0.11",
         "io-ts": "^2.2.20",
@@ -236,9 +236,9 @@
       }
     },
     "apps/nextjs-website/node_modules/@pagopa/pagopa-editorial-components": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@pagopa/pagopa-editorial-components/-/pagopa-editorial-components-3.2.0.tgz",
-      "integrity": "sha512-8gALA1nD06BaYY6+Uw8V6kiAWp68CV25JeEFuIuejxOnVvzck4J8IpBxtjvdanKgJpTOidWgIVlBH5oDcKlcdQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@pagopa/pagopa-editorial-components/-/pagopa-editorial-components-4.0.0.tgz",
+      "integrity": "sha512-CfxHxIjX+4QeY+ksjGtxnw2+CiYmdAF1xXJRMzKaccAZPuhDKqTl9FVSZaOi3Y8fUIxe5r5UfuBcbQvl8SEAPw==",
       "dependencies": {
         "@pagopa/mui-italia": "^0.8.12",
         "@testing-library/jest-dom": "^6.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -211,7 +211,7 @@
         "@mui/icons-material": "^5.14.14",
         "@mui/material": "^5.14.14",
         "@pagopa/mui-italia": "^1.0.1",
-        "@pagopa/pagopa-editorial-components": "^3.1.2",
+        "@pagopa/pagopa-editorial-components": "^3.2.0",
         "fp-ts": "^2.16.1",
         "html-react-parser": "^5.0.11",
         "io-ts": "^2.2.20",
@@ -236,9 +236,9 @@
       }
     },
     "apps/nextjs-website/node_modules/@pagopa/pagopa-editorial-components": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@pagopa/pagopa-editorial-components/-/pagopa-editorial-components-3.1.2.tgz",
-      "integrity": "sha512-/omLffTgHMsd5SD9Pu33rUij2061RozzY+ILE40Vr3XmMVX6fLaSOd+oJmc4TFxdWR5hj2YMhmw2SBrjS8OGIg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@pagopa/pagopa-editorial-components/-/pagopa-editorial-components-3.2.0.tgz",
+      "integrity": "sha512-8gALA1nD06BaYY6+Uw8V6kiAWp68CV25JeEFuIuejxOnVvzck4J8IpBxtjvdanKgJpTOidWgIVlBH5oDcKlcdQ==",
       "dependencies": {
         "@pagopa/mui-italia": "^0.8.12",
         "@testing-library/jest-dom": "^6.1.4",
@@ -284,6 +284,14 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.9.tgz",
       "integrity": "sha512-PcGNd//40kHAS3sTlzKB9C9XL4K0sTup8nbG5lC14kzEteTNuAFh9u5nA0o5TWnSG2r/JNPRXFVcHJIIeRlmqQ==",
       "dev": true
+    },
+    "apps/nextjs-website/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "apps/strapi-cms": {
       "version": "0.1.0",


### PR DESCRIPTION
#### List of Changes
- Updated the "@pagopa/pagopa-editorial-components" package from version 3.1.2 to 4.0.0

#### Motivation and Context
This new version will fix:
- Cards layout
- Hero size for FAQ page
- Added badges for "Editorial" components

#### How Has This Been Tested?
Testing the updated package version involved the following steps:
- Delete node_modules folders from local
- Update from the old to new package version
- Npm install from the root folder

#### Types of changes
- [ ] Chore (nothing changes from a user perspective)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Doesn't need any documentation updates