### PR TITLE
[B2BP-625] Make Page's slug not unique

### DIFF
--- a/.changeset/empty-lies-cheat.md
+++ b/.changeset/empty-lies-cheat.md
@@ -1,0 +1,5 @@
+---
+"strapi-cms": patch
+---
+
+Make Page's slug field not unique

--- a/apps/strapi-cms/src/api/page/content-types/page/schema.json
+++ b/apps/strapi-cms/src/api/page/content-types/page/schema.json
@@ -21,7 +21,7 @@
       "type": "string",
       "regex": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
       "required": true,
-      "unique": true
+      "unique": false
     },
     "sections": {
       "type": "dynamiczone",


### PR DESCRIPTION
Strapi's "unique" constraint applies cross-tenant.

This made it so two tenants where unable to both have a page with slug "homepage", which is the special slug used to identify the site's home page and such every tenant should have one.

#### List of Changes
<!--- Describe your changes in detail -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Created pages with the same slug (works as expected)
- Inserted pages with the same slug in different navigations (works as expected)
- Inserted pages with the same slug in the same navigation (the auto-filled URL field blocks this action, as desired)
- Forcibly changed URL field to pass two pages with the same slug to NextJS. The site's build does not break, it instead simply renders the first of the pages with the same slug. This behaviour is acceptable given that any normal user not actively attempting to break the system will be stopped by the Navigation Plugin not allowing them to insert duplicate URLs.

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
