### PR TITLE
[B2BP-612] Fix build error due to implicit storybook types

### DIFF
--- a/apps/nextjs-website/stories/Accordion/dark.stories.tsx
+++ b/apps/nextjs-website/stories/Accordion/dark.stories.tsx
@@ -1,14 +1,16 @@
-import { Meta } from '@storybook/react';
+import { Meta, StoryFn } from '@storybook/react';
 import { Accordion } from '@react-components/components';
 import { defaultPropsDark, AccordionTemplate } from './accordionCommons';
 
 // Define the default export with metadata about your component
-export default {
+const meta: Meta<typeof Accordion> = {
   title: 'Components/Accordion/Dark',
   component: Accordion,
-} as Meta;
+};
+export default meta;
 
-export const AccordionDarkLeftLayoutFull = AccordionTemplate.bind({});
+export const AccordionDarkLeftLayoutFull: StoryFn<typeof Accordion> =
+  AccordionTemplate.bind({});
 AccordionDarkLeftLayoutFull.args = {
   ...defaultPropsDark,
   subtitle: 'Accordion Subtitle',
@@ -16,7 +18,8 @@ AccordionDarkLeftLayoutFull.args = {
   layout: 'left',
 };
 
-export const AccordionDarkCenterLayoutFull = AccordionTemplate.bind({});
+export const AccordionDarkCenterLayoutFull: StoryFn<typeof Accordion> =
+  AccordionTemplate.bind({});
 AccordionDarkCenterLayoutFull.args = {
   ...defaultPropsDark,
   subtitle: 'Accordion Subtitle',
@@ -24,7 +27,8 @@ AccordionDarkCenterLayoutFull.args = {
   layout: 'center',
 };
 
-export const AccordionDarkRightLayoutFull = AccordionTemplate.bind({});
+export const AccordionDarkRightLayoutFull: StoryFn<typeof Accordion> =
+  AccordionTemplate.bind({});
 AccordionDarkRightLayoutFull.args = {
   ...defaultPropsDark,
   subtitle: 'Accordion Subtitle',
@@ -32,60 +36,71 @@ AccordionDarkRightLayoutFull.args = {
   layout: 'right',
 };
 
-export const AccordionDarkLeftLayoutOnlyTitle = AccordionTemplate.bind({});
+export const AccordionDarkLeftLayoutOnlyTitle: StoryFn<typeof Accordion> =
+  AccordionTemplate.bind({});
 AccordionDarkLeftLayoutOnlyTitle.args = {
   ...defaultPropsDark,
   layout: 'left',
 };
 
-export const AccordionDarkCenterLayoutOnlyTitle = AccordionTemplate.bind({});
+export const AccordionDarkCenterLayoutOnlyTitle: StoryFn<typeof Accordion> =
+  AccordionTemplate.bind({});
 AccordionDarkCenterLayoutOnlyTitle.args = {
   ...defaultPropsDark,
   layout: 'center',
 };
 
-export const AccordionDarkRightLayoutOnlyTitle = AccordionTemplate.bind({});
+export const AccordionDarkRightLayoutOnlyTitle: StoryFn<typeof Accordion> =
+  AccordionTemplate.bind({});
 AccordionDarkRightLayoutOnlyTitle.args = {
   ...defaultPropsDark,
   layout: 'right',
 };
 
-export const AccordionDarkLeftLayoutWithSubtitle = AccordionTemplate.bind({});
+export const AccordionDarkLeftLayoutWithSubtitle: StoryFn<typeof Accordion> =
+  AccordionTemplate.bind({});
 AccordionDarkLeftLayoutWithSubtitle.args = {
   ...defaultPropsDark,
   subtitle: 'Accordion Subtitle',
   layout: 'left',
 };
 
-export const AccordionDarkCenterLayoutWithSubtitle = AccordionTemplate.bind({});
+export const AccordionDarkCenterLayoutWithSubtitle: StoryFn<typeof Accordion> =
+  AccordionTemplate.bind({});
 AccordionDarkCenterLayoutWithSubtitle.args = {
   ...defaultPropsDark,
   subtitle: 'Accordion Subtitle',
   layout: 'center',
 };
 
-export const AccordionDarkRightLayoutWithSubtitle = AccordionTemplate.bind({});
+export const AccordionDarkRightLayoutWithSubtitle: StoryFn<typeof Accordion> =
+  AccordionTemplate.bind({});
 AccordionDarkRightLayoutWithSubtitle.args = {
   ...defaultPropsDark,
   subtitle: 'Accordion Subtitle',
   layout: 'right',
 };
 
-export const AccordionDarkLeftLayoutWithDescription = AccordionTemplate.bind({});
+export const AccordionDarkLeftLayoutWithDescription: StoryFn<typeof Accordion> =
+  AccordionTemplate.bind({});
 AccordionDarkLeftLayoutWithDescription.args = {
   ...defaultPropsDark,
   description: 'This is a description for the accordion.',
   layout: 'left',
 };
 
-export const AccordionDarkCenterLayoutWithDescription = AccordionTemplate.bind({});
+export const AccordionDarkCenterLayoutWithDescription: StoryFn<
+  typeof Accordion
+> = AccordionTemplate.bind({});
 AccordionDarkCenterLayoutWithDescription.args = {
   ...defaultPropsDark,
   description: 'This is a description for the accordion.',
   layout: 'center',
 };
 
-export const AccordionDarkRightLayoutWithDescription = AccordionTemplate.bind({});
+export const AccordionDarkRightLayoutWithDescription: StoryFn<
+  typeof Accordion
+> = AccordionTemplate.bind({});
 AccordionDarkRightLayoutWithDescription.args = {
   ...defaultPropsDark,
   description: 'This is a description for the accordion.',

--- a/apps/nextjs-website/stories/Accordion/light.stories.tsx
+++ b/apps/nextjs-website/stories/Accordion/light.stories.tsx
@@ -1,14 +1,16 @@
-import { Meta } from '@storybook/react';
+import { Meta, StoryFn } from '@storybook/react';
 import { Accordion } from '@react-components/components';
 import { defaultPropsLight, AccordionTemplate } from './accordionCommons';
 
 // Define the default export with metadata about your component
-export default {
+const meta: Meta<typeof Accordion> = {
   title: 'Components/Accordion/Light',
   component: Accordion,
-} as Meta;
+};
+export default meta;
 
-export const AccordionLightLeftLayoutFull = AccordionTemplate.bind({});
+export const AccordionLightLeftLayoutFull: StoryFn<typeof Accordion> =
+  AccordionTemplate.bind({});
 AccordionLightLeftLayoutFull.args = {
   ...defaultPropsLight,
   subtitle: 'Accordion Subtitle',
@@ -16,7 +18,8 @@ AccordionLightLeftLayoutFull.args = {
   layout: 'left',
 };
 
-export const AccordionLightCenterLayoutFull = AccordionTemplate.bind({});
+export const AccordionLightCenterLayoutFull: StoryFn<typeof Accordion> =
+  AccordionTemplate.bind({});
 AccordionLightCenterLayoutFull.args = {
   ...defaultPropsLight,
   subtitle: 'Accordion Subtitle',
@@ -24,7 +27,8 @@ AccordionLightCenterLayoutFull.args = {
   layout: 'center',
 };
 
-export const AccordionLightRightLayoutFull = AccordionTemplate.bind({});
+export const AccordionLightRightLayoutFull: StoryFn<typeof Accordion> =
+  AccordionTemplate.bind({});
 AccordionLightRightLayoutFull.args = {
   ...defaultPropsLight,
   subtitle: 'Accordion Subtitle',
@@ -32,60 +36,72 @@ AccordionLightRightLayoutFull.args = {
   layout: 'right',
 };
 
-export const AccordionLightLeftLayoutOnlyTitle = AccordionTemplate.bind({});
+export const AccordionLightLeftLayoutOnlyTitle: StoryFn<typeof Accordion> =
+  AccordionTemplate.bind({});
 AccordionLightLeftLayoutOnlyTitle.args = {
   ...defaultPropsLight,
   layout: 'left',
 };
 
-export const AccordionLightCenterLayoutOnlyTitle = AccordionTemplate.bind({});
+export const AccordionLightCenterLayoutOnlyTitle: StoryFn<typeof Accordion> =
+  AccordionTemplate.bind({});
 AccordionLightCenterLayoutOnlyTitle.args = {
   ...defaultPropsLight,
   layout: 'center',
 };
 
-export const AccordionLightRightLayoutOnlyTitle = AccordionTemplate.bind({});
+export const AccordionLightRightLayoutOnlyTitle: StoryFn<typeof Accordion> =
+  AccordionTemplate.bind({});
 AccordionLightRightLayoutOnlyTitle.args = {
   ...defaultPropsLight,
   layout: 'right',
 };
 
-export const AccordionLightLeftLayoutWithSubtitle = AccordionTemplate.bind({});
+export const AccordionLightLeftLayoutWithSubtitle: StoryFn<typeof Accordion> =
+  AccordionTemplate.bind({});
 AccordionLightLeftLayoutWithSubtitle.args = {
   ...defaultPropsLight,
   subtitle: 'Accordion Subtitle',
   layout: 'left',
 };
 
-export const AccordionLightCenterLayoutWithSubtitle = AccordionTemplate.bind({});
+export const AccordionLightCenterLayoutWithSubtitle: StoryFn<typeof Accordion> =
+  AccordionTemplate.bind({});
 AccordionLightCenterLayoutWithSubtitle.args = {
   ...defaultPropsLight,
   subtitle: 'Accordion Subtitle',
   layout: 'center',
 };
 
-export const AccordionLightRightLayoutWithSubtitle = AccordionTemplate.bind({});
+export const AccordionLightRightLayoutWithSubtitle: StoryFn<typeof Accordion> =
+  AccordionTemplate.bind({});
 AccordionLightRightLayoutWithSubtitle.args = {
   ...defaultPropsLight,
   subtitle: 'Accordion Subtitle',
   layout: 'right',
 };
 
-export const AccordionLightLeftLayoutWithDescription = AccordionTemplate.bind({});
+export const AccordionLightLeftLayoutWithDescription: StoryFn<
+  typeof Accordion
+> = AccordionTemplate.bind({});
 AccordionLightLeftLayoutWithDescription.args = {
   ...defaultPropsLight,
   description: 'This is a description for the accordion.',
   layout: 'left',
 };
 
-export const AccordionLightCenterLayoutWithDescription = AccordionTemplate.bind({});
+export const AccordionLightCenterLayoutWithDescription: StoryFn<
+  typeof Accordion
+> = AccordionTemplate.bind({});
 AccordionLightCenterLayoutWithDescription.args = {
   ...defaultPropsLight,
   description: 'This is a description for the accordion.',
   layout: 'center',
 };
 
-export const AccordionLightRightLayoutWithDescription = AccordionTemplate.bind({});
+export const AccordionLightRightLayoutWithDescription: StoryFn<
+  typeof Accordion
+> = AccordionTemplate.bind({});
 AccordionLightRightLayoutWithDescription.args = {
   ...defaultPropsLight,
   description: 'This is a description for the accordion.',

--- a/apps/nextjs-website/stories/Bannerlink/dark.stories.tsx
+++ b/apps/nextjs-website/stories/Bannerlink/dark.stories.tsx
@@ -1,20 +1,23 @@
-import { Meta } from '@storybook/react';
+import { Meta, StoryFn } from '@storybook/react';
 import { BannerLink } from '@react-components/components';
 import { BannerLinkTemplate, defaultPropsDark } from './bannerlinkCommons';
 
 // Define the default export with metadata about your component
-export default {
+const meta: Meta<typeof BannerLink> = {
   title: 'Components/BannerLink/Dark',
   component: BannerLink,
-} as Meta;
+};
+export default meta;
 
-export const BannerLinkFull = BannerLinkTemplate.bind({});
+export const BannerLinkFull: StoryFn<typeof BannerLink> =
+  BannerLinkTemplate.bind({});
 BannerLinkFull.args = {
   ...defaultPropsDark,
   body: 'This is a description for the banner link.',
 };
 
-export const BannerLinkOnlyTitle = BannerLinkTemplate.bind({});
+export const BannerLinkOnlyTitle: StoryFn<typeof BannerLink> =
+  BannerLinkTemplate.bind({});
 BannerLinkOnlyTitle.args = {
   ...defaultPropsDark,
 };

--- a/apps/nextjs-website/stories/Bannerlink/light.stories.tsx
+++ b/apps/nextjs-website/stories/Bannerlink/light.stories.tsx
@@ -1,20 +1,23 @@
-import { Meta } from '@storybook/react';
+import { Meta, StoryFn } from '@storybook/react';
 import { BannerLink } from '@react-components/components';
 import { BannerLinkTemplate, defaultPropsLight } from './bannerlinkCommons';
 
 // Define the default export with metadata about your component
-export default {
+const meta: Meta<typeof BannerLink> = {
   title: 'Components/BannerLink/Light',
   component: BannerLink,
-} as Meta;
+};
+export default meta;
 
-export const BannerLinkFull = BannerLinkTemplate.bind({});
+export const BannerLinkFull: StoryFn<typeof BannerLink> =
+  BannerLinkTemplate.bind({});
 BannerLinkFull.args = {
   ...defaultPropsLight,
   body: 'This is a description for the banner link.',
 };
 
-export const BannerLinkOnlyTitle = BannerLinkTemplate.bind({});
+export const BannerLinkOnlyTitle: StoryFn<typeof BannerLink> =
+  BannerLinkTemplate.bind({});
 BannerLinkOnlyTitle.args = {
   ...defaultPropsLight,
 };

--- a/apps/nextjs-website/stories/Cards/dark.stories.tsx
+++ b/apps/nextjs-website/stories/Cards/dark.stories.tsx
@@ -1,14 +1,22 @@
-import { Meta } from '@storybook/react';
+import { Meta, StoryFn } from '@storybook/react';
 import { Cards } from '@react-components/components';
-import { CardsTemplate, defaultPropsDarkThree, defaultPropsDarkThreeWithLinks, defaultPropsDarkFour, defaultPropsDarkFourWithLinks } from './cardsCommons';
+import {
+  CardsTemplate,
+  defaultPropsDarkThree,
+  defaultPropsDarkThreeWithLinks,
+  defaultPropsDarkFour,
+  defaultPropsDarkFourWithLinks,
+} from './cardsCommons';
 
 // Define the default export with metadata about your component
-export default {
+const meta: Meta<typeof Cards> = {
   title: 'Components/Cards/Dark',
   component: Cards,
-} as Meta;
+};
+export default meta;
 
-export const DarkCardsThreeColumnOnlyTitleNoLinks = CardsTemplate.bind({});
+export const DarkCardsThreeColumnOnlyTitleNoLinks: StoryFn<typeof Cards> =
+  CardsTemplate.bind({});
 DarkCardsThreeColumnOnlyTitleNoLinks.args = {
   ...defaultPropsDarkThree,
   text: {
@@ -16,7 +24,8 @@ DarkCardsThreeColumnOnlyTitleNoLinks.args = {
   },
 };
 
-export const DarkCardsThreeColumnOnlyTitleWithLinks = CardsTemplate.bind({});
+export const DarkCardsThreeColumnOnlyTitleWithLinks: StoryFn<typeof Cards> =
+  CardsTemplate.bind({});
 DarkCardsThreeColumnOnlyTitleWithLinks.args = {
   ...defaultPropsDarkThreeWithLinks,
   text: {
@@ -24,7 +33,8 @@ DarkCardsThreeColumnOnlyTitleWithLinks.args = {
   },
 };
 
-export const DarkCardsFourColumnOnlyTitleNoLinks = CardsTemplate.bind({});
+export const DarkCardsFourColumnOnlyTitleNoLinks: StoryFn<typeof Cards> =
+  CardsTemplate.bind({});
 DarkCardsFourColumnOnlyTitleNoLinks.args = {
   ...defaultPropsDarkFour,
   text: {
@@ -32,7 +42,8 @@ DarkCardsFourColumnOnlyTitleNoLinks.args = {
   },
 };
 
-export const DarkCardsFourColumnOnlyTitleWithLinks = CardsTemplate.bind({});
+export const DarkCardsFourColumnOnlyTitleWithLinks: StoryFn<typeof Cards> =
+  CardsTemplate.bind({});
 DarkCardsFourColumnOnlyTitleWithLinks.args = {
   ...defaultPropsDarkFourWithLinks,
   text: {
@@ -40,7 +51,8 @@ DarkCardsFourColumnOnlyTitleWithLinks.args = {
   },
 };
 
-export const DarkCardsWithTextNoLinks = CardsTemplate.bind({});
+export const DarkCardsWithTextNoLinks: StoryFn<typeof Cards> =
+  CardsTemplate.bind({});
 DarkCardsWithTextNoLinks.args = {
   ...defaultPropsDarkFour,
   text: {
@@ -50,7 +62,8 @@ DarkCardsWithTextNoLinks.args = {
   },
 };
 
-export const DarkCardsWithTextWithLinks = CardsTemplate.bind({});
+export const DarkCardsWithTextWithLinks: StoryFn<typeof Cards> =
+  CardsTemplate.bind({});
 DarkCardsWithTextWithLinks.args = {
   ...defaultPropsDarkFourWithLinks,
   text: {
@@ -60,7 +73,8 @@ DarkCardsWithTextWithLinks.args = {
   },
 };
 
-export const DarkCardsWithTextandButtonNoLinks = CardsTemplate.bind({});
+export const DarkCardsWithTextandButtonNoLinks: StoryFn<typeof Cards> =
+  CardsTemplate.bind({});
 DarkCardsWithTextandButtonNoLinks.args = {
   ...defaultPropsDarkFour,
   text: {
@@ -76,7 +90,8 @@ DarkCardsWithTextandButtonNoLinks.args = {
   ],
 };
 
-export const DarkCardsWithTextandButtonWithLinks = CardsTemplate.bind({});
+export const DarkCardsWithTextandButtonWithLinks: StoryFn<typeof Cards> =
+  CardsTemplate.bind({});
 DarkCardsWithTextandButtonWithLinks.args = {
   ...defaultPropsDarkFourWithLinks,
   text: {

--- a/apps/nextjs-website/stories/Cards/light.stories.tsx
+++ b/apps/nextjs-website/stories/Cards/light.stories.tsx
@@ -1,14 +1,22 @@
-import { Meta } from '@storybook/react';
+import { Meta, StoryFn } from '@storybook/react';
 import { Cards } from '@react-components/components';
-import { CardsTemplate, defaultPropsLightThree, defaultPropsLightThreeWithLinks, defaultPropsLightFour, defaultPropsLightFourWithLinks } from './cardsCommons';
+import {
+  CardsTemplate,
+  defaultPropsLightThree,
+  defaultPropsLightThreeWithLinks,
+  defaultPropsLightFour,
+  defaultPropsLightFourWithLinks,
+} from './cardsCommons';
 
 // Define the default export with metadata about your component
-export default {
+const meta: Meta<typeof Cards> = {
   title: 'Components/Cards/Light',
   component: Cards,
-} as Meta;
+};
+export default meta;
 
-export const LightCardsThreeColumnOnlyTitleNoLinks = CardsTemplate.bind({});
+export const LightCardsThreeColumnOnlyTitleNoLinks: StoryFn<typeof Cards> =
+  CardsTemplate.bind({});
 LightCardsThreeColumnOnlyTitleNoLinks.args = {
   ...defaultPropsLightThree,
   text: {
@@ -16,7 +24,8 @@ LightCardsThreeColumnOnlyTitleNoLinks.args = {
   },
 };
 
-export const LightCardsThreeColumnOnlyTitleWithLinks = CardsTemplate.bind({});
+export const LightCardsThreeColumnOnlyTitleWithLinks: StoryFn<typeof Cards> =
+  CardsTemplate.bind({});
 LightCardsThreeColumnOnlyTitleWithLinks.args = {
   ...defaultPropsLightThreeWithLinks,
   text: {
@@ -24,7 +33,8 @@ LightCardsThreeColumnOnlyTitleWithLinks.args = {
   },
 };
 
-export const LightCardsFourColumnOnlyTitleNoLinks = CardsTemplate.bind({});
+export const LightCardsFourColumnOnlyTitleNoLinks: StoryFn<typeof Cards> =
+  CardsTemplate.bind({});
 LightCardsFourColumnOnlyTitleNoLinks.args = {
   ...defaultPropsLightFour,
   text: {
@@ -32,7 +42,8 @@ LightCardsFourColumnOnlyTitleNoLinks.args = {
   },
 };
 
-export const LightCardsFourColumnOnlyTitleWithLinks = CardsTemplate.bind({});
+export const LightCardsFourColumnOnlyTitleWithLinks: StoryFn<typeof Cards> =
+  CardsTemplate.bind({});
 LightCardsFourColumnOnlyTitleWithLinks.args = {
   ...defaultPropsLightFourWithLinks,
   text: {
@@ -40,7 +51,8 @@ LightCardsFourColumnOnlyTitleWithLinks.args = {
   },
 };
 
-export const LightCardsWithTextNoLinks = CardsTemplate.bind({});
+export const LightCardsWithTextNoLinks: StoryFn<typeof Cards> =
+  CardsTemplate.bind({});
 LightCardsWithTextNoLinks.args = {
   ...defaultPropsLightFour,
   text: {
@@ -50,7 +62,8 @@ LightCardsWithTextNoLinks.args = {
   },
 };
 
-export const LightCardsWithTextWithLinks = CardsTemplate.bind({});
+export const LightCardsWithTextWithLinks: StoryFn<typeof Cards> =
+  CardsTemplate.bind({});
 LightCardsWithTextWithLinks.args = {
   ...defaultPropsLightFourWithLinks,
   text: {
@@ -60,7 +73,8 @@ LightCardsWithTextWithLinks.args = {
   },
 };
 
-export const LightCardsWithTextandButtonNoLinks = CardsTemplate.bind({});
+export const LightCardsWithTextandButtonNoLinks: StoryFn<typeof Cards> =
+  CardsTemplate.bind({});
 LightCardsWithTextandButtonNoLinks.args = {
   ...defaultPropsLightFour,
   text: {
@@ -76,7 +90,8 @@ LightCardsWithTextandButtonNoLinks.args = {
   ],
 };
 
-export const LightCardsWithTextandButtonWithLinks = CardsTemplate.bind({});
+export const LightCardsWithTextandButtonWithLinks: StoryFn<typeof Cards> =
+  CardsTemplate.bind({});
 LightCardsWithTextandButtonWithLinks.args = {
   ...defaultPropsLightFourWithLinks,
   text: {

--- a/apps/nextjs-website/stories/Editorial/dark.stories.tsx
+++ b/apps/nextjs-website/stories/Editorial/dark.stories.tsx
@@ -1,21 +1,29 @@
-import { Meta } from '@storybook/react';
+import { Meta, StoryFn } from '@storybook/react';
 import { Editorial } from '@react-components/components';
-import { EditorialTemplate, defaultPropsDark, generateCtaButtons } from './editorialCommons';
+import {
+  EditorialTemplate,
+  defaultPropsDark,
+  generateCtaButtons,
+} from './editorialCommons';
 
 // Define the default export with metadata about your component
-export default {
+const meta: Meta<typeof Editorial> = {
   title: 'Components/Editorial/Dark',
   component: Editorial,
-} as Meta;
+};
+export default meta;
 
-export const DarkEditorialFullOneButtonNoPattern = EditorialTemplate.bind({});
+export const DarkEditorialFullOneButtonNoPattern: StoryFn<typeof Editorial> =
+  EditorialTemplate.bind({});
 DarkEditorialFullOneButtonNoPattern.args = {
   ...defaultPropsDark,
   ctaButtons: generateCtaButtons(1),
   eyelet: 'Editorial Eyelet',
 };
 
-export const DarkEditorialFullOneButtonNoPatternReversed = EditorialTemplate.bind({});
+export const DarkEditorialFullOneButtonNoPatternReversed: StoryFn<
+  typeof Editorial
+> = EditorialTemplate.bind({});
 DarkEditorialFullOneButtonNoPatternReversed.args = {
   ...defaultPropsDark,
   ctaButtons: generateCtaButtons(1),
@@ -23,7 +31,8 @@ DarkEditorialFullOneButtonNoPatternReversed.args = {
   reversed: true,
 };
 
-export const DarkEditorialFullOneButtonWithPattern = EditorialTemplate.bind({});
+export const DarkEditorialFullOneButtonWithPattern: StoryFn<typeof Editorial> =
+  EditorialTemplate.bind({});
 DarkEditorialFullOneButtonWithPattern.args = {
   ...defaultPropsDark,
   ctaButtons: generateCtaButtons(1),
@@ -31,7 +40,9 @@ DarkEditorialFullOneButtonWithPattern.args = {
   pattern: 'dots',
 };
 
-export const DarkEditorialFullOneButtonWithPatternReversed = EditorialTemplate.bind({});
+export const DarkEditorialFullOneButtonWithPatternReversed: StoryFn<
+  typeof Editorial
+> = EditorialTemplate.bind({});
 DarkEditorialFullOneButtonWithPatternReversed.args = {
   ...defaultPropsDark,
   ctaButtons: generateCtaButtons(1),
@@ -40,14 +51,16 @@ DarkEditorialFullOneButtonWithPatternReversed.args = {
   pattern: 'dots',
 };
 
-export const DarkEditorialFullTwoButtons = EditorialTemplate.bind({});
+export const DarkEditorialFullTwoButtons: StoryFn<typeof Editorial> =
+  EditorialTemplate.bind({});
 DarkEditorialFullTwoButtons.args = {
   ...defaultPropsDark,
   ctaButtons: generateCtaButtons(2),
   eyelet: 'Editorial Eyelet',
 };
 
-export const DarkEditorialFullTwoButtonsReversed = EditorialTemplate.bind({});
+export const DarkEditorialFullTwoButtonsReversed: StoryFn<typeof Editorial> =
+  EditorialTemplate.bind({});
 DarkEditorialFullTwoButtonsReversed.args = {
   ...defaultPropsDark,
   ctaButtons: generateCtaButtons(2),
@@ -55,33 +68,38 @@ DarkEditorialFullTwoButtonsReversed.args = {
   reversed: true,
 };
 
-export const DarkEditorialFullNoButtons = EditorialTemplate.bind({});
+export const DarkEditorialFullNoButtons: StoryFn<typeof Editorial> =
+  EditorialTemplate.bind({});
 DarkEditorialFullNoButtons.args = {
   ...defaultPropsDark,
   eyelet: 'Editorial Eyelet',
 };
 
-export const DarkEditorialFullReversedNoButtons = EditorialTemplate.bind({});
+export const DarkEditorialFullReversedNoButtons: StoryFn<typeof Editorial> =
+  EditorialTemplate.bind({});
 DarkEditorialFullReversedNoButtons.args = {
   ...defaultPropsDark,
   eyelet: 'Editorial Eyelet',
   reversed: true,
 };
 
-export const DarkEditorialNoEyelet = EditorialTemplate.bind({});
+export const DarkEditorialNoEyelet: StoryFn<typeof Editorial> =
+  EditorialTemplate.bind({});
 DarkEditorialNoEyelet.args = {
   ...defaultPropsDark,
-  ctaButtons: generateCtaButtons(1)
+  ctaButtons: generateCtaButtons(1),
 };
 
-export const DarkEditorialNoEyeletReversed = EditorialTemplate.bind({});
+export const DarkEditorialNoEyeletReversed: StoryFn<typeof Editorial> =
+  EditorialTemplate.bind({});
 DarkEditorialNoEyeletReversed.args = {
   ...defaultPropsDark,
   ctaButtons: generateCtaButtons(1),
   reversed: true,
 };
 
-export const DarkEditorialFullStoreButtons = EditorialTemplate.bind({});
+export const DarkEditorialFullStoreButtons: StoryFn<typeof Editorial> =
+  EditorialTemplate.bind({});
 DarkEditorialFullStoreButtons.args = {
   ...defaultPropsDark,
   ctaButtons: generateCtaButtons(1),
@@ -92,7 +110,8 @@ DarkEditorialFullStoreButtons.args = {
   },
 };
 
-export const DarkEditorialFullStoreButtonsReversed = EditorialTemplate.bind({});
+export const DarkEditorialFullStoreButtonsReversed: StoryFn<typeof Editorial> =
+  EditorialTemplate.bind({});
 DarkEditorialFullStoreButtonsReversed.args = {
   ...defaultPropsDark,
   ctaButtons: generateCtaButtons(1),
@@ -104,23 +123,26 @@ DarkEditorialFullStoreButtonsReversed.args = {
   reversed: true,
 };
 
-export const DarkEditorialFullOneStoreButtons = EditorialTemplate.bind({});
+export const DarkEditorialFullOneStoreButtons: StoryFn<typeof Editorial> =
+  EditorialTemplate.bind({});
 DarkEditorialFullOneStoreButtons.args = {
   ...defaultPropsDark,
   ctaButtons: generateCtaButtons(1),
   eyelet: 'Editorial Eyelet',
   storeButtons: {
-    hrefApple: 'https://apple.com'
+    hrefApple: 'https://apple.com',
   },
 };
 
-export const DarkEditorialFullOneStoreButtonsReversed = EditorialTemplate.bind({});
+export const DarkEditorialFullOneStoreButtonsReversed: StoryFn<
+  typeof Editorial
+> = EditorialTemplate.bind({});
 DarkEditorialFullOneStoreButtonsReversed.args = {
   ...defaultPropsDark,
   ctaButtons: generateCtaButtons(1),
   eyelet: 'Editorial Eyelet',
   storeButtons: {
-    hrefGoogle: 'https://play.google.com'
+    hrefGoogle: 'https://play.google.com',
   },
   reversed: true,
 };

--- a/apps/nextjs-website/stories/Editorial/light.stories.tsx
+++ b/apps/nextjs-website/stories/Editorial/light.stories.tsx
@@ -1,21 +1,29 @@
-import { Meta } from '@storybook/react';
+import { Meta, StoryFn } from '@storybook/react';
 import { Editorial } from '@react-components/components';
-import { EditorialTemplate, defaultPropsLight, generateCtaButtons } from './editorialCommons';
+import {
+  EditorialTemplate,
+  defaultPropsLight,
+  generateCtaButtons,
+} from './editorialCommons';
 
 // Define the default export with metadata about your component
-export default {
+const meta: Meta<typeof Editorial> = {
   title: 'Components/Editorial/Light',
   component: Editorial,
-} as Meta;
+};
+export default meta;
 
-export const LightEditorialFullOneButtonNoPattern = EditorialTemplate.bind({});
+export const LightEditorialFullOneButtonNoPattern: StoryFn<typeof Editorial> =
+  EditorialTemplate.bind({});
 LightEditorialFullOneButtonNoPattern.args = {
   ...defaultPropsLight,
   ctaButtons: generateCtaButtons(1),
   eyelet: 'Editorial Eyelet',
 };
 
-export const LightEditorialFullOneButtonNoPatternReversed = EditorialTemplate.bind({});
+export const LightEditorialFullOneButtonNoPatternReversed: StoryFn<
+  typeof Editorial
+> = EditorialTemplate.bind({});
 LightEditorialFullOneButtonNoPatternReversed.args = {
   ...defaultPropsLight,
   ctaButtons: generateCtaButtons(1),
@@ -23,7 +31,8 @@ LightEditorialFullOneButtonNoPatternReversed.args = {
   reversed: true,
 };
 
-export const LightEditorialFullOneButtonWithPattern = EditorialTemplate.bind({});
+export const LightEditorialFullOneButtonWithPattern: StoryFn<typeof Editorial> =
+  EditorialTemplate.bind({});
 LightEditorialFullOneButtonWithPattern.args = {
   ...defaultPropsLight,
   ctaButtons: generateCtaButtons(1),
@@ -31,7 +40,9 @@ LightEditorialFullOneButtonWithPattern.args = {
   pattern: 'dots',
 };
 
-export const LightEditorialFullOneButtonWithPatternReversed = EditorialTemplate.bind({});
+export const LightEditorialFullOneButtonWithPatternReversed: StoryFn<
+  typeof Editorial
+> = EditorialTemplate.bind({});
 LightEditorialFullOneButtonWithPatternReversed.args = {
   ...defaultPropsLight,
   ctaButtons: generateCtaButtons(1),
@@ -40,14 +51,16 @@ LightEditorialFullOneButtonWithPatternReversed.args = {
   pattern: 'dots',
 };
 
-export const LightEditorialFullTwoButtons = EditorialTemplate.bind({});
+export const LightEditorialFullTwoButtons: StoryFn<typeof Editorial> =
+  EditorialTemplate.bind({});
 LightEditorialFullTwoButtons.args = {
   ...defaultPropsLight,
   ctaButtons: generateCtaButtons(2),
   eyelet: 'Editorial Eyelet',
 };
 
-export const LightEditorialFullTwoButtonsReversed = EditorialTemplate.bind({});
+export const LightEditorialFullTwoButtonsReversed: StoryFn<typeof Editorial> =
+  EditorialTemplate.bind({});
 LightEditorialFullTwoButtonsReversed.args = {
   ...defaultPropsLight,
   ctaButtons: generateCtaButtons(2),
@@ -55,33 +68,38 @@ LightEditorialFullTwoButtonsReversed.args = {
   reversed: true,
 };
 
-export const LightEditorialFullNoButtons = EditorialTemplate.bind({});
+export const LightEditorialFullNoButtons: StoryFn<typeof Editorial> =
+  EditorialTemplate.bind({});
 LightEditorialFullNoButtons.args = {
   ...defaultPropsLight,
   eyelet: 'Editorial Eyelet',
 };
 
-export const LightEditorialFullReversedNoButtons = EditorialTemplate.bind({});
+export const LightEditorialFullReversedNoButtons: StoryFn<typeof Editorial> =
+  EditorialTemplate.bind({});
 LightEditorialFullReversedNoButtons.args = {
   ...defaultPropsLight,
   eyelet: 'Editorial Eyelet',
   reversed: true,
 };
 
-export const LightEditorialNoEyelet = EditorialTemplate.bind({});
+export const LightEditorialNoEyelet: StoryFn<typeof Editorial> =
+  EditorialTemplate.bind({});
 LightEditorialNoEyelet.args = {
   ...defaultPropsLight,
-  ctaButtons: generateCtaButtons(1)
+  ctaButtons: generateCtaButtons(1),
 };
 
-export const LightEditorialNoEyeletReversed = EditorialTemplate.bind({});
+export const LightEditorialNoEyeletReversed: StoryFn<typeof Editorial> =
+  EditorialTemplate.bind({});
 LightEditorialNoEyeletReversed.args = {
   ...defaultPropsLight,
   ctaButtons: generateCtaButtons(1),
   reversed: true,
 };
 
-export const LightEditorialFullStoreButtons = EditorialTemplate.bind({});
+export const LightEditorialFullStoreButtons: StoryFn<typeof Editorial> =
+  EditorialTemplate.bind({});
 LightEditorialFullStoreButtons.args = {
   ...defaultPropsLight,
   ctaButtons: generateCtaButtons(1),
@@ -92,7 +110,8 @@ LightEditorialFullStoreButtons.args = {
   },
 };
 
-export const LightEditorialFullStoreButtonsReversed = EditorialTemplate.bind({});
+export const LightEditorialFullStoreButtonsReversed: StoryFn<typeof Editorial> =
+  EditorialTemplate.bind({});
 LightEditorialFullStoreButtonsReversed.args = {
   ...defaultPropsLight,
   ctaButtons: generateCtaButtons(1),
@@ -104,23 +123,26 @@ LightEditorialFullStoreButtonsReversed.args = {
   reversed: true,
 };
 
-export const LightEditorialFullOneStoreButtons = EditorialTemplate.bind({});
+export const LightEditorialFullOneStoreButtons: StoryFn<typeof Editorial> =
+  EditorialTemplate.bind({});
 LightEditorialFullOneStoreButtons.args = {
   ...defaultPropsLight,
   ctaButtons: generateCtaButtons(1),
   eyelet: 'Editorial Eyelet',
   storeButtons: {
-    hrefApple: 'https://apple.com'
+    hrefApple: 'https://apple.com',
   },
 };
 
-export const LightEditorialFullOneStoreButtonsReversed = EditorialTemplate.bind({});
+export const LightEditorialFullOneStoreButtonsReversed: StoryFn<
+  typeof Editorial
+> = EditorialTemplate.bind({});
 LightEditorialFullOneStoreButtonsReversed.args = {
   ...defaultPropsLight,
   ctaButtons: generateCtaButtons(1),
   eyelet: 'Editorial Eyelet',
   storeButtons: {
-    hrefGoogle: 'https://play.google.com'
+    hrefGoogle: 'https://play.google.com',
   },
   reversed: true,
 };

--- a/apps/nextjs-website/stories/Hero/dark.stories.tsx
+++ b/apps/nextjs-website/stories/Hero/dark.stories.tsx
@@ -1,92 +1,108 @@
 // Import the necessary modules
-import { Meta } from '@storybook/react';
-import { HeroTemplate, defaultsDarkWithButtons, defaultsDarkWithoutButtons } from './heroCommons';
+import { Meta, StoryFn } from '@storybook/react';
+import {
+  HeroTemplate,
+  defaultsDarkWithButtons,
+  defaultsDarkWithoutButtons,
+} from './heroCommons';
 import { Hero } from '@react-components/components';
 
 // Define the default export with metadata about your component
-export default {
+const meta: Meta<typeof Hero> = {
   title: 'Components/Hero/Dark',
   component: Hero,
-} as Meta;
+};
+export default meta;
 
-export const DarkHeroBig = HeroTemplate.bind({});
+export const DarkHeroBig: StoryFn<typeof Hero> = HeroTemplate.bind({});
 DarkHeroBig.args = {
   ...defaultsDarkWithButtons,
   size: 'big',
   inverse: false,
 };
 
-export const DarkHeroBigNoButtons = HeroTemplate.bind({});
+export const DarkHeroBigNoButtons: StoryFn<typeof Hero> = HeroTemplate.bind({});
 DarkHeroBigNoButtons.args = {
   ...defaultsDarkWithoutButtons,
   size: 'big',
   inverse: false,
 };
 
-export const DarkHeroBigInverted = HeroTemplate.bind({});
+export const DarkHeroBigInverted: StoryFn<typeof Hero> = HeroTemplate.bind({});
 DarkHeroBigInverted.args = {
   ...defaultsDarkWithButtons,
   size: 'big',
   inverse: true,
 };
 
-export const DarkHeroBigInvertedNoButtons = HeroTemplate.bind({});
+export const DarkHeroBigInvertedNoButtons: StoryFn<typeof Hero> =
+  HeroTemplate.bind({});
 DarkHeroBigInvertedNoButtons.args = {
   ...defaultsDarkWithoutButtons,
   size: 'big',
   inverse: true,
 };
 
-export const DarkHeroMedium = HeroTemplate.bind({});
+export const DarkHeroMedium: StoryFn<typeof Hero> = HeroTemplate.bind({});
 DarkHeroMedium.args = {
   ...defaultsDarkWithButtons,
   size: 'medium',
   inverse: false,
 };
 
-export const DarkHeroMediumNoButtons = HeroTemplate.bind({});
+export const DarkHeroMediumNoButtons: StoryFn<typeof Hero> = HeroTemplate.bind(
+  {}
+);
 DarkHeroMediumNoButtons.args = {
   ...defaultsDarkWithoutButtons,
   size: 'medium',
   inverse: false,
 };
 
-export const DarkHeroMediumInverted = HeroTemplate.bind({});
+export const DarkHeroMediumInverted: StoryFn<typeof Hero> = HeroTemplate.bind(
+  {}
+);
 DarkHeroMediumInverted.args = {
   ...defaultsDarkWithButtons,
   size: 'medium',
   inverse: true,
 };
 
-export const DarkHeroMediumInvertedNoButtons = HeroTemplate.bind({});
+export const DarkHeroMediumInvertedNoButtons: StoryFn<typeof Hero> =
+  HeroTemplate.bind({});
 DarkHeroMediumInvertedNoButtons.args = {
   ...defaultsDarkWithoutButtons,
   size: 'medium',
   inverse: true,
 };
 
-export const DarkHeroSmall = HeroTemplate.bind({});
+export const DarkHeroSmall: StoryFn<typeof Hero> = HeroTemplate.bind({});
 DarkHeroSmall.args = {
   ...defaultsDarkWithButtons,
   size: 'small',
   inverse: false,
 };
 
-export const DarkHeroSmallNoButtons = HeroTemplate.bind({});
+export const DarkHeroSmallNoButtons: StoryFn<typeof Hero> = HeroTemplate.bind(
+  {}
+);
 DarkHeroSmallNoButtons.args = {
   ...defaultsDarkWithoutButtons,
   size: 'small',
   inverse: false,
 };
 
-export const DarkHeroSmallInverted = HeroTemplate.bind({});
+export const DarkHeroSmallInverted: StoryFn<typeof Hero> = HeroTemplate.bind(
+  {}
+);
 DarkHeroSmallInverted.args = {
   ...defaultsDarkWithButtons,
   size: 'small',
   inverse: true,
 };
 
-export const DarkHeroSmallInvertedNoButtons = HeroTemplate.bind({});
+export const DarkHeroSmallInvertedNoButtons: StoryFn<typeof Hero> =
+  HeroTemplate.bind({});
 DarkHeroSmallInvertedNoButtons.args = {
   ...defaultsDarkWithoutButtons,
   size: 'small',

--- a/apps/nextjs-website/stories/Hero/light.stories.tsx
+++ b/apps/nextjs-website/stories/Hero/light.stories.tsx
@@ -1,92 +1,110 @@
 // Import the necessary modules
-import { Meta } from '@storybook/react';
-import { HeroTemplate, defaultsLightWithButtons, defaultsLightWithoutButtons } from './heroCommons';
+import { Meta, StoryFn } from '@storybook/react';
+import {
+  HeroTemplate,
+  defaultsLightWithButtons,
+  defaultsLightWithoutButtons,
+} from './heroCommons';
 import { Hero } from '@react-components/components';
 
 // Define the default export with metadata about your component
-export default {
+const meta: Meta<typeof Hero> = {
   title: 'Components/Hero/Light',
   component: Hero,
-} as Meta;
+};
+export default meta;
 
-export const LightHeroBig = HeroTemplate.bind({});
+export const LightHeroBig: StoryFn<typeof Hero> = HeroTemplate.bind({});
 LightHeroBig.args = {
   ...defaultsLightWithButtons,
   size: 'big',
   inverse: false,
 };
 
-export const LightHeroBigNoButtons = HeroTemplate.bind({});
+export const LightHeroBigNoButtons: StoryFn<typeof Hero> = HeroTemplate.bind(
+  {}
+);
 LightHeroBigNoButtons.args = {
   ...defaultsLightWithoutButtons,
   size: 'big',
   inverse: false,
 };
 
-export const LightHeroBigInverted = HeroTemplate.bind({});
+export const LightHeroBigInverted: StoryFn<typeof Hero> = HeroTemplate.bind({});
 LightHeroBigInverted.args = {
   ...defaultsLightWithButtons,
   size: 'big',
   inverse: true,
 };
 
-export const LightHeroBigInvertedNoButtons = HeroTemplate.bind({});
+export const LightHeroBigInvertedNoButtons: StoryFn<typeof Hero> =
+  HeroTemplate.bind({});
 LightHeroBigInvertedNoButtons.args = {
   ...defaultsLightWithoutButtons,
   size: 'big',
   inverse: true,
 };
 
-export const LightHeroMedium = HeroTemplate.bind({});
+export const LightHeroMedium: StoryFn<typeof Hero> = HeroTemplate.bind({});
 LightHeroMedium.args = {
   ...defaultsLightWithButtons,
   size: 'medium',
   inverse: false,
 };
 
-export const LightHeroMediumNoButtons = HeroTemplate.bind({});
+export const LightHeroMediumNoButtons: StoryFn<typeof Hero> = HeroTemplate.bind(
+  {}
+);
 LightHeroMediumNoButtons.args = {
   ...defaultsLightWithoutButtons,
   size: 'medium',
   inverse: false,
 };
 
-export const LightHeroMediumInverted = HeroTemplate.bind({});
+export const LightHeroMediumInverted: StoryFn<typeof Hero> = HeroTemplate.bind(
+  {}
+);
 LightHeroMediumInverted.args = {
   ...defaultsLightWithButtons,
   size: 'medium',
   inverse: true,
 };
 
-export const LightHeroMediumInvertedNoButtons = HeroTemplate.bind({});
+export const LightHeroMediumInvertedNoButtons: StoryFn<typeof Hero> =
+  HeroTemplate.bind({});
 LightHeroMediumInvertedNoButtons.args = {
   ...defaultsLightWithoutButtons,
   size: 'medium',
   inverse: true,
 };
 
-export const LightHeroSmall = HeroTemplate.bind({});
+export const LightHeroSmall: StoryFn<typeof Hero> = HeroTemplate.bind({});
 LightHeroSmall.args = {
   ...defaultsLightWithButtons,
   size: 'small',
   inverse: false,
 };
 
-export const LightHeroSmallNoButtons = HeroTemplate.bind({});
+export const LightHeroSmallNoButtons: StoryFn<typeof Hero> = HeroTemplate.bind(
+  {}
+);
 LightHeroSmallNoButtons.args = {
   ...defaultsLightWithoutButtons,
   size: 'small',
   inverse: false,
 };
 
-export const LightHeroSmallInverted = HeroTemplate.bind({});
+export const LightHeroSmallInverted: StoryFn<typeof Hero> = HeroTemplate.bind(
+  {}
+);
 LightHeroSmallInverted.args = {
   ...defaultsLightWithButtons,
   size: 'small',
   inverse: true,
 };
 
-export const LightHeroSmallInvertedNoButtons = HeroTemplate.bind({});
+export const LightHeroSmallInvertedNoButtons: StoryFn<typeof Hero> =
+  HeroTemplate.bind({});
 LightHeroSmallInvertedNoButtons.args = {
   ...defaultsLightWithoutButtons,
   size: 'small',

--- a/apps/nextjs-website/stories/Typography.stories.tsx
+++ b/apps/nextjs-website/stories/Typography.stories.tsx
@@ -1,124 +1,123 @@
 import { StoryFn, Meta } from '@storybook/react';
-import { Typography } from "@mui/material";
+import { Typography } from '@mui/material';
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
-export default {
-  title: "General/Typography",
+const meta: Meta<typeof Typography> = {
+  title: 'General/Typography',
   component: Typography,
   argTypes: {
     variant: {
       options: [
-        "body1",
-        "headline",
-        "h1",
-        "h2",
-        "h3",
-        "h4",
-        "h5",
-        "h6",
-        "overline",
-        "sidenav",
-        "caption",
-        "caption-semibold",
-        "monospaced",
+        'body1',
+        'headline',
+        'h1',
+        'h2',
+        'h3',
+        'h4',
+        'h5',
+        'h6',
+        'overline',
+        'sidenav',
+        'caption',
+        'caption-semibold',
+        'monospaced',
       ],
-      control: { type: "select" },
+      control: { type: 'select' },
     },
   },
-} as Meta<typeof Typography>;
+};
+export default meta;
 
 // More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
-const Template: StoryFn<typeof Typography> = (args) => (
-  <Typography {...args} />
-);
+const Template: StoryFn<typeof Typography> = (args) => <Typography {...args} />;
 
-export const Default = Template.bind({});
+export const Default: StoryFn<typeof Typography> = Template.bind({});
 Default.args = {
-  variant: "body1",
-  children: "Default Typography Component",
+  variant: 'body1',
+  children: 'Default Typography Component',
 };
 
-export const Headline = Template.bind({});
+export const Headline: StoryFn<typeof Typography> = Template.bind({});
 Headline.args = {
-  variant: "headline",
-  children: "Headline",
+  variant: 'headline',
+  children: 'Headline',
 };
 
-export const H1 = Template.bind({});
+export const H1: StoryFn<typeof Typography> = Template.bind({});
 H1.args = {
-  variant: "h1",
-  children: "Heading Title 1",
+  variant: 'h1',
+  children: 'Heading Title 1',
 };
 
-export const H2 = Template.bind({});
+export const H2: StoryFn<typeof Typography> = Template.bind({});
 H2.args = {
-  variant: "h2",
-  children: "Heading Title 2",
+  variant: 'h2',
+  children: 'Heading Title 2',
 };
 
-export const H3 = Template.bind({});
+export const H3: StoryFn<typeof Typography> = Template.bind({});
 H3.args = {
-  variant: "h3",
-  children: "Heading Title 3",
+  variant: 'h3',
+  children: 'Heading Title 3',
 };
 
-export const H4 = Template.bind({});
+export const H4: StoryFn<typeof Typography> = Template.bind({});
 H4.args = {
-  variant: "h4",
-  children: "Heading Title 4",
+  variant: 'h4',
+  children: 'Heading Title 4',
 };
 
-export const H5 = Template.bind({});
+export const H5: StoryFn<typeof Typography> = Template.bind({});
 H5.args = {
-  variant: "h5",
-  children: "Heading Title 5",
+  variant: 'h5',
+  children: 'Heading Title 5',
 };
 
-export const H6 = Template.bind({});
+export const H6: StoryFn<typeof Typography> = Template.bind({});
 H6.args = {
-  variant: "h6",
-  children: "Heading Title 6",
+  variant: 'h6',
+  children: 'Heading Title 6',
 };
 
-export const Overline = Template.bind({});
+export const Overline: StoryFn<typeof Typography> = Template.bind({});
 Overline.args = {
-  variant: "overline",
-  children: "Overline",
+  variant: 'overline',
+  children: 'Overline',
 };
 
-export const Sidenav = Template.bind({});
+export const Sidenav: StoryFn<typeof Typography> = Template.bind({});
 Sidenav.args = {
-  variant: "sidenav",
-  children: "Sidenav",
+  variant: 'sidenav',
+  children: 'Sidenav',
 };
 
-export const Body1 = Template.bind({});
+export const Body1: StoryFn<typeof Typography> = Template.bind({});
 Body1.args = {
-  variant: "body1",
+  variant: 'body1',
   children:
-    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque posuere maximus semper. Etiam mauris magna, commodo sed egestas vel, scelerisque a turpis. Nulla a viverra eros. Nunc suscipit elementum tortor non ornare. Pellentesque vel erat nibh. Sed vulputate facilisis tincidunt. Phasellus euismod nibh ac faucibus faucibus. Suspendisse convallis, libero fermentum dictum commodo, nisi velit euismod sem, quis mollis nisl nibh lobortis nibh. Integer rhoncus tincidunt tellus laoreet scelerisque. Donec sodales nulla vel elit pretium, in dictum neque rhoncus.",
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque posuere maximus semper. Etiam mauris magna, commodo sed egestas vel, scelerisque a turpis. Nulla a viverra eros. Nunc suscipit elementum tortor non ornare. Pellentesque vel erat nibh. Sed vulputate facilisis tincidunt. Phasellus euismod nibh ac faucibus faucibus. Suspendisse convallis, libero fermentum dictum commodo, nisi velit euismod sem, quis mollis nisl nibh lobortis nibh. Integer rhoncus tincidunt tellus laoreet scelerisque. Donec sodales nulla vel elit pretium, in dictum neque rhoncus.',
 };
-export const Body2 = Template.bind({});
+export const Body2: StoryFn<typeof Typography> = Template.bind({});
 Body2.args = {
-  variant: "body2",
+  variant: 'body2',
   children:
-    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque posuere maximus semper. Etiam mauris magna, commodo sed egestas vel, scelerisque a turpis. Nulla a viverra eros. Nunc suscipit elementum tortor non ornare. Pellentesque vel erat nibh. Sed vulputate facilisis tincidunt. Phasellus euismod nibh ac faucibus faucibus. Suspendisse convallis, libero fermentum dictum commodo, nisi velit euismod sem, quis mollis nisl nibh lobortis nibh. Integer rhoncus tincidunt tellus laoreet scelerisque. Donec sodales nulla vel elit pretium, in dictum neque rhoncus.",
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque posuere maximus semper. Etiam mauris magna, commodo sed egestas vel, scelerisque a turpis. Nulla a viverra eros. Nunc suscipit elementum tortor non ornare. Pellentesque vel erat nibh. Sed vulputate facilisis tincidunt. Phasellus euismod nibh ac faucibus faucibus. Suspendisse convallis, libero fermentum dictum commodo, nisi velit euismod sem, quis mollis nisl nibh lobortis nibh. Integer rhoncus tincidunt tellus laoreet scelerisque. Donec sodales nulla vel elit pretium, in dictum neque rhoncus.',
 };
 
-export const Caption = Template.bind({});
+export const Caption: StoryFn<typeof Typography> = Template.bind({});
 Caption.args = {
-  variant: "caption",
-  children: "Caption",
+  variant: 'caption',
+  children: 'Caption',
 };
 
-export const CaptionSemiBold = Template.bind({});
+export const CaptionSemiBold: StoryFn<typeof Typography> = Template.bind({});
 CaptionSemiBold.args = {
-  variant: "caption-semibold",
-  children: "Caption Semibold",
+  variant: 'caption-semibold',
+  children: 'Caption Semibold',
 };
 
-export const Monospaced = Template.bind({});
+export const Monospaced: StoryFn<typeof Typography> = Template.bind({});
 Monospaced.args = {
-  variant: "monospaced",
-  children: "IT 99 C 12345 67890 123456789012",
+  variant: 'monospaced',
+  children: 'IT 99 C 12345 67890 123456789012',
 };


### PR DESCRIPTION
As per title.

Since adding Storybook, NextJS's build failed. This was due to not giving Storybook components explicit types.

#### List of Changes
<!--- Describe your changes in detail -->
All Storybook components have been given explicit types.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Bug fix.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran build locally.

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
