### PR TITLE
[B2BP-559] - Implementing 'Header' EC inside B2BP

### DIFF
--- a/.changeset/happy-beans-fry.md
+++ b/.changeset/happy-beans-fry.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": minor
+---
+
+Migrate Header component from EC to B2BP

--- a/apps/nextjs-website/react-components/components/Header/Header.helpers.tsx
+++ b/apps/nextjs-website/react-components/components/Header/Header.helpers.tsx
@@ -1,0 +1,37 @@
+import { Stack, type StackProps, useTheme, type Theme } from '@mui/material';
+import { type ReactNode } from 'react';
+
+interface DialogBubbleProps extends StackProps {
+  children: ReactNode;
+}
+
+const useStyles = (mui: Theme) => ({
+  bubbleContainer: {
+    transform: 'rotate(180deg)',
+    position: 'absolute',
+    marginTop: '42px',
+    padding: mui.spacing(2),
+    direction: 'rtl',
+    textAlign: 'left',
+    borderRadius: '4px',
+  },
+  bubble: { transform: 'rotate(180deg)' },
+});
+
+export const DialogBubble = ({
+  children,
+  ...stackProps
+}: DialogBubbleProps) => {
+  const mui = useTheme();
+  const styles = useStyles(mui);
+  return (
+    <Stack
+      sx={{ ...styles.bubbleContainer, bgcolor: mui.palette.common.white }}
+      aria-haspopup="true"
+    >
+      <Stack sx={styles.bubble} {...stackProps}>
+        {children}
+      </Stack>
+    </Stack>
+  );
+};

--- a/apps/nextjs-website/react-components/components/Header/Header.helpers.tsx
+++ b/apps/nextjs-website/react-components/components/Header/Header.helpers.tsx
@@ -1,9 +1,5 @@
-import { Stack, type StackProps, useTheme, type Theme } from '@mui/material';
-import { type ReactNode } from 'react';
-
-interface DialogBubbleProps extends StackProps {
-  children: ReactNode;
-}
+import { Stack, useTheme, type Theme } from '@mui/material';
+import { DialogBubbleProps } from '../../types/Header/Header.types';
 
 const useStyles = (mui: Theme) => ({
   bubbleContainer: {

--- a/apps/nextjs-website/react-components/components/Header/Header.helpers.tsx
+++ b/apps/nextjs-website/react-components/components/Header/Header.helpers.tsx
@@ -1,12 +1,12 @@
 import { Stack, useTheme, type Theme } from '@mui/material';
 import { DialogBubbleProps } from '../../types/Header/Header.types';
 
-const useStyles = (mui: Theme) => ({
+const useStyles = (muiTheme: Theme) => ({
   bubbleContainer: {
     transform: 'rotate(180deg)',
     position: 'absolute',
     marginTop: '42px',
-    padding: mui.spacing(2),
+    padding: muiTheme.spacing(2),
     direction: 'rtl',
     textAlign: 'left',
     borderRadius: '4px',
@@ -18,11 +18,11 @@ export const DialogBubble = ({
   children,
   ...stackProps
 }: DialogBubbleProps) => {
-  const mui = useTheme();
-  const styles = useStyles(mui);
+  const muiTheme = useTheme();
+  const styles = useStyles(muiTheme);
   return (
     <Stack
-      sx={{ ...styles.bubbleContainer, bgcolor: mui.palette.common.white }}
+      sx={{ ...styles.bubbleContainer, bgcolor: muiTheme.palette.common.white }}
       aria-haspopup="true"
     >
       <Stack sx={styles.bubble} {...stackProps}>

--- a/apps/nextjs-website/react-components/components/Header/Header.tsx
+++ b/apps/nextjs-website/react-components/components/Header/Header.tsx
@@ -1,0 +1,117 @@
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import { useEffect, useState } from 'react';
+import { HamburgerMenu } from './components/HamburgerMenu';
+import { Navigation } from './components/Navigation';
+import { Content } from './components/Title';
+import { HeaderProps } from '@react-components/types/Header/Header.types';
+import { CtaButtons } from '../common/Common';
+import { BackgroundColor } from '../common/Common.helpers';
+
+export const Header = ({
+  product,
+  theme,
+  menu,
+  ctaButtons,
+  avatar,
+  beta,
+}: HeaderProps) => {
+  const [headerOpen, setHeaderOpen] = useState(false);
+
+  const openHeader = () => {
+    setHeaderOpen(true);
+  };
+
+  const closeHeader = () => {
+    setHeaderOpen(false);
+  };
+
+  const onResize = () => {
+    closeHeader();
+  };
+
+  useEffect(() => {
+    window.addEventListener('resize', onResize);
+
+    return () => {
+      window.removeEventListener('resize', onResize);
+    };
+  }, []);
+
+  const backgroundColor = BackgroundColor(theme);
+
+  const HeaderCtas = () => {
+    ctaButtons && ctaButtons.length > 0 && (
+      <Stack direction='row'>
+        {CtaButtons({
+          ctaButtons: ctaButtons.map((CtaButton) => ({
+            ...CtaButton,
+            sx: { width: { md: 'auto', xs: '100%' } },
+          })),
+          theme,
+        })}
+      </Stack>
+    );
+  };
+
+  return (
+    <Box
+      bgcolor={backgroundColor}
+      paddingX={{ xs: 1, sm: 3 }}
+      component='header'
+      role='banner'
+    >
+      <Stack
+        direction={{ md: 'row' }}
+        paddingY={{ xs: 2, sm: 3, md: 0 }}
+        gap={4}
+      >
+        <Stack
+          sx={{
+            flexDirection: 'row',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+          }}
+        >
+          <Content
+            theme={theme}
+            product={product}
+            {...(beta ? { beta } : {})}
+            {...(avatar ? { avatar } : {})}
+          />
+          <Stack
+            sx={{ display: { md: 'none' } }}
+            direction='row'
+            alignItems='center'
+            gap={4}
+          >
+            <Box sx={{ display: { xs: 'none', sm: 'block', md: 'none' } }}>
+              <HeaderCtas />
+            </Box>
+            <HamburgerMenu
+              onOpen={openHeader}
+              onClose={closeHeader}
+              open={headerOpen}
+            />
+          </Stack>
+        </Stack>
+
+        <Stack
+          sx={{
+            justifyContent: 'space-between',
+            width: '100%',
+            flexDirection: { xs: 'column', md: 'row' },
+            alignItems: { md: 'center', xs: 'flex-start' },
+            gap: { xs: 2 },
+            display: { xs: headerOpen ? 'flex' : 'none', md: 'flex' },
+          }}
+        >
+          <Navigation {...{ menu, theme }} />
+          <Box sx={{ display: { sm: 'none', md: 'block' } }}>
+            <HeaderCtas />
+          </Box>
+        </Stack>
+      </Stack>
+    </Box>
+  );
+};

--- a/apps/nextjs-website/react-components/components/Header/Header.tsx
+++ b/apps/nextjs-website/react-components/components/Header/Header.tsx
@@ -3,7 +3,7 @@ import Stack from '@mui/material/Stack';
 import { useEffect, useState } from 'react';
 import { HamburgerMenu } from './components/HamburgerMenu';
 import { Navigation } from './components/Navigation';
-import { Content } from './components/Title';
+import { HeaderTitle } from './components/Title';
 import { HeaderProps } from '@react-components/types/Header/Header.types';
 import { CtaButtons } from '../common/Common';
 import { BackgroundColor } from '../common/Common.helpers';
@@ -17,25 +17,21 @@ const Header = ({
   beta,
   logo,
 }: HeaderProps) => {
-  const [headerOpen, setHeaderOpen] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
 
   const openHeader = () => {
-    setHeaderOpen(true);
+    setMenuOpen(true);
   };
 
   const closeHeader = () => {
-    setHeaderOpen(false);
-  };
-
-  const onResize = () => {
-    closeHeader();
+    setMenuOpen(false);
   };
 
   useEffect(() => {
-    window.addEventListener('resize', onResize);
+    window.addEventListener('resize', closeHeader);
 
     return () => {
-      window.removeEventListener('resize', onResize);
+      window.removeEventListener('resize', closeHeader);
     };
   }, []);
 
@@ -74,7 +70,7 @@ const Header = ({
             alignItems: 'center',
           }}
         >
-          <Content
+          <HeaderTitle
             theme={theme}
             product={product}
             {...(beta ? { beta } : {})}
@@ -95,7 +91,7 @@ const Header = ({
             <HamburgerMenu
               onOpen={openHeader}
               onClose={closeHeader}
-              open={headerOpen}
+              open={menuOpen}
             />
           </Stack>
         </Stack>
@@ -107,7 +103,7 @@ const Header = ({
             flexDirection: { xs: 'column', md: 'row' },
             alignItems: { md: 'center', xs: 'flex-start' },
             gap: { xs: 2 },
-            display: { xs: headerOpen ? 'flex' : 'none', md: 'flex' },
+            display: { xs: menuOpen ? 'flex' : 'none', md: 'flex' },
           }}
         >
           <Navigation {...{ menu, theme }} />

--- a/apps/nextjs-website/react-components/components/Header/Header.tsx
+++ b/apps/nextjs-website/react-components/components/Header/Header.tsx
@@ -8,13 +8,14 @@ import { HeaderProps } from '@react-components/types/Header/Header.types';
 import { CtaButtons } from '../common/Common';
 import { BackgroundColor } from '../common/Common.helpers';
 
-export const Header = ({
+const Header = ({
   product,
   theme,
   menu,
   ctaButtons,
   avatar,
   beta,
+  logo,
 }: HeaderProps) => {
   const [headerOpen, setHeaderOpen] = useState(false);
 
@@ -41,7 +42,7 @@ export const Header = ({
   const backgroundColor = BackgroundColor(theme);
 
   const HeaderCtas = () => {
-    ctaButtons && ctaButtons.length > 0 && (
+    return ctaButtons && ctaButtons.length > 0 ? (
       <Stack direction='row'>
         {CtaButtons({
           ctaButtons: ctaButtons.map((CtaButton) => ({
@@ -51,7 +52,7 @@ export const Header = ({
           theme,
         })}
       </Stack>
-    );
+    ) : null;
   };
 
   return (
@@ -78,7 +79,9 @@ export const Header = ({
             product={product}
             {...(beta ? { beta } : {})}
             {...(avatar ? { avatar } : {})}
+            {...(logo ? { logo } : {})}
           />
+
           <Stack
             sx={{ display: { md: 'none' } }}
             direction='row'
@@ -88,6 +91,7 @@ export const Header = ({
             <Box sx={{ display: { xs: 'none', sm: 'block', md: 'none' } }}>
               <HeaderCtas />
             </Box>
+
             <HamburgerMenu
               onOpen={openHeader}
               onClose={closeHeader}
@@ -107,6 +111,7 @@ export const Header = ({
           }}
         >
           <Navigation {...{ menu, theme }} />
+
           <Box sx={{ display: { sm: 'none', md: 'block' } }}>
             <HeaderCtas />
           </Box>
@@ -115,3 +120,5 @@ export const Header = ({
     </Box>
   );
 };
+
+export default Header;

--- a/apps/nextjs-website/react-components/components/Header/Header.tsx
+++ b/apps/nextjs-website/react-components/components/Header/Header.tsx
@@ -17,6 +17,8 @@ const Header = ({
   beta,
   logo,
 }: HeaderProps) => {
+  const backgroundColor = BackgroundColor(theme);
+
   const [menuOpen, setMenuOpen] = useState(false);
 
   const openHeader = () => {
@@ -34,8 +36,6 @@ const Header = ({
       window.removeEventListener('resize', closeHeader);
     };
   }, []);
-
-  const backgroundColor = BackgroundColor(theme);
 
   const HeaderCtas = () => {
     return ctaButtons && ctaButtons.length > 0 ? (

--- a/apps/nextjs-website/react-components/components/Header/components/HamburgerMenu.tsx
+++ b/apps/nextjs-website/react-components/components/Header/components/HamburgerMenu.tsx
@@ -1,0 +1,29 @@
+import CloseIcon from '@mui/icons-material/Close';
+import MenuIcon from '@mui/icons-material/Menu';
+
+interface HamburgerMenuProps {
+  open: boolean;
+  onOpen: () => void;
+  onClose: () => void;
+}
+
+export const HamburgerMenu = ({ open, onOpen, onClose }: HamburgerMenuProps) =>
+  open ? (
+    <CloseIcon
+      color="primary"
+      cursor="pointer"
+      onClick={onClose}
+      aria-label="chiudi"
+      aria-haspopup="true"
+      aria-expanded="true"
+    />
+  ) : (
+    <MenuIcon
+      color="primary"
+      cursor="pointer"
+      onClick={onOpen}
+      aria-label="apri"
+      aria-haspopup="true"
+      aria-expanded="false"
+    />
+  );

--- a/apps/nextjs-website/react-components/components/Header/components/MenuDropdown.tsx
+++ b/apps/nextjs-website/react-components/components/Header/components/MenuDropdown.tsx
@@ -80,9 +80,9 @@ export const MenuDropdown = (props: MenuDropdownProp) => {
 
   // style
   const hasLinks = items?.length;
-  const mui = useTheme();
-  const md = useMediaQuery(mui.breakpoints.up('md'));
-  const styles = useStyles(props, mui);
+  const muiTheme = useTheme();
+  const md = useMediaQuery(muiTheme.breakpoints.up('md'));
+  const styles = useStyles(props, muiTheme);
 
   const dropdownVisible = menuHover || dropdownHover;
 

--- a/apps/nextjs-website/react-components/components/Header/components/MenuDropdown.tsx
+++ b/apps/nextjs-website/react-components/components/Header/components/MenuDropdown.tsx
@@ -1,0 +1,155 @@
+import {
+  Stack,
+  type StackProps,
+  Typography,
+  useTheme,
+  useMediaQuery,
+  Link,
+  type Theme,
+} from '@mui/material';
+import { useState } from 'react';
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
+import { DialogBubble } from '../Header.helpers';
+import { isJSX } from '../../../types/common/Common.types';
+import { DropdownItem, MenuDropdownProp } from '../../../types/Header/Header.types';
+
+const TIMEOUT_LENGTH = 100;
+
+const useStyles = (props: MenuDropdownProp, mui: Theme) => {
+  const textColor =
+    props.theme === 'dark'
+      ? mui.palette.primary.contrastText
+      : mui.palette.primary.dark;
+
+  return {
+    menu: {
+      paddingY: { md: 2 },
+      borderColor: textColor,
+      borderBottomStyle: 'solid',
+      borderBottomWidth: { md: props.active ? 3 : 0, xs: 0 },
+    },
+    item: {
+      cursor: {
+        md: props.items?.length ? 'default' : 'pointer',
+        xs: 'pointer',
+      },
+      flexDirection: 'row',
+      color: textColor,
+      textDecoration: 'none',
+    },
+    link: {
+      color: { xs: textColor, md: mui.palette.primary.contrastText },
+      textIndent: { xs: mui.spacing(2), md: 0 },
+    },
+    arrowAnimate: {
+      transition: 'transform 0.2s',
+      transform: { xs: 'rotate(-180deg)', md: '' },
+    },
+  };
+};
+
+export const MenuDropdown = (props: MenuDropdownProp) => {
+  // props
+  const { label, active, theme, items, ...button } = props;
+
+  // state
+  const [menuHover, setMenuHover] = useState(false);
+  const [dropdownHover, setDropdownHover] = useState(false);
+
+  const hoverOnMenu = () => {
+    setMenuHover(true);
+  };
+
+  const leavesMenu = () => {
+    setTimeout(() => {
+      setMenuHover(false);
+    }, TIMEOUT_LENGTH);
+  };
+
+  const hoverOnDropdown = () => {
+    setDropdownHover(true);
+  };
+
+  const leavesDropdown = () => {
+    setTimeout(() => {
+      setDropdownHover(false);
+    }, TIMEOUT_LENGTH);
+  };
+
+  const toggleMenu = () => {
+    setMenuHover((status) => !status);
+  };
+
+  // style
+  const hasLinks = items?.length;
+  const mui = useTheme();
+  const md = useMediaQuery(mui.breakpoints.up('md'));
+  const styles = useStyles(props, mui);
+
+  const dropdownVisible = menuHover || dropdownHover;
+
+  const menuEventsHandlers = md
+    ? {
+        onMouseEnter: hoverOnMenu,
+        onMouseLeave: leavesMenu,
+      }
+    : {
+        onClick: toggleMenu,
+      };
+
+  const Dropdown = ({
+    children,
+    ...stackProps
+  }: { children: JSX.Element[] } & StackProps) =>
+    md ? (
+      <DialogBubble
+        {...stackProps}
+        onMouseEnter={hoverOnDropdown}
+        onMouseLeave={leavesDropdown}
+      >
+        {children}
+      </DialogBubble>
+    ) : (
+      <Stack {...stackProps} onClick={toggleMenu}>
+        {children}
+      </Stack>
+    );
+
+  return (
+    <Stack sx={styles.menu} {...menuEventsHandlers}>
+      <Link sx={styles.item} {...button}>
+        <Typography variant="sidenav" color="inherit">
+          {label}
+        </Typography>
+        {hasLinks && (
+          <ArrowDropDownIcon
+            color="inherit"
+            fontSize="small"
+            sx={{
+              ...(!md && dropdownVisible && styles.arrowAnimate),
+            }}
+          />
+        )}
+      </Link>
+      {hasLinks && dropdownVisible && (
+        <Dropdown gap={1}>
+          {items?.map((item: DropdownItem, index) =>
+            isJSX(item) ? (
+              item
+            ) : (
+              <Link
+                variant="body1"
+                underline="none"
+                key={item.key ?? index}
+                sx={styles.link}
+                {...item}
+              >
+                {item.label}
+              </Link>
+            )
+          )}
+        </Dropdown>
+      )}
+    </Stack>
+  );
+};

--- a/apps/nextjs-website/react-components/components/Header/components/MenuDropdown.tsx
+++ b/apps/nextjs-website/react-components/components/Header/components/MenuDropdown.tsx
@@ -8,29 +8,27 @@ import {
   type Theme,
 } from '@mui/material';
 import { useState } from 'react';
-import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
+import { ArrowDropDown } from '@mui/icons-material';
 import { DialogBubble } from '../Header.helpers';
 import { isJSX } from '../../../types/common/Common.types';
 import { DropdownItem, MenuDropdownProp } from '../../../types/Header/Header.types';
+import { TextAlternativeColor } from '@react-components/components/common/Common.helpers';
 
 const TIMEOUT_LENGTH = 100;
 
-const useStyles = (props: MenuDropdownProp, mui: Theme) => {
-  const textColor =
-    props.theme === 'dark'
-      ? mui.palette.primary.contrastText
-      : mui.palette.primary.dark;
+const useStyles = ({ theme, active, items }: MenuDropdownProp, { palette, spacing }: Theme) => {
+  const textColor = TextAlternativeColor(theme);
 
   return {
     menu: {
       paddingY: { md: 2 },
       borderColor: textColor,
       borderBottomStyle: 'solid',
-      borderBottomWidth: { md: props.active ? 3 : 0, xs: 0 },
+      borderBottomWidth: { md: active ? 3 : 0, xs: 0 },
     },
     item: {
       cursor: {
-        md: props.items?.length ? 'default' : 'pointer',
+        md: items?.length ? 'default' : 'pointer',
         xs: 'pointer',
       },
       flexDirection: 'row',
@@ -38,8 +36,8 @@ const useStyles = (props: MenuDropdownProp, mui: Theme) => {
       textDecoration: 'none',
     },
     link: {
-      color: { xs: textColor, md: mui.palette.primary.contrastText },
-      textIndent: { xs: mui.spacing(2), md: 0 },
+      color: { xs: textColor, md: palette.primary.contrastText },
+      textIndent: { xs: spacing(2), md: 0 },
     },
     arrowAnimate: {
       transition: 'transform 0.2s',
@@ -122,7 +120,7 @@ export const MenuDropdown = (props: MenuDropdownProp) => {
           {label}
         </Typography>
         {hasLinks && (
-          <ArrowDropDownIcon
+          <ArrowDropDown
             color="inherit"
             fontSize="small"
             sx={{

--- a/apps/nextjs-website/react-components/components/Header/components/Navigation.tsx
+++ b/apps/nextjs-website/react-components/components/Header/components/Navigation.tsx
@@ -1,0 +1,16 @@
+import { Stack } from '@mui/material';
+import { MenuDropdown } from './MenuDropdown';
+import { NavigationProps } from '../../../types/Header/Header.types';
+
+export const Navigation = ({ menu, theme }: NavigationProps) => (
+  <Stack
+    gap={{ md: 4, xs: 2 }}
+    direction={{ md: 'row', xs: 'column' }}
+    component="nav"
+    aria-label="main"
+  >
+    {menu.map((menu, index) => (
+      <MenuDropdown key={index} {...menu} theme={theme} />
+    ))}
+  </Stack>
+);

--- a/apps/nextjs-website/react-components/components/Header/components/Title.tsx
+++ b/apps/nextjs-website/react-components/components/Header/components/Title.tsx
@@ -8,7 +8,7 @@ import {
 } from '@mui/material';
 import { HeaderTitleProps } from '../../../types/Header/Header.types';
 
-export const Content = ({
+export const HeaderTitle = ({
   avatar,
   beta,
   product: { name: productName, href: productHref },
@@ -22,12 +22,13 @@ export const Content = ({
 
   return (
     <Stack direction="column" alignItems="center" gap={1}>
-      {logo && (
+      {logo ? (
         <Link href={logo.href}>
           <img src={logo.src} alt={logo.alt} height={48} />
         </Link>
-      )}
-      {avatar && <Avatar {...avatar} />}
+      ) : avatar ? (
+        <Avatar {...avatar} />
+      ) : null}
       {!logo && (
         <Typography
           color={textColor}

--- a/apps/nextjs-website/react-components/components/Header/components/Title.tsx
+++ b/apps/nextjs-website/react-components/components/Header/components/Title.tsx
@@ -6,7 +6,7 @@ import {
   useTheme,
   Link,
 } from '@mui/material';
-import { TitleProps } from '../../../types/Header/Header.types';
+import { HeaderTitleProps } from '../../../types/Header/Header.types';
 
 export const Content = ({
   avatar,
@@ -14,7 +14,7 @@ export const Content = ({
   product: { name: productName, href: productHref },
   theme,
   logo,
-}: TitleProps) => {
+}: HeaderTitleProps) => {
   const { palette, spacing } = useTheme();
   const textColor =
     theme === 'dark' ? palette.primary.contrastText : palette.text.primary;

--- a/apps/nextjs-website/react-components/components/Header/components/Title.tsx
+++ b/apps/nextjs-website/react-components/components/Header/components/Title.tsx
@@ -1,0 +1,57 @@
+import {
+  Stack,
+  Avatar,
+  Typography,
+  Chip,
+  useTheme,
+  Link,
+} from '@mui/material';
+import { TitleProps } from '../../../types/Header/Header.types';
+
+export const Content = ({
+  avatar,
+  beta,
+  product: { name: productName, href: productHref },
+  theme,
+  logo,
+}: TitleProps) => {
+  const { palette, spacing } = useTheme();
+  const textColor =
+    theme === 'dark' ? palette.primary.contrastText : palette.text.primary;
+  const label = 'beta';
+
+  return (
+    <Stack direction="column" alignItems="center" gap={1}>
+      {logo && (
+        <Link href={logo.href}>
+          <img src={logo.src} alt={logo.alt} height={48} />
+        </Link>
+      )}
+      {avatar && <Avatar {...avatar} />}
+      {!logo && (
+        <Typography
+          color={textColor}
+          fontSize={{ xs: spacing(3), sm: spacing(3.5) }}
+          noWrap
+          variant="h5"
+        >
+          {productHref ? (
+            <Link href={productHref} underline="none" color="text.primary">
+              <b>{productName}</b>
+            </Link>
+          ) : (
+            <b>{productName}</b>
+          )}
+        </Typography>
+      )}
+      {beta && (
+        <Chip
+          label={label}
+          color="primary"
+          sx={{ height: 20, width: 45 }}
+          size="small"
+        />
+      )}
+    </Stack>
+  );
+};

--- a/apps/nextjs-website/react-components/components/Header/components/Title.tsx
+++ b/apps/nextjs-website/react-components/components/Header/components/Title.tsx
@@ -22,14 +22,14 @@ export const HeaderTitle = ({
 
   return (
     <Stack direction="column" alignItems="center" gap={1}>
-      {logo ? (
+      {logo && (
         <Link href={logo.href}>
           <img src={logo.src} alt={logo.alt} height={48} />
         </Link>
-      ) : avatar ? (
-        <Avatar {...avatar} />
-      ) : null}
+      )}
       {!logo && (
+      <>
+        {avatar && <Avatar {...avatar} />}
         <Typography
           color={textColor}
           fontSize={{ xs: spacing(3), sm: spacing(3.5) }}
@@ -44,6 +44,7 @@ export const HeaderTitle = ({
             <b>{productName}</b>
           )}
         </Typography>
+      </>
       )}
       {beta && (
         <Chip

--- a/apps/nextjs-website/react-components/components/index.ts
+++ b/apps/nextjs-website/react-components/components/index.ts
@@ -8,6 +8,7 @@ import Footer from './Footer/Footer';
 import EditorialSwitch from './Editorial-Switch/Editorial-Switch';
 import PreHeader from './PreHeader/PreHeader';
 import StripeLink from './StripeLink/StripeLink';
+import Header from './Header/Header';
 
 export {
   Hero,
@@ -20,4 +21,5 @@ export {
   EditorialSwitch,
   PreHeader,
   StripeLink,
+  Header,
 };

--- a/apps/nextjs-website/react-components/types/Header/Header.types.ts
+++ b/apps/nextjs-website/react-components/types/Header/Header.types.ts
@@ -1,9 +1,9 @@
 import { AvatarProps, LinkProps } from "@mui/material";
 import { CommonProps, CtaButtonProps, Generic } from "../common/Common.types";
 
-interface BottomHeaderProps extends CtaButtonProps, NavigationProps, TitleProps {}
-
-export interface HeaderProps extends CommonProps, BottomHeaderProps {}
+export interface HeaderProps extends HeaderTitleProps, NavigationProps {
+  ctaButtons: CtaButtonProps[];
+}
 
 interface DropdownLink extends LinkProps {
   label: string;
@@ -23,7 +23,7 @@ export interface NavigationProps extends CommonProps {
   menu: MenuDropdownProp[];
 }
 
-export interface TitleProps extends CommonProps {
+export interface HeaderTitleProps extends CommonProps {
   product: {
     name: string;
     href?: string;

--- a/apps/nextjs-website/react-components/types/Header/Header.types.ts
+++ b/apps/nextjs-website/react-components/types/Header/Header.types.ts
@@ -2,7 +2,7 @@ import { AvatarProps, LinkProps } from "@mui/material";
 import { CommonProps, CtaButtonProps, Generic } from "../common/Common.types";
 
 export interface HeaderProps extends HeaderTitleProps, NavigationProps {
-  ctaButtons: CtaButtonProps[];
+  ctaButtons?: CtaButtonProps[];
 }
 
 interface DropdownLink extends LinkProps {

--- a/apps/nextjs-website/react-components/types/Header/Header.types.ts
+++ b/apps/nextjs-website/react-components/types/Header/Header.types.ts
@@ -1,0 +1,38 @@
+import { AvatarProps, LinkProps } from "@mui/material";
+import { CommonProps, CtaButtonProps, Generic } from "../common/Common.types";
+
+interface BottomHeaderProps extends CtaButtonProps, NavigationProps, TitleProps {}
+
+export interface HeaderProps extends CommonProps, BottomHeaderProps {}
+
+interface DropdownLink extends LinkProps {
+  label: string;
+}
+
+export type DropdownItem = Generic | DropdownLink;
+
+export interface MenuDropdownProp
+  extends Partial<Omit<LinkProps, 'children'>>,
+    CommonProps {
+  label: string;
+  active?: boolean;
+  items?: DropdownItem[];
+}
+
+export interface NavigationProps extends CommonProps {
+  menu: MenuDropdownProp[];
+}
+
+export interface TitleProps extends CommonProps {
+  product: {
+    name: string;
+    href?: string;
+  };
+  avatar?: AvatarProps;
+  beta?: boolean;
+  logo?: {
+    src: string;
+    alt: string;
+    href: string;
+  };
+}

--- a/apps/nextjs-website/react-components/types/Header/Header.types.ts
+++ b/apps/nextjs-website/react-components/types/Header/Header.types.ts
@@ -1,4 +1,5 @@
-import { AvatarProps, LinkProps } from "@mui/material";
+import { ReactNode } from "react";
+import { AvatarProps, LinkProps, StackProps } from "@mui/material";
 import { CommonProps, CtaButtonProps, Generic } from "../common/Common.types";
 
 export interface HeaderProps extends HeaderTitleProps, NavigationProps {
@@ -35,4 +36,8 @@ export interface HeaderTitleProps extends CommonProps {
     alt: string;
     href: string;
   };
+}
+
+export interface DialogBubbleProps extends StackProps {
+  children: ReactNode;
 }

--- a/apps/nextjs-website/react-components/types/index.ts
+++ b/apps/nextjs-website/react-components/types/index.ts
@@ -8,6 +8,7 @@ import { FooterProps } from './Footer/Footer.types';
 import { EditorialSwitchProps } from './Editorial-Switch/Editorial-Switch.types';
 import { PreHeaderProps } from './PreHeader/PreHeader.types';
 import { StripeLinkProps } from './StripeLink/StripeLink.types';
+import { HeaderProps } from './Header/Header.types';
 
 export type {
   HeroProps,
@@ -19,5 +20,6 @@ export type {
   FooterProps,
   EditorialSwitchProps,
   PreHeaderProps,
-  StripeLinkProps
+  StripeLinkProps,
+  HeaderProps,
 };

--- a/apps/nextjs-website/src/components/Header.tsx
+++ b/apps/nextjs-website/src/components/Header.tsx
@@ -1,8 +1,8 @@
 'use client';
-import { Header as HeaderRC } from '@react-components/components';
-import { HeaderProps } from '@react-components/types';
 import { usePathname } from 'next/navigation';
 import Icon from './Icon';
+import { Header as HeaderRC } from '@react-components/components';
+import { HeaderProps } from '@react-components/types';
 import { HeaderWithNavigation } from '@/lib/header';
 
 const makeHeaderProps = (

--- a/apps/nextjs-website/src/components/Header.tsx
+++ b/apps/nextjs-website/src/components/Header.tsx
@@ -1,7 +1,6 @@
 'use client';
-import { Header as HeaderEC } from '@pagopa/pagopa-editorial-components/dist/components/Header';
-import { HeaderProps } from '@pagopa/pagopa-editorial-components/dist/components/Header/Header';
-import { Stack } from '@mui/material';
+import { Header as HeaderRC } from '@react-components/components';
+import { HeaderProps } from '@react-components/types';
 import { usePathname } from 'next/navigation';
 import Icon from './Icon';
 import { HeaderWithNavigation } from '@/lib/header';
@@ -42,44 +41,7 @@ const makeHeaderProps = (
 const Header = (props: HeaderWithNavigation) => {
   const pathname = usePathname();
 
-  return (
-    <Stack
-      sx={{
-        nav: {
-          '.MuiStack-root': {
-            borderColor: 'primary.main',
-            a: {
-              display: 'flex',
-              justifyContent: 'left',
-              '&.MuiTypography-body1': {
-                color: 'text.secondary',
-              },
-            },
-            '.MuiTypography-root': {
-              textDecoration: 'none',
-              fontWeight: 600,
-              fontSize: '1rem',
-            },
-            '& .MuiStack-root': {
-              zIndex: 10,
-              boxShadow: 'custom.boxShadow',
-              '& .MuiStack-root': {
-                boxShadow: 'none',
-              },
-            },
-          },
-        },
-        '.MuiChip-root': {
-          width: 'auto',
-          '.MuiChip-label': {
-            whiteSpace: 'nowrap',
-          },
-        },
-      }}
-    >
-      <HeaderEC {...makeHeaderProps(props, pathname)} />
-    </Stack>
-  );
+  return <HeaderRC {...makeHeaderProps(props, pathname)} />;
 };
 
 export default Header;


### PR DESCRIPTION
This PR refers to Option 3 from: [https://pagopa.atlassian.net/wiki/spaces/SV/pages/983531952/SV-021+Implementazione+componenti+EC+all+interno+di+B2BP#Opzione-3%3A-Integrazione-EC-su-B2BP-all%E2%80%99interno-della-cartella-Next.JS](url)

#### List of Changes
- Copied 'Header' component inside the folder apps\nextjs-website\react-components\components\Header
- Refactored 'Header' component for lint and more readability and code comprehension. Splitted in more small files.
- Created two files where all types and mid-blocks are exported instead of taking duplicated files inside each component

#### Motivation and Context
Move away from editorial-components entirely as a dependency to make updates easier and reduce times to fix bugs and integrating new functionalities.

#### How Has This Been Tested?
Tested locally.
The generated HTML equates the old one.

#### Types of changes
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Doesn't need any documentation update.
