### PR TITLE
[B2BP-560] - Implementing 'PreHeader' EC inside B2BP

### DIFF
--- a/.changeset/proud-bats-flash.md
+++ b/.changeset/proud-bats-flash.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": minor
+---
+
+Migrate PreHeader component from EC to B2BP

--- a/apps/nextjs-website/react-components/components/PreHeader/PreHeader.tsx
+++ b/apps/nextjs-website/react-components/components/PreHeader/PreHeader.tsx
@@ -1,0 +1,48 @@
+import Stack from '@mui/material/Stack/Stack';
+import { PreHeaderProps } from '../../types/PreHeader/PreHeader.types';
+import { CtaButtons } from '../common/Common';
+
+const PreHeader = ({ leftCtas, rightCtas }: PreHeaderProps) => (
+  <Stack
+    display='flex'
+    flexDirection='row'
+    bgcolor='background.paper'
+    paddingY={2}
+    paddingX={{ xs: 2, sm: 4 }}
+    justifyContent='space-between'
+    flexWrap='wrap'
+  >
+    {leftCtas && (
+      <Stack direction='row'>
+        {CtaButtons({
+          ctaButtons: [
+            {
+              ...leftCtas,
+              variant: 'text',
+              disableRipple: true,
+              sx: { width: { md: 'auto', xs: '100%' } },
+            },
+          ],
+          theme: 'light',
+        })}
+      </Stack>
+    )}
+    {rightCtas && (
+      <Stack direction='row-reverse'>
+        {CtaButtons({
+          ctaButtons: [
+            {
+              ...rightCtas,
+              variant: 'text',
+              disableRipple: true,
+              sx: { width: { md: 'auto', xs: '100%' } },
+            },
+          ],
+          theme: 'light',
+        })}
+      </Stack>
+    )}
+  </Stack>
+);
+
+export default PreHeader;

--- a/apps/nextjs-website/react-components/components/index.ts
+++ b/apps/nextjs-website/react-components/components/index.ts
@@ -6,6 +6,7 @@ import BannerLink from './BannerLink/BannerLink';
 import Cards from './Cards/Cards';
 import Footer from './Footer/Footer';
 import EditorialSwitch from './Editorial-Switch/Editorial-Switch';
+import PreHeader from './PreHeader/PreHeader';
 
 export {
   Hero,
@@ -16,4 +17,5 @@ export {
   Cards,
   Footer,
   EditorialSwitch,
+  PreHeader
 };

--- a/apps/nextjs-website/react-components/types/PreHeader/PreHeader.types.ts
+++ b/apps/nextjs-website/react-components/types/PreHeader/PreHeader.types.ts
@@ -1,0 +1,15 @@
+import { CtaButtonProps } from "../common/Common.types";
+
+export type PreHeaderProps =
+  | {
+      rightCtas: CtaButtonProps;
+      leftCtas: CtaButtonProps;
+    }
+  | {
+      rightCtas: CtaButtonProps;
+      leftCtas?: CtaButtonProps;
+    }
+  | {
+      rightCtas?: CtaButtonProps;
+      leftCtas: CtaButtonProps;
+    };

--- a/apps/nextjs-website/react-components/types/common/Common.types.ts
+++ b/apps/nextjs-website/react-components/types/common/Common.types.ts
@@ -22,5 +22,5 @@ export const isJSX = <T>(arg: T | Generic): arg is Generic =>
 
 export interface CtaButtonProps extends Partial<ButtonProps> {
   readonly text: string;
-  variant?: 'contained' | 'outlined';
+  variant?: 'contained' | 'outlined' | 'text';
 }

--- a/apps/nextjs-website/react-components/types/index.ts
+++ b/apps/nextjs-website/react-components/types/index.ts
@@ -6,6 +6,7 @@ import { BannerLinkProps } from './BannerLink/BannerLink.types';
 import { CardsProps } from './Cards/Cards.types';
 import { FooterProps } from './Footer/Footer.types';
 import { EditorialSwitchProps } from './Editorial-Switch/Editorial-Switch.types';
+import { PreHeaderProps } from './PreHeader/PreHeader.types';
 
 export type {
   HeroProps,
@@ -15,5 +16,6 @@ export type {
   BannerLinkProps,
   CardsProps,
   FooterProps,
-  EditorialSwitchProps
+  EditorialSwitchProps,
+  PreHeaderProps
 };

--- a/apps/nextjs-website/src/components/PreHeader.tsx
+++ b/apps/nextjs-website/src/components/PreHeader.tsx
@@ -1,77 +1,34 @@
 'use client';
-import {
-  PreHeader as PreHeaderEC,
-  PreHeaderProps,
-} from '@pagopa/pagopa-editorial-components/dist/components/PreHeader';
-import { Stack } from '@mui/material';
-import { CtaProps } from '@pagopa/pagopa-editorial-components/dist/components/Ctas';
+import { PreHeader as PreHeaderEC } from '@react-components/components';
+import { PreHeaderProps } from '@react-components/types';
 import { PreHeader } from '@/lib/fetch/preHeader';
 import Icon from '@/components/Icon';
-
-const preHeaderNakedButtonStyle = {
-  padding: '0',
-  color: 'text.primary', // Theme-aware property --> equivalent to (theme) => theme.palette.text.primary
-  backgroundColor: 'transparent',
-  '&:hover': {
-    backgroundColor: 'transparent',
-    color: 'text.secondary', // Theme-aware property --> equivalent to (theme) => theme.palette.text.secondary
-  },
-};
+import { CtaButtonProps } from '@react-components/types/common/Common.types';
 
 // Add styles, SEO related values and extra JS parameters for singular components
 // Styling 'naked' variant for PreHeader using 'text' variant as a base
 // (since editorial-components does not accept 'naked' variant)
 const makeCtas = (
-  ctaButtons: PreHeader['data']['attributes']['leftCtas'],
-  side: 'left' | 'right'
-): CtaProps => ({
-  theme: 'light',
-  ctaButtons: ctaButtons.map((ctaBtn) => ({
+  ctaButtons: PreHeader['data']['attributes']['leftCtas']
+): CtaButtonProps[] =>
+  ctaButtons.map((ctaBtn) => ({
     ...ctaBtn,
+    text: ctaBtn.text || '',
     target: '_blank',
     rel: 'noopener noreferrer',
-    disableRipple: ctaBtn.variant === 'naked',
-    disableTouchRipple: ctaBtn.variant === 'naked',
-    sx: {
-      fontWeight: side === 'left' ? 'bold' : '600',
-      letterSpacing: side === 'left' ? '0' : '.3px',
-      ...(ctaBtn.variant === 'naked' && { ...preHeaderNakedButtonStyle }),
-    },
+    variant: 'text',
     ...(ctaBtn.icon && { startIcon: Icon(ctaBtn.icon) }),
-  })),
-});
+  }));
 
 const makePreHeaderProps = (
   props: PreHeader['data']['attributes']
 ): PreHeaderProps => ({
-  leftCtas: makeCtas(props.leftCtas, 'left'),
-  rightCtas: makeCtas(props.rightCtas, 'right'),
+  leftCtas: makeCtas(props.leftCtas),
+  rightCtas: makeCtas(props.rightCtas),
 });
 
 const PreHeader = (preHeaderData: PreHeader['data']['attributes']) => (
-  // Using sx over styled() because, for styled() to work, the component (in this case PreHeaderEC)
-  // needs to take a className parameter and set it to itself (which PreHeaderEC does not)
-  <Stack
-    sx={{
-      borderBottom: 1,
-      borderBottomColor: 'divider', // Theme-aware property --> equivalent to (theme) => theme.palette.divider
-      minHeight: '48px',
-      padding: '0 24px',
-      display: 'flex',
-      flexDirection: 'row',
-      alignItems: 'center',
-      justifyContent: 'center',
-      '> *': {
-        flex: '1',
-        padding: '0 !important',
-        '.MuiStack-root': {
-          alignItems: 'center',
-        },
-      },
-    }}
-  >
-    <PreHeaderEC {...makePreHeaderProps(preHeaderData)} />
-  </Stack>
+  <PreHeaderEC {...makePreHeaderProps(preHeaderData)} />
 );
 
 export default PreHeader;

--- a/apps/nextjs-website/src/lib/fetch/preHeader.ts
+++ b/apps/nextjs-website/src/lib/fetch/preHeader.ts
@@ -11,7 +11,6 @@ const PreHeaderButtonCodec = t.strict({
   icon: t.union([MUIButtonIconCodec, t.null]),
   size: MUIButtonSizeCodec,
   variant: t.keyof({
-    naked: null, // Unique to PreHeader
     text: null,
     outlined: null,
     contained: null,


### PR DESCRIPTION
This PR refers to Option 3 from: [https://pagopa.atlassian.net/wiki/spaces/SV/pages/983531952/SV-021+Implementazione+componenti+EC+all+interno+di+B2BP#Opzione-3%3A-Integrazione-EC-su-B2BP-all%E2%80%99interno-della-cartella-Next.JS](url)

#### List of Changes
- Copied 'PreHeader' component inside the folder apps\nextjs-website\react-components\components\PreHeader
- Refactored 'PreHeader' component for lint and more readability and code comprehension. Splitted in more small files.
- Created two files where all types and mid-blocks are exported instead of taking duplicated files inside each component

#### Motivation and Context
Move away from editorial-components entirely as a dependency to make updates easier and reduce times to fix bugs and integrating new functionalities.

#### How Has This Been Tested?
Tested locally.
The generated HTML equates the old one.

#### Types of changes
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Doesn't need any documentation update.
