### PR TITLE
[B2BP-559] - Removing EC as dependencies

### DIFF
--- a/.changeset/yellow-teachers-build.md
+++ b/.changeset/yellow-teachers-build.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": minor
+---
+
+Remove EC dependencies from Next.JS

--- a/apps/nextjs-website/package.json
+++ b/apps/nextjs-website/package.json
@@ -16,7 +16,6 @@
     "@mui/icons-material": "^5.14.14",
     "@mui/material": "^5.14.14",
     "@pagopa/mui-italia": "^1.0.1",
-    "@pagopa/pagopa-editorial-components": "^4.0.0",
     "fp-ts": "^2.16.1",
     "html-react-parser": "^5.0.11",
     "io-ts": "^2.2.20",

--- a/apps/nextjs-website/src/lib/header.ts
+++ b/apps/nextjs-website/src/lib/header.ts
@@ -1,7 +1,9 @@
-import { type MenuDropdownProp } from '@pagopa/pagopa-editorial-components/dist/components/Header/components/MenuDropdown';
-import { NavigationProps } from '@pagopa/pagopa-editorial-components/dist/components/Header/components/Navigation';
 import { Header } from './fetch/header';
 import { Navigation } from './fetch/navigation';
+import {
+  MenuDropdownProp,
+  NavigationProps,
+} from '@react-components/types/Header/Header.types';
 
 export type HeaderWithNavigation = Header['data']['attributes'] &
   NavigationProps;

--- a/package-lock.json
+++ b/package-lock.json
@@ -211,7 +211,6 @@
         "@mui/icons-material": "^5.14.14",
         "@mui/material": "^5.14.14",
         "@pagopa/mui-italia": "^1.0.1",
-        "@pagopa/pagopa-editorial-components": "^4.0.0",
         "fp-ts": "^2.16.1",
         "html-react-parser": "^5.0.11",
         "io-ts": "^2.2.20",
@@ -238,63 +237,11 @@
         "vitest": "^0.34.6"
       }
     },
-    "apps/nextjs-website/node_modules/@pagopa/pagopa-editorial-components": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@pagopa/pagopa-editorial-components/-/pagopa-editorial-components-4.0.0.tgz",
-      "integrity": "sha512-CfxHxIjX+4QeY+ksjGtxnw2+CiYmdAF1xXJRMzKaccAZPuhDKqTl9FVSZaOi3Y8fUIxe5r5UfuBcbQvl8SEAPw==",
-      "dependencies": {
-        "@pagopa/mui-italia": "^0.8.12",
-        "@testing-library/jest-dom": "^6.1.4",
-        "react-swipeable-views": "^0.14.0",
-        "react-swipeable-views-utils": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=16.10.0"
-      },
-      "peerDependencies": {
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
-      }
-    },
-    "apps/nextjs-website/node_modules/@pagopa/pagopa-editorial-components/node_modules/@pagopa/mui-italia": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@pagopa/mui-italia/-/mui-italia-0.8.12.tgz",
-      "integrity": "sha512-Qz0fMf5T3GHp/5g0VLyMR3kUtYnXpjtM3H9Hy5Co776Bi9BSiNLEPgP1svupIyW+RX8xpQD5fohyAmCNhP4qRw==",
-      "dependencies": {
-        "@fontsource/dm-mono": "^4.5.10",
-        "@fontsource/titillium-web": "^4.5.9",
-        "clsx": "^1.2.1",
-        "fp-ts": "^2.12.3",
-        "io-ts": "^2.2.18"
-      },
-      "engines": {
-        "node": ">=14.x",
-        "npm": ">=8.x"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.10.4",
-        "@emotion/styled": "^11.10.4",
-        "@mui/icons-material": "^5.10.9",
-        "@mui/lab": "^5.0.0-alpha.100",
-        "@mui/material": "^5.10.9",
-        "@mui/system": "^5.10.8",
-        "react": "^17.0.0",
-        "react-dom": "^17.0.0"
-      }
-    },
     "apps/nextjs-website/node_modules/@types/node": {
       "version": "20.5.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.9.tgz",
       "integrity": "sha512-PcGNd//40kHAS3sTlzKB9C9XL4K0sTup8nbG5lC14kzEteTNuAFh9u5nA0o5TWnSG2r/JNPRXFVcHJIIeRlmqQ==",
       "dev": true
-    },
-    "apps/nextjs-website/node_modules/clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "apps/strapi-cms": {
       "version": "0.2.0",
@@ -340,11 +287,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/@adobe/css-tools": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.3.tgz",
-      "integrity": "sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ=="
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -2735,7 +2677,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
       "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
       },
@@ -2984,47 +2926,6 @@
         "react": "^17.0.0 || ^18.0.0"
       },
       "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/lab": {
-      "version": "5.0.0-alpha.169",
-      "resolved": "https://registry.npmjs.org/@mui/lab/-/lab-5.0.0-alpha.169.tgz",
-      "integrity": "sha512-h6xe1K6ISKUbyxTDgdvql4qoDP6+q8ad5fg9nXQxGLUrIeT2jVrBuT/jRECSTufbnhzP+V5kulvYxaMfM8rEdA==",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@mui/base": "5.0.0-beta.40",
-        "@mui/system": "^5.15.14",
-        "@mui/types": "^7.2.14",
-        "@mui/utils": "^5.15.14",
-        "clsx": "^2.1.0",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.5.0",
-        "@emotion/styled": "^11.3.0",
-        "@mui/material": ">=5.15.0",
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        },
         "@types/react": {
           "optional": true
         }
@@ -4907,7 +4808,7 @@
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
@@ -10998,111 +10899,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@testing-library/jest-dom": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.4.2.tgz",
-      "integrity": "sha512-CzqH0AFymEMG48CpzXFriYYkOjk6ZGPCLMhW9e9jg3KMCn5OfJecF8GtGW7yGfR/IgCe3SX8BSwjdzI6BBbZLw==",
-      "dependencies": {
-        "@adobe/css-tools": "^4.3.2",
-        "@babel/runtime": "^7.9.2",
-        "aria-query": "^5.0.0",
-        "chalk": "^3.0.0",
-        "css.escape": "^1.5.1",
-        "dom-accessibility-api": "^0.6.3",
-        "lodash": "^4.17.15",
-        "redent": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6",
-        "yarn": ">=1"
-      },
-      "peerDependencies": {
-        "@jest/globals": ">= 28",
-        "@types/bun": "latest",
-        "@types/jest": ">= 28",
-        "jest": ">= 28",
-        "vitest": ">= 0.32"
-      },
-      "peerDependenciesMeta": {
-        "@jest/globals": {
-          "optional": true
-        },
-        "@types/bun": {
-          "optional": true
-        },
-        "@types/jest": {
-          "optional": true
-        },
-        "jest": {
-          "optional": true
-        },
-        "vitest": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@testing-library/jest-dom/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@testing-library/jest-dom/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@testing-library/jest-dom/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@testing-library/jest-dom/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/@testing-library/jest-dom/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@testing-library/jest-dom/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@types/accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.7.tgz",
@@ -11195,13 +10991,13 @@
       "version": "4.3.13",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.13.tgz",
       "integrity": "sha512-+LxQEbg4BDUf88utmhpUpTyYn1zHao443aGnXIAQak9ZMt9Rtsic0Oig0OS1xyIqdDXc5uMekoC6NaiUlkT/qA==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/chai-subset": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/chai-subset/-/chai-subset-1.3.5.tgz",
       "integrity": "sha512-c2mPnw+xHtXDoHmdtcCXGwyLMiauiAyxWMzhGpqHC4nqI/Y5G2XhTampslK2rb59kpcuHon03UH8W6iYUzw88A==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/chai": "*"
       }
@@ -12479,6 +12275,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -12717,7 +12514,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -13456,7 +13253,7 @@
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
       "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -13622,7 +13419,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
       "integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.3",
@@ -13717,7 +13514,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
       "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "get-func-name": "^2.0.2"
       },
@@ -14812,11 +14609,6 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
-    "node_modules/css.escape": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
-      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="
-    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -15027,7 +14819,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
       "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "type-detect": "^4.0.0"
       },
@@ -15424,6 +15216,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -15488,7 +15281,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
       "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -15556,11 +15349,6 @@
       "engines": {
         "node": ">=6.0.0"
       }
-    },
-    "node_modules/dom-accessibility-api": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
-      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
@@ -18439,7 +18227,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
       "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -20885,7 +20673,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
       "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/jsonfile": {
       "version": "4.0.0",
@@ -20973,11 +20761,6 @@
         "jwa": "^2.0.0",
         "safe-buffer": "^5.0.1"
       }
-    },
-    "node_modules/keycode": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.1.tgz",
-      "integrity": "sha512-Rdgz9Hl9Iv4QKi8b0OlCRQEzp4AgVxyCtz5S/+VIHezDmrDhkp2N2TqBWOLz0/gbeREXOOiI9/4b8BY9uw2vFg=="
     },
     "node_modules/keygrip": {
       "version": "1.1.0",
@@ -21661,7 +21444,7 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
       "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "get-func-name": "^2.0.1"
       }
@@ -21713,7 +21496,7 @@
       "version": "0.30.8",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.8.tgz",
       "integrity": "sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
       },
@@ -22072,6 +21855,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -22259,7 +22043,7 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.6.1.tgz",
       "integrity": "sha512-vLgaHvaeunuOXHSmEbZ9izxPx3USsk8KCQ8iC+aTlp5sKRSoZvwhHh5L9VbKSaVC6sJDqbyohIS76E2VmHIPAA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "acorn": "^8.11.3",
         "pathe": "^1.1.2",
@@ -23688,13 +23472,13 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
       "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/pathval": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
       "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -23832,7 +23616,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.3.tgz",
       "integrity": "sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "jsonc-parser": "^3.2.0",
         "mlly": "^1.2.0",
@@ -24482,7 +24266,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
       "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
@@ -24496,7 +24280,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -24847,19 +24631,6 @@
         "react": ">=16.13.1"
       }
     },
-    "node_modules/react-event-listener": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.6.6.tgz",
-      "integrity": "sha512-+hCNqfy7o9wvO6UgjqFmBzARJS7qrNoda0VqzvOuioEpoEXKutiKuv92dSz6kP7rYLmyHPyYNLesi5t/aH1gfw==",
-      "dependencies": {
-        "@babel/runtime": "^7.2.0",
-        "prop-types": "^15.6.0",
-        "warning": "^4.0.1"
-      },
-      "peerDependencies": {
-        "react": "^16.3.0"
-      }
-    },
     "node_modules/react-fast-compare": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
@@ -25156,91 +24927,6 @@
         }
       }
     },
-    "node_modules/react-swipeable-views": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/react-swipeable-views/-/react-swipeable-views-0.14.0.tgz",
-      "integrity": "sha512-wrTT6bi2nC3JbmyNAsPXffUXLn0DVT9SbbcFr36gKpbaCgEp7rX/OFxsu5hPc/NBsUhHyoSRGvwqJNNrWTwCww==",
-      "dependencies": {
-        "@babel/runtime": "7.0.0",
-        "prop-types": "^15.5.4",
-        "react-swipeable-views-core": "^0.14.0",
-        "react-swipeable-views-utils": "^0.14.0",
-        "warning": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "peerDependencies": {
-        "react": "^15.3.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/react-swipeable-views-core": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/react-swipeable-views-core/-/react-swipeable-views-core-0.14.0.tgz",
-      "integrity": "sha512-0W/e9uPweNEOSPjmYtuKSC/SvKKg1sfo+WtPdnxeLF3t2L82h7jjszuOHz9C23fzkvLfdgkaOmcbAxE9w2GEjA==",
-      "dependencies": {
-        "@babel/runtime": "7.0.0",
-        "warning": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/react-swipeable-views-core/node_modules/@babel/runtime": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0.tgz",
-      "integrity": "sha512-7hGhzlcmg01CvH1EHdSPVXYX1aJ8KCEyz6I9xYIi/asDtzBPMyMhVibhM/K6g/5qnKBwjZtp10bNZIEFTRW1MA==",
-      "dependencies": {
-        "regenerator-runtime": "^0.12.0"
-      }
-    },
-    "node_modules/react-swipeable-views-core/node_modules/regenerator-runtime": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
-    },
-    "node_modules/react-swipeable-views-utils": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/react-swipeable-views-utils/-/react-swipeable-views-utils-0.14.0.tgz",
-      "integrity": "sha512-W+fXBOsDqgFK1/g7MzRMVcDurp3LqO3ksC8UgInh2P/tKgb5DusuuB1geKHFc6o1wKl+4oyER4Zh3Lxmr8xbXA==",
-      "dependencies": {
-        "@babel/runtime": "7.0.0",
-        "keycode": "^2.1.7",
-        "prop-types": "^15.6.0",
-        "react-event-listener": "^0.6.0",
-        "react-swipeable-views-core": "^0.14.0",
-        "shallow-equal": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/react-swipeable-views-utils/node_modules/@babel/runtime": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0.tgz",
-      "integrity": "sha512-7hGhzlcmg01CvH1EHdSPVXYX1aJ8KCEyz6I9xYIi/asDtzBPMyMhVibhM/K6g/5qnKBwjZtp10bNZIEFTRW1MA==",
-      "dependencies": {
-        "regenerator-runtime": "^0.12.0"
-      }
-    },
-    "node_modules/react-swipeable-views-utils/node_modules/regenerator-runtime": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
-    },
-    "node_modules/react-swipeable-views/node_modules/@babel/runtime": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0.tgz",
-      "integrity": "sha512-7hGhzlcmg01CvH1EHdSPVXYX1aJ8KCEyz6I9xYIi/asDtzBPMyMhVibhM/K6g/5qnKBwjZtp10bNZIEFTRW1MA==",
-      "dependencies": {
-        "regenerator-runtime": "^0.12.0"
-      }
-    },
-    "node_modules/react-swipeable-views/node_modules/regenerator-runtime": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
-    },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
@@ -25380,6 +25066,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
       "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
       "dependencies": {
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
@@ -25910,7 +25597,7 @@
       "version": "4.13.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.13.0.tgz",
       "integrity": "sha512-3YegKemjoQnYKmsBlOHfMLVPPA5xLkQ8MHLLSw/fBrFaVkEayL51DilPpNNLq1exr98F2B1TzrV0FUlN3gWRPg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/estree": "1.0.5"
       },
@@ -26545,11 +26232,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/shallow-equal": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
-      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA=="
-    },
     "node_modules/shallowequal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
@@ -26836,7 +26518,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
@@ -27616,7 +27298,7 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/stackframe": {
       "version": "1.3.4",
@@ -28181,6 +27863,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
       "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
       "dependencies": {
         "min-indent": "^1.0.0"
       },
@@ -28674,7 +28357,7 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.6.0.tgz",
       "integrity": "sha512-N8hW3PG/3aOoZAN5V/NSAEDz0ZixDSSt5b/a05iqtpgfLWMSVuCo7w0k2vVvEjdrIoeGqZzweX2WlyioNIHchA==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/tinypool": {
       "version": "0.8.2",
@@ -28689,7 +28372,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
       "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -29080,7 +28763,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -29206,7 +28889,7 @@
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.3.tgz",
       "integrity": "sha512-Y7HYmWaFwPUmkoQCUIAYpKqkOf+SbVj/2fJJZ4RJMCfZp0rTGwRbzQD+HghfnhKOjL9E01okqz+ncJskGYfBNw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/uglify-js": {
       "version": "3.17.4",
@@ -29748,7 +29431,7 @@
       "version": "0.34.6",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.34.6.tgz",
       "integrity": "sha512-+5CALsOvbNKnS+ZHMXtuUC7nL8/7F1F2DnHGjSsszX8zCjWSSviphCb/NuS9Nzf4Q03KyyDRBAXhF/8lffME4Q==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/chai": "^4.3.5",
         "@types/chai-subset": "^1.3.3",
@@ -29825,7 +29508,7 @@
       "version": "20.11.30",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.30.tgz",
       "integrity": "sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -29834,7 +29517,7 @@
       "version": "0.34.6",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.34.6.tgz",
       "integrity": "sha512-QUzKpUQRc1qC7qdGo7rMK3AkETI7w18gTCUrsNnyjjJKYiuUB9+TQK3QnR1unhCnWRC0AbKv2omLGQDF/mIjOw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@vitest/spy": "0.34.6",
         "@vitest/utils": "0.34.6",
@@ -29848,7 +29531,7 @@
       "version": "0.34.6",
       "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.34.6.tgz",
       "integrity": "sha512-1CUQgtJSLF47NnhN+F9X2ycxUP0kLHQ/JWvNHbeBfwW8CzEGgeskzNnHDyv1ieKTltuR6sdIHV+nmR6kPxQqzQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@vitest/utils": "0.34.6",
         "p-limit": "^4.0.0",
@@ -29862,7 +29545,7 @@
       "version": "0.34.6",
       "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.34.6.tgz",
       "integrity": "sha512-B3OZqYn6k4VaN011D+ve+AA4whM4QkcwcrwaKwAbyyvS/NB1hCWjFIBQxAQQSQir9/RtyAAGuq+4RJmbn2dH4w==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "magic-string": "^0.30.1",
         "pathe": "^1.1.1",
@@ -29876,7 +29559,7 @@
       "version": "0.34.6",
       "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.34.6.tgz",
       "integrity": "sha512-xaCvneSaeBw/cz8ySmF7ZwGvL0lBjfvqc1LpQ/vcdHEvpLn3Ff1vAvjw+CoGn0802l++5L/pxb7whwcWAw+DUQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "tinyspy": "^2.1.1"
       },
@@ -29888,7 +29571,7 @@
       "version": "0.34.6",
       "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.34.6.tgz",
       "integrity": "sha512-IG5aDD8S6zlvloDsnzHw0Ut5xczlF+kv2BOTo+iXfPr54Yhi5qbVOgGB1hZaVq4iJ4C/MZ2J0y15IlsV/ZcI0A==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "diff-sequences": "^29.4.3",
         "loupe": "^2.3.6",
@@ -29902,7 +29585,7 @@
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.4.3.tgz",
       "integrity": "sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=14"
       },
@@ -29914,7 +29597,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
       "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "yocto-queue": "^1.0.0"
       },
@@ -29929,7 +29612,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-1.3.0.tgz",
       "integrity": "sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "acorn": "^8.10.0"
       },
@@ -29941,7 +29624,7 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.7.0.tgz",
       "integrity": "sha512-zSYNUlYSMhJ6Zdou4cJwo/p7w5nmAH17GRfU/ui3ctvjXFErXXkruT4MWW6poDeXgCaIBlGLrfU6TbTXxyGMww==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -29950,7 +29633,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.0.tgz",
       "integrity": "sha512-xMSLJNEjNk/3DJRgWlPADDwaU9AgYRodDH2t6oENhJnIlmU9Hx1Q6VpjyXua/JdMw1WJRbnAgHJ9xgET9gnIAg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "esbuild": "^0.20.1",
         "postcss": "^8.4.36",
@@ -30005,7 +29688,7 @@
       "version": "0.34.6",
       "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.34.6.tgz",
       "integrity": "sha512-nlBMJ9x6n7/Amaz6F3zJ97EBwR2FkzhBRxF5e+jE6LA3yi6Wtc2lyTij1OnDMIr34v5g/tVQtsVAzhT0jc5ygA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "cac": "^6.7.14",
         "debug": "^4.3.4",
@@ -30028,14 +29711,6 @@
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="
-    },
-    "node_modules/warning": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
-      }
     },
     "node_modules/watchpack": {
       "version": "2.4.1",
@@ -30702,7 +30377,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.2.2.tgz",
       "integrity": "sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "siginfo": "^2.0.0",
         "stackback": "0.0.2"
@@ -31117,7 +30792,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
       "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=12.20"
       },


### PR DESCRIPTION
This PR refers to Option 3 from: [https://pagopa.atlassian.net/wiki/spaces/SV/pages/983531952/SV-021+Implementazione+componenti+EC+all+interno+di+B2BP#Opzione-3%3A-Integrazione-EC-su-B2BP-all%E2%80%99interno-della-cartella-Next.JS](url)

#### List of Changes
- Removed @PagoPa/Editorial-Components dependencies from B2BP

#### Motivation and Context
This is the last step to migrate all components used from EC library into B2BP

#### How Has This Been Tested?
Tested locally.
The generated HTML equates the old one.

#### Types of changes
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Doesn't need any documentation update.
