### PR TITLE
[B2BP-497] Set up Strapi data structure for multitenancy

### DIFF
--- a/.changeset/blue-snakes-agree.md
+++ b/.changeset/blue-snakes-agree.md
@@ -1,0 +1,5 @@
+---
+"strapi-cms": minor
+---
+
+Duplicated Single Types for SEND and AppIO tenants

--- a/apps/strapi-cms/.eslintrc.json
+++ b/apps/strapi-cms/.eslintrc.json
@@ -3,5 +3,5 @@
     "extends": [
       "custom/eslint-strong"
     ],
-    "ignorePatterns": ["config/*.ts", "types/**", "database/**", "src/admin/**"]
+    "ignorePatterns": ["config/*.ts", "types/**", "database/**", "src/admin/**", "src/api/**"]
   }

--- a/apps/strapi-cms/src/api/appio-footer/content-types/appio-footer/schema.json
+++ b/apps/strapi-cms/src/api/appio-footer/content-types/appio-footer/schema.json
@@ -1,0 +1,54 @@
+{
+  "kind": "singleType",
+  "collectionName": "appio_footers",
+  "info": {
+    "singularName": "appio-footer",
+    "pluralName": "appio-footers",
+    "displayName": "Footer (AppIO)"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "legalInfo": {
+      "type": "richtext",
+      "required": true
+    },
+    "showFundedByNextGenerationEULogo": {
+      "type": "boolean",
+      "default": false,
+      "required": true
+    },
+    "companyLink": {
+      "type": "component",
+      "repeatable": false,
+      "component": "components.company-link",
+      "required": true
+    },
+    "links_aboutUs": {
+      "type": "component",
+      "repeatable": false,
+      "component": "components.footer-link-group",
+      "required": true
+    },
+    "links_services": {
+      "type": "component",
+      "repeatable": false,
+      "component": "components.footer-link-group",
+      "required": true
+    },
+    "links_resources": {
+      "type": "component",
+      "repeatable": false,
+      "component": "components.footer-link-group",
+      "required": true
+    },
+    "links_followUs": {
+      "type": "component",
+      "repeatable": false,
+      "component": "components.footer-link-group-with-social",
+      "required": true
+    }
+  }
+}

--- a/apps/strapi-cms/src/api/appio-footer/controllers/appio-footer.ts
+++ b/apps/strapi-cms/src/api/appio-footer/controllers/appio-footer.ts
@@ -1,0 +1,7 @@
+/**
+ * appio-footer controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::appio-footer.appio-footer');

--- a/apps/strapi-cms/src/api/appio-footer/routes/appio-footer.ts
+++ b/apps/strapi-cms/src/api/appio-footer/routes/appio-footer.ts
@@ -1,0 +1,7 @@
+/**
+ * appio-footer router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::appio-footer.appio-footer');

--- a/apps/strapi-cms/src/api/appio-footer/services/appio-footer.ts
+++ b/apps/strapi-cms/src/api/appio-footer/services/appio-footer.ts
@@ -1,0 +1,7 @@
+/**
+ * appio-footer service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::appio-footer.appio-footer');

--- a/apps/strapi-cms/src/api/appio-general/content-types/appio-general/schema.json
+++ b/apps/strapi-cms/src/api/appio-general/content-types/appio-general/schema.json
@@ -1,0 +1,45 @@
+{
+  "kind": "singleType",
+  "collectionName": "appio_generals",
+  "info": {
+    "singularName": "appio-general",
+    "pluralName": "appio-generals",
+    "displayName": "Generale (AppIO)"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "metaImage": {
+      "allowedTypes": [
+        "images"
+      ],
+      "type": "media",
+      "multiple": false,
+      "required": true
+    },
+    "favicon": {
+      "allowedTypes": [
+        "images"
+      ],
+      "type": "media",
+      "multiple": false,
+      "required": true
+    },
+    "appleTouchIcon": {
+      "allowedTypes": [
+        "images"
+      ],
+      "type": "media",
+      "multiple": false,
+      "required": true
+    },
+    "manifest": {
+      "type": "component",
+      "repeatable": false,
+      "component": "shared.manifest",
+      "required": true
+    }
+  }
+}

--- a/apps/strapi-cms/src/api/appio-general/controllers/appio-general.ts
+++ b/apps/strapi-cms/src/api/appio-general/controllers/appio-general.ts
@@ -1,0 +1,7 @@
+/**
+ * appio-general controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::appio-general.appio-general');

--- a/apps/strapi-cms/src/api/appio-general/routes/appio-general.ts
+++ b/apps/strapi-cms/src/api/appio-general/routes/appio-general.ts
@@ -1,0 +1,7 @@
+/**
+ * appio-general router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::appio-general.appio-general');

--- a/apps/strapi-cms/src/api/appio-general/services/appio-general.ts
+++ b/apps/strapi-cms/src/api/appio-general/services/appio-general.ts
@@ -1,0 +1,7 @@
+/**
+ * appio-general service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::appio-general.appio-general');

--- a/apps/strapi-cms/src/api/appio-header/content-types/appio-header/schema.json
+++ b/apps/strapi-cms/src/api/appio-header/content-types/appio-header/schema.json
@@ -1,0 +1,37 @@
+{
+  "kind": "singleType",
+  "collectionName": "appio_headers",
+  "info": {
+    "singularName": "appio-header",
+    "pluralName": "appio-headers",
+    "displayName": "Header (AppIO)"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "productName": {
+      "type": "string",
+      "required": true
+    },
+    "beta": {
+      "type": "boolean",
+      "default": false,
+      "required": true
+    },
+    "ctaButtons": {
+      "type": "component",
+      "repeatable": true,
+      "component": "components.cta-button-simple",
+      "max": 2
+    },
+    "logo": {
+      "allowedTypes": [
+        "images"
+      ],
+      "type": "media",
+      "multiple": false
+    }
+  }
+}

--- a/apps/strapi-cms/src/api/appio-header/controllers/appio-header.ts
+++ b/apps/strapi-cms/src/api/appio-header/controllers/appio-header.ts
@@ -1,0 +1,7 @@
+/**
+ * appio-header controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::appio-header.appio-header');

--- a/apps/strapi-cms/src/api/appio-header/routes/appio-header.ts
+++ b/apps/strapi-cms/src/api/appio-header/routes/appio-header.ts
@@ -1,0 +1,7 @@
+/**
+ * appio-header router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::appio-header.appio-header');

--- a/apps/strapi-cms/src/api/appio-header/services/appio-header.ts
+++ b/apps/strapi-cms/src/api/appio-header/services/appio-header.ts
@@ -1,0 +1,7 @@
+/**
+ * appio-header service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::appio-header.appio-header');

--- a/apps/strapi-cms/src/api/appio-pre-header/content-types/appio-pre-header/schema.json
+++ b/apps/strapi-cms/src/api/appio-pre-header/content-types/appio-pre-header/schema.json
@@ -1,0 +1,29 @@
+{
+  "kind": "singleType",
+  "collectionName": "appio_pre_headers",
+  "info": {
+    "singularName": "appio-pre-header",
+    "pluralName": "appio-pre-headers",
+    "displayName": "PreHeader (AppIO)"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "leftCtas": {
+      "type": "component",
+      "repeatable": true,
+      "component": "components.pre-header-button",
+      "required": true,
+      "min": 1
+    },
+    "rightCtas": {
+      "type": "component",
+      "repeatable": true,
+      "component": "components.pre-header-button",
+      "required": true,
+      "min": 1
+    }
+  }
+}

--- a/apps/strapi-cms/src/api/appio-pre-header/controllers/appio-pre-header.ts
+++ b/apps/strapi-cms/src/api/appio-pre-header/controllers/appio-pre-header.ts
@@ -1,0 +1,7 @@
+/**
+ * appio-pre-header controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::appio-pre-header.appio-pre-header');

--- a/apps/strapi-cms/src/api/appio-pre-header/routes/appio-pre-header.ts
+++ b/apps/strapi-cms/src/api/appio-pre-header/routes/appio-pre-header.ts
@@ -1,0 +1,7 @@
+/**
+ * appio-pre-header router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::appio-pre-header.appio-pre-header');

--- a/apps/strapi-cms/src/api/appio-pre-header/services/appio-pre-header.ts
+++ b/apps/strapi-cms/src/api/appio-pre-header/services/appio-pre-header.ts
@@ -1,0 +1,7 @@
+/**
+ * appio-pre-header service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::appio-pre-header.appio-pre-header');

--- a/apps/strapi-cms/src/api/send-footer/content-types/send-footer/schema.json
+++ b/apps/strapi-cms/src/api/send-footer/content-types/send-footer/schema.json
@@ -1,0 +1,54 @@
+{
+  "kind": "singleType",
+  "collectionName": "send_footers",
+  "info": {
+    "singularName": "send-footer",
+    "pluralName": "send-footers",
+    "displayName": "Footer (SEND)"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "legalInfo": {
+      "type": "richtext",
+      "required": true
+    },
+    "showFundedByNextGenerationEULogo": {
+      "type": "boolean",
+      "default": false,
+      "required": true
+    },
+    "companyLink": {
+      "type": "component",
+      "repeatable": false,
+      "component": "components.company-link",
+      "required": true
+    },
+    "links_aboutUs": {
+      "type": "component",
+      "repeatable": false,
+      "component": "components.footer-link-group",
+      "required": true
+    },
+    "links_services": {
+      "type": "component",
+      "repeatable": false,
+      "component": "components.footer-link-group",
+      "required": true
+    },
+    "links_resources": {
+      "type": "component",
+      "repeatable": false,
+      "component": "components.footer-link-group",
+      "required": true
+    },
+    "links_followUs": {
+      "type": "component",
+      "repeatable": false,
+      "component": "components.footer-link-group-with-social",
+      "required": true
+    }
+  }
+}

--- a/apps/strapi-cms/src/api/send-footer/controllers/send-footer.ts
+++ b/apps/strapi-cms/src/api/send-footer/controllers/send-footer.ts
@@ -1,0 +1,7 @@
+/**
+ * send-footer controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::send-footer.send-footer');

--- a/apps/strapi-cms/src/api/send-footer/routes/send-footer.ts
+++ b/apps/strapi-cms/src/api/send-footer/routes/send-footer.ts
@@ -1,0 +1,7 @@
+/**
+ * send-footer router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::send-footer.send-footer');

--- a/apps/strapi-cms/src/api/send-footer/services/send-footer.ts
+++ b/apps/strapi-cms/src/api/send-footer/services/send-footer.ts
@@ -1,0 +1,7 @@
+/**
+ * send-footer service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::send-footer.send-footer');

--- a/apps/strapi-cms/src/api/send-general/content-types/send-general/schema.json
+++ b/apps/strapi-cms/src/api/send-general/content-types/send-general/schema.json
@@ -1,0 +1,46 @@
+{
+  "kind": "singleType",
+  "collectionName": "send_generals",
+  "info": {
+    "singularName": "send-general",
+    "pluralName": "send-generals",
+    "displayName": "Generale (SEND)",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "metaImage": {
+      "type": "media",
+      "multiple": false,
+      "required": true,
+      "allowedTypes": [
+        "images"
+      ]
+    },
+    "favicon": {
+      "type": "media",
+      "multiple": false,
+      "required": true,
+      "allowedTypes": [
+        "images"
+      ]
+    },
+    "appleTouchIcon": {
+      "type": "media",
+      "multiple": false,
+      "required": true,
+      "allowedTypes": [
+        "images"
+      ]
+    },
+    "manifest": {
+      "type": "component",
+      "repeatable": false,
+      "component": "shared.manifest",
+      "required": true
+    }
+  }
+}

--- a/apps/strapi-cms/src/api/send-general/controllers/send-general.ts
+++ b/apps/strapi-cms/src/api/send-general/controllers/send-general.ts
@@ -1,0 +1,7 @@
+/**
+ * send-general controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::send-general.send-general');

--- a/apps/strapi-cms/src/api/send-general/routes/send-general.ts
+++ b/apps/strapi-cms/src/api/send-general/routes/send-general.ts
@@ -1,0 +1,7 @@
+/**
+ * send-general router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::send-general.send-general');

--- a/apps/strapi-cms/src/api/send-general/services/send-general.ts
+++ b/apps/strapi-cms/src/api/send-general/services/send-general.ts
@@ -1,0 +1,7 @@
+/**
+ * send-general service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::send-general.send-general');

--- a/apps/strapi-cms/src/api/send-header/content-types/send-header/schema.json
+++ b/apps/strapi-cms/src/api/send-header/content-types/send-header/schema.json
@@ -1,0 +1,37 @@
+{
+  "kind": "singleType",
+  "collectionName": "send_headers",
+  "info": {
+    "singularName": "send-header",
+    "pluralName": "send-headers",
+    "displayName": "Header (SEND)"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "productName": {
+      "type": "string",
+      "required": true
+    },
+    "beta": {
+      "type": "boolean",
+      "default": false,
+      "required": true
+    },
+    "ctaButtons": {
+      "type": "component",
+      "repeatable": true,
+      "component": "components.cta-button-simple",
+      "max": 2
+    },
+    "logo": {
+      "allowedTypes": [
+        "images"
+      ],
+      "type": "media",
+      "multiple": false
+    }
+  }
+}

--- a/apps/strapi-cms/src/api/send-header/controllers/send-header.ts
+++ b/apps/strapi-cms/src/api/send-header/controllers/send-header.ts
@@ -1,0 +1,7 @@
+/**
+ * send-header controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::send-header.send-header');

--- a/apps/strapi-cms/src/api/send-header/routes/send-header.ts
+++ b/apps/strapi-cms/src/api/send-header/routes/send-header.ts
@@ -1,0 +1,7 @@
+/**
+ * send-header router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::send-header.send-header');

--- a/apps/strapi-cms/src/api/send-header/services/send-header.ts
+++ b/apps/strapi-cms/src/api/send-header/services/send-header.ts
@@ -1,0 +1,7 @@
+/**
+ * send-header service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::send-header.send-header');

--- a/apps/strapi-cms/src/api/send-pre-header/content-types/send-pre-header/schema.json
+++ b/apps/strapi-cms/src/api/send-pre-header/content-types/send-pre-header/schema.json
@@ -1,0 +1,29 @@
+{
+  "kind": "singleType",
+  "collectionName": "send_pre_headers",
+  "info": {
+    "singularName": "send-pre-header",
+    "pluralName": "send-pre-headers",
+    "displayName": "PreHeader (SEND)"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "leftCtas": {
+      "type": "component",
+      "repeatable": true,
+      "component": "components.pre-header-button",
+      "required": true,
+      "min": 1
+    },
+    "rightCtas": {
+      "type": "component",
+      "repeatable": true,
+      "component": "components.pre-header-button",
+      "required": true,
+      "min": 1
+    }
+  }
+}

--- a/apps/strapi-cms/src/api/send-pre-header/controllers/send-pre-header.ts
+++ b/apps/strapi-cms/src/api/send-pre-header/controllers/send-pre-header.ts
@@ -1,0 +1,7 @@
+/**
+ * send-pre-header controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::send-pre-header.send-pre-header');

--- a/apps/strapi-cms/src/api/send-pre-header/routes/send-pre-header.ts
+++ b/apps/strapi-cms/src/api/send-pre-header/routes/send-pre-header.ts
@@ -1,0 +1,7 @@
+/**
+ * send-pre-header router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::send-pre-header.send-pre-header');

--- a/apps/strapi-cms/src/api/send-pre-header/services/send-pre-header.ts
+++ b/apps/strapi-cms/src/api/send-pre-header/services/send-pre-header.ts
@@ -1,0 +1,7 @@
+/**
+ * send-pre-header service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::send-pre-header.send-pre-header');

--- a/apps/strapi-cms/tsconfig.json
+++ b/apps/strapi-cms/tsconfig.json
@@ -39,7 +39,6 @@
     ".cache/",
     ".tmp/",
     "src/admin/",
-    "src/api/",
     "**/*.test.*",
     "src/plugins/**"
   ]

--- a/apps/strapi-cms/tsconfig.json
+++ b/apps/strapi-cms/tsconfig.json
@@ -39,6 +39,7 @@
     ".cache/",
     ".tmp/",
     "src/admin/",
+    "src/api/",
     "**/*.test.*",
     "src/plugins/**"
   ]


### PR DESCRIPTION
As per title, following decision in [RFC SV-018](https://pagopa.atlassian.net/wiki/spaces/SV/pages/969703545/SV-018+Multi-tenancy+Siti+Vetrina)

#### List of Changes
<!--- Describe your changes in detail -->
- Duplicates all Single Types (General, Header, PreHeader, Footer) for SEND tenant
- Duplicated all Single Types for AppIO tenant
- Default Single Types (who belong to no tenant) have currently been left in so as to not break the current online system

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Achieve multitenancy

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested locally

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
