### PR TITLE
[B2BP-571] Move @types/koa depedency from devDependencies to standard dependencies

### DIFF
--- a/.changeset/itchy-adults-begin.md
+++ b/.changeset/itchy-adults-begin.md
@@ -2,4 +2,4 @@
 "strapi-cms": patch
 ---
 
-Moved @types/koa depedency from devDependencies to standard dependecies
+Move @types/koa depedency from devDependencies to standard dependecies

--- a/.changeset/itchy-adults-begin.md
+++ b/.changeset/itchy-adults-begin.md
@@ -1,0 +1,5 @@
+---
+"strapi-cms": patch
+---
+
+Moved @types/koa depedency from devDependencies to standard dependecies

--- a/apps/strapi-cms/package.json
+++ b/apps/strapi-cms/package.json
@@ -17,7 +17,6 @@
     "strapi": "strapi"
   },
   "devDependencies": {
-    "@types/koa": "^2.15.0",
     "eslint": "^8.50.0",
     "eslint-config-custom": "*",
     "shx": "^0.3.4",
@@ -29,6 +28,7 @@
     "@strapi/plugin-users-permissions": "4.13.7",
     "@strapi/provider-upload-aws-s3": "^4.17.0",
     "@strapi/strapi": "4.13.7",
+    "@types/koa": "^2.15.0",
     "axios": "^1.6.8",
     "better-sqlite3": "8.6.0",
     "pg": "^8.11.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -302,6 +302,7 @@
         "@strapi/plugin-users-permissions": "4.13.7",
         "@strapi/provider-upload-aws-s3": "^4.17.0",
         "@strapi/strapi": "4.13.7",
+        "@types/koa": "^2.15.0",
         "axios": "^1.6.8",
         "better-sqlite3": "8.6.0",
         "pg": "^8.11.3",
@@ -309,7 +310,6 @@
         "strapi-plugin-update-static-content": "^1.0.8"
       },
       "devDependencies": {
-        "@types/koa": "^2.15.0",
         "eslint": "^8.50.0",
         "eslint-config-custom": "*",
         "shx": "^0.3.4",
@@ -11104,7 +11104,6 @@
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.7.tgz",
       "integrity": "sha512-Pay9fq2lM2wXPWbteBsRAGiWH2hig4ZE2asK+mm7kUzlxRTfL961rj89I6zV/E3PcIkDqyuBEcMxFT7rccugeQ==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -11224,14 +11223,12 @@
     "node_modules/@types/content-disposition": {
       "version": "0.5.8",
       "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.8.tgz",
-      "integrity": "sha512-QVSSvno3dE0MgO76pJhmv4Qyi/j0Yk9pBp0Y7TJ2Tlj+KCgJWY6qX7nnxCOLkZ3VYRSIk1WTxCvwUSdx6CCLdg==",
-      "dev": true
+      "integrity": "sha512-QVSSvno3dE0MgO76pJhmv4Qyi/j0Yk9pBp0Y7TJ2Tlj+KCgJWY6qX7nnxCOLkZ3VYRSIk1WTxCvwUSdx6CCLdg=="
     },
     "node_modules/@types/cookies": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.9.0.tgz",
       "integrity": "sha512-40Zk8qR147RABiQ7NQnBzWzDcjKzNrntB5BAmeGCb2p/MIyOE+4BVvc17wumsUqUw00bJYqoXFHYygQnEFh4/Q==",
-      "dev": true,
       "dependencies": {
         "@types/connect": "*",
         "@types/express": "*",
@@ -11323,8 +11320,7 @@
     "node_modules/@types/http-assert": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.5.tgz",
-      "integrity": "sha512-4+tE/lwdAahgZT1g30Jkdm9PzFRde0xwxBNUyRsCitRvCQB90iuA2uJYdUnhnANRcqGXaWOGY4FEoxeElNAK2g==",
-      "dev": true
+      "integrity": "sha512-4+tE/lwdAahgZT1g30Jkdm9PzFRde0xwxBNUyRsCitRvCQB90iuA2uJYdUnhnANRcqGXaWOGY4FEoxeElNAK2g=="
     },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.4",
@@ -11402,8 +11398,7 @@
     "node_modules/@types/keygrip": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.6.tgz",
-      "integrity": "sha512-lZuNAY9xeJt7Bx4t4dx0rYCDqGPW8RXhQZK1td7d4H6E9zYbLoOtjBvfwdTKpsyxQI/2jv+armjX/RW+ZNpXOQ==",
-      "dev": true
+      "integrity": "sha512-lZuNAY9xeJt7Bx4t4dx0rYCDqGPW8RXhQZK1td7d4H6E9zYbLoOtjBvfwdTKpsyxQI/2jv+armjX/RW+ZNpXOQ=="
     },
     "node_modules/@types/keyv": {
       "version": "3.1.4",
@@ -11417,7 +11412,6 @@
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.15.0.tgz",
       "integrity": "sha512-7QFsywoE5URbuVnG3loe03QXuGajrnotr3gQkXcEBShORai23MePfFYdhz90FEtBBpkyIYQbVD+evKtloCgX3g==",
-      "dev": true,
       "dependencies": {
         "@types/accepts": "*",
         "@types/content-disposition": "*",
@@ -11433,7 +11427,6 @@
       "version": "3.2.8",
       "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.8.tgz",
       "integrity": "sha512-4Olc63RY+MKvxMwVknCUDhRQX1pFQoBZ/lXcRLP69PQkEpze/0cr8LNqJQe5NFb/b19DWi2a5bTi2VAlQzhJuA==",
-      "dev": true,
       "dependencies": {
         "@types/koa": "*"
       }


### PR DESCRIPTION
After merging PR #262 the error still showed up in production, although it was fixed in a development / local environment.

Turns out this was due to Strapi not being able to build because it couldn't access the `@types/koa` dependency due to it being a devDependency.

This PR fixes that.

#### List of Changes
<!--- Describe your changes in detail -->
Moved `@types/koa` from devDependecies to dependencies.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Bug fix.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested in AWS environment analogous to our production environment.

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
