### PR TITLE
[B2BP-426] Update Strapi API call to populate storeButtons inside navigation

### DIFF
--- a/.changeset/young-beers-happen.md
+++ b/.changeset/young-beers-happen.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Update Strapi API call to populate storeButtons inside navigation

--- a/apps/nextjs-website/src/lib/fetch/__tests__/navigation.test.ts
+++ b/apps/nextjs-website/src/lib/fetch/__tests__/navigation.test.ts
@@ -83,7 +83,7 @@ describe('getNavigation', () => {
     expect(fetchMock).toHaveBeenCalledWith(
       `${config.STRAPI_API_BASE_URL}/api/navigation/render/${
         tenants[config.ENVIRONMENT].navigation
-      }?type=FLAT&populate[seo][populate][0]=metaTitle&populate[sections][populate][0]=ctaButtons&populate[sections][populate][1]=image&populate[sections][populate][2]=background&populate[sections][populate][3]=items.links&populate[sections][populate][4]=link&populate[sections][populate][5]=steps&populate[sections][populate][6]=accordionItems&populate[sections][populate][7]=decoration`,
+      }?type=FLAT&populate[seo][populate][0]=metaTitle&populate[sections][populate][0]=ctaButtons&populate[sections][populate][1]=image&populate[sections][populate][2]=background&populate[sections][populate][3]=items.links&populate[sections][populate][4]=link&populate[sections][populate][5]=steps&populate[sections][populate][6]=accordionItems&populate[sections][populate][7]=decoration&populate[sections][populate][8]=storeButtons`,
       {
         method: 'GET',
         headers: {

--- a/apps/nextjs-website/src/lib/fetch/navigation.ts
+++ b/apps/nextjs-website/src/lib/fetch/navigation.ts
@@ -38,7 +38,7 @@ export const getNavigation = ({
       // All query parameters in the following URL indicate specific fields that would not otherwise be automatically returned by Strapi
       `${config.STRAPI_API_BASE_URL}/api/navigation/render/${
         tenants[config.ENVIRONMENT].navigation
-      }?type=FLAT&populate[seo][populate][0]=metaTitle&populate[sections][populate][0]=ctaButtons&populate[sections][populate][1]=image&populate[sections][populate][2]=background&populate[sections][populate][3]=items.links&populate[sections][populate][4]=link&populate[sections][populate][5]=steps&populate[sections][populate][6]=accordionItems&populate[sections][populate][7]=decoration`,
+      }?type=FLAT&populate[seo][populate][0]=metaTitle&populate[sections][populate][0]=ctaButtons&populate[sections][populate][1]=image&populate[sections][populate][2]=background&populate[sections][populate][3]=items.links&populate[sections][populate][4]=link&populate[sections][populate][5]=steps&populate[sections][populate][6]=accordionItems&populate[sections][populate][7]=decoration&populate[sections][populate][8]=storeButtons`,
       {
         method: 'GET',
         headers: {


### PR DESCRIPTION
Static website build would fail due to an `undefined` value.

That value was `storeButtons` which was not yet indicated as a property to populate, so Strapi simply did not return it.

#### List of Changes
<!--- Describe your changes in detail -->
Added `storeButtons` as a field to be populated when calling Strapi's API.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Bug fix. Static website won't build otherwise.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested locally.

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
