### PR TITLE
[B2BP-522] - Fix Editorial badge buttons images not rendered

### DIFF
--- a/.changeset/breezy-masks-mate.md
+++ b/.changeset/breezy-masks-mate.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": minor
+---
+
+Fix editorial badge error with rendered image from @pagopa/pagopa-editorial-components

--- a/apps/nextjs-website/public/pagopa-images
+++ b/apps/nextjs-website/public/pagopa-images
@@ -1,0 +1,1 @@
+../node_modules/@pagopa/pagopa-editorial-components/dist/assets/images

--- a/apps/nextjs-website/src/components/Editorial.tsx
+++ b/apps/nextjs-website/src/components/Editorial.tsx
@@ -1,13 +1,14 @@
 'use client';
 import { Editorial as EditorialEC } from '@pagopa/pagopa-editorial-components';
 import { EditorialProps } from '@pagopa/pagopa-editorial-components/dist/components/Editorial';
-import googleStoreImage from '@pagopa/pagopa-editorial-components/dist/assets/images/google-play-badge.png';
-import appleStoreImage from '@pagopa/pagopa-editorial-components/dist/assets/images/app-store-badge.png';
 import { Stack } from '@mui/material';
 import Image from 'next/image';
 import MarkdownRenderer from './MarkdownRenderer';
 import { EditorialSection } from '@/lib/fetch/types/PageSection';
 import Icon from '@/components/Icon';
+
+const googleStoreImage = '/pagopa-images/google-play-badge.png';
+const appleStoreImage = '/pagopa-images/app-store-badge.png';
 
 const makeEditorialProps = ({
   theme,
@@ -41,11 +42,11 @@ const makeEditorialProps = ({
     storeButtons: {
       ...(storeButtons.hrefGoogle && {
         hrefGoogle: storeButtons.hrefGoogle,
-        googleImage: googleStoreImage,
+        googleBadge: googleStoreImage,
       }),
       ...(storeButtons.hrefApple && {
         hrefApple: storeButtons.hrefApple,
-        appleImage: appleStoreImage,
+        appleBadge: appleStoreImage,
       }),
     },
   }),

--- a/apps/nextjs-website/src/components/Editorial.tsx
+++ b/apps/nextjs-website/src/components/Editorial.tsx
@@ -1,6 +1,8 @@
 'use client';
 import { Editorial as EditorialEC } from '@pagopa/pagopa-editorial-components';
 import { EditorialProps } from '@pagopa/pagopa-editorial-components/dist/components/Editorial';
+import googleStoreImage from '@pagopa/pagopa-editorial-components/dist/assets/images/google-play-badge.png';
+import appleStoreImage from '@pagopa/pagopa-editorial-components/dist/assets/images/app-store-badge.png';
 import { Stack } from '@mui/material';
 import Image from 'next/image';
 import MarkdownRenderer from './MarkdownRenderer';
@@ -37,8 +39,14 @@ const makeEditorialProps = ({
     }),
   ...(storeButtons && {
     storeButtons: {
-      ...(storeButtons.hrefGoogle && { hrefGoogle: storeButtons.hrefGoogle }),
-      ...(storeButtons.hrefApple && { hrefApple: storeButtons.hrefApple }),
+      ...(storeButtons.hrefGoogle && {
+        hrefGoogle: storeButtons.hrefGoogle,
+        googleImage: googleStoreImage,
+      }),
+      ...(storeButtons.hrefApple && {
+        hrefApple: storeButtons.hrefApple,
+        appleImage: appleStoreImage,
+      }),
     },
   }),
   ...rest,


### PR DESCRIPTION
This PR depends on this from EC: [https://github.com/pagopa/pagopa-editorial-components/pull/183](url)

#### List of Changes
- Added a symbolic link to both .png images from the assets/images of @pagopa/pagopa-editorial-components
- Added the badges props on Editorial.tsx

#### Motivation and Context
This PR will fix the issue with the Editorial badges that are not rendered

#### How Has This Been Tested?
Tested in local:
1) run "npm run dev"
2) after building, navigate to http://localhost:3000/

#### Types of changes
- [ ] Chore (nothing changes by a user perspective)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Doesn't need any documentation updates.
