### PR TITLE
[B2BP-571] Fix deploy plugin "Your workflow_dispatch event is disabled" error

### DIFF
--- a/.changeset/new-deers-drum.md
+++ b/.changeset/new-deers-drum.md
@@ -1,0 +1,5 @@
+---
+"strapi-cms": patch
+---
+
+Switched from strapi.config.get to strapi.plugin.config to fetch Update Static Content plugin configuration

--- a/apps/strapi-cms/src/index.ts
+++ b/apps/strapi-cms/src/index.ts
@@ -43,8 +43,21 @@ export default {
       userRole: 'SEND Editor' | 'AppIO Editor'
     ): Promise<AxiosResponse | IServiceError> => {
       try {
-        const { owner, repo, workflowId, branch, githubToken } =
-          strapi.config.get(UpdateStaticContentPluginName);
+        const owner = strapi
+          .plugin(UpdateStaticContentPluginName)
+          .config('owner');
+        const repo = strapi
+          .plugin(UpdateStaticContentPluginName)
+          .config('repo');
+        const workflowId = strapi
+          .plugin(UpdateStaticContentPluginName)
+          .config('workflowId');
+        const branch = strapi
+          .plugin(UpdateStaticContentPluginName)
+          .config('branch');
+        const githubToken = strapi
+          .plugin(UpdateStaticContentPluginName)
+          .config('githubToken');
 
         return await axios.post(
           `https://api.github.com/repos/${owner}/${repo}/actions/workflows/${workflowId}/dispatches`,


### PR DESCRIPTION
Above mentioned error showed up after deployment of multitenancy.

#### List of Changes
<!--- Describe your changes in detail -->
Switched from using `strapi.config.get`, which returned `undefined`, to `strapi.plugin.config` to fetch the Update Static Content plugin configuration.
The issue was present both in prod and dev.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Bug fix.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Triggered actual deployment workflow from local instance of Strapi.

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
