### PR TITLE
[B2BP-451] Add Matomo Analytics

### DIFF
--- a/.changeset/nasty-emus-argue.md
+++ b/.changeset/nasty-emus-argue.md
@@ -1,0 +1,6 @@
+---
+"nextjs-website": patch
+"strapi-cms": patch
+---
+
+Add Matomo Analytics

--- a/apps/nextjs-website/src/app/layout.tsx
+++ b/apps/nextjs-website/src/app/layout.tsx
@@ -4,7 +4,29 @@ import { theme } from './theme';
 import PreHeader from '@/components/PreHeader';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
-import { getPreHeaderProps, getHeaderProps, getFooterProps } from '@/lib/api';
+import {
+  getPreHeaderProps,
+  getHeaderProps,
+  getFooterProps,
+  getSiteWideSEO,
+} from '@/lib/api';
+
+const MatomoScript = (id: string): string => `
+var _paq = (window._paq = window._paq || []);
+/* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+_paq.push(["trackPageView"]);
+_paq.push(["enableLinkTracking"]);
+(function () {
+  var u = "https://pagopa.matomo.cloud/";
+  _paq.push(["setTrackerUrl", u + "matomo.php"]);
+  _paq.push(["setSiteId", "${id}"]);
+  var d = document,
+    g = d.createElement("script"),
+    s = d.getElementsByTagName("script")[0];
+  g.async = true;
+  g.src = "//cdn.matomo.cloud/pagopa.matomo.cloud/matomo.js";
+  s.parentNode.insertBefore(g, s);
+})();`;
 
 export default async function RootLayout({
   children,
@@ -14,6 +36,7 @@ export default async function RootLayout({
   const preHeaderProps = await getPreHeaderProps();
   const headerProps = await getHeaderProps();
   const footerProps = await getFooterProps();
+  const { matomoID } = await getSiteWideSEO();
 
   return (
     <ThemeProvider theme={theme}>
@@ -29,6 +52,14 @@ export default async function RootLayout({
             id='otprivacy-notice-script'
             strategy='beforeInteractive'
           />
+          {matomoID !== null && (
+            <Script
+              id='matomo'
+              key='script-matomo'
+              dangerouslySetInnerHTML={{ __html: MatomoScript(matomoID) }}
+              strategy='lazyOnload'
+            />
+          )}
         </body>
       </html>
     </ThemeProvider>

--- a/apps/nextjs-website/src/lib/fetch/__tests__/siteWideSEO.test.ts
+++ b/apps/nextjs-website/src/lib/fetch/__tests__/siteWideSEO.test.ts
@@ -55,6 +55,7 @@ const siteWideSEOResponse = {
         name: 'SEND-PagoPA - Servizio di Notifiche Digitali',
         shortName: 'SEND-PagoPA',
       },
+      matomoID: '12',
     },
   },
 };

--- a/apps/nextjs-website/src/lib/fetch/siteWideSEO.ts
+++ b/apps/nextjs-website/src/lib/fetch/siteWideSEO.ts
@@ -14,6 +14,7 @@ const SiteWideSEOCodec = t.strict({
         name: t.string,
         shortName: t.string,
       }),
+      matomoID: t.union([t.string, t.null]),
     }),
   }),
 });

--- a/apps/strapi-cms/src/api/appio-general/content-types/appio-general/schema.json
+++ b/apps/strapi-cms/src/api/appio-general/content-types/appio-general/schema.json
@@ -4,7 +4,8 @@
   "info": {
     "singularName": "appio-general",
     "pluralName": "appio-generals",
-    "displayName": "Generale (AppIO)"
+    "displayName": "Generale (AppIO)",
+    "description": ""
   },
   "options": {
     "draftAndPublish": false
@@ -12,34 +13,37 @@
   "pluginOptions": {},
   "attributes": {
     "metaImage": {
-      "allowedTypes": [
-        "images"
-      ],
       "type": "media",
       "multiple": false,
-      "required": true
+      "required": true,
+      "allowedTypes": [
+        "images"
+      ]
     },
     "favicon": {
-      "allowedTypes": [
-        "images"
-      ],
       "type": "media",
       "multiple": false,
-      "required": true
+      "required": true,
+      "allowedTypes": [
+        "images"
+      ]
     },
     "appleTouchIcon": {
-      "allowedTypes": [
-        "images"
-      ],
       "type": "media",
       "multiple": false,
-      "required": true
+      "required": true,
+      "allowedTypes": [
+        "images"
+      ]
     },
     "manifest": {
       "type": "component",
       "repeatable": false,
       "component": "shared.manifest",
       "required": true
+    },
+    "matomoID": {
+      "type": "string"
     }
   }
 }

--- a/apps/strapi-cms/src/api/send-general/content-types/send-general/schema.json
+++ b/apps/strapi-cms/src/api/send-general/content-types/send-general/schema.json
@@ -41,6 +41,9 @@
       "repeatable": false,
       "component": "shared.manifest",
       "required": true
+    },
+    "matomoID": {
+      "type": "string"
     }
   }
 }


### PR DESCRIPTION
As per title.

This PR adds the capability to optionally setup Matomo Analytics.

It currently only allows to set the site's ID used for tracking.
Any other additional configurations needed will be implemented with new PRs when requested.

#### List of Changes
<!--- Describe your changes in detail -->
- Add `matomoID` field to Strapi's General Single Type (for all tenants)
- Implement Matomo Analytics Script in NextJS

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
As described in task [B2BP-451](https://pagopa.atlassian.net/browse/B2BP-451?atlOrigin=eyJpIjoiN2NlMjQwYzZlMWI5NGIzZTgxZjllYTY0NDRiZjEyNzciLCJwIjoiaiJ9)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Locally tested the correct creation of the script.
Some production testing to make sure Matomo correctly gathers data is recommended.

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.


[B2BP-451]: https://pagopa.atlassian.net/browse/B2BP-451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ