### PR TITLE
[B2BP-698] Re-enabled Preview Button inside Strapi

### DIFF
--- a/.changeset/purple-scissors-give.md
+++ b/.changeset/purple-scissors-give.md
@@ -1,0 +1,5 @@
+---
+"strapi-cms": patch
+---
+
+Re-enabled Preview Button inside Strapi

--- a/apps/strapi-cms/config/plugins.ts
+++ b/apps/strapi-cms/config/plugins.ts
@@ -43,7 +43,7 @@ export default ({ env }: any) => ({
     },
   },
   'preview-button': {
-    enabled: false,
+    enabled: true,
     config: {
       contentTypes: [
         {
@@ -53,6 +53,7 @@ export default ({ env }: any) => ({
             query: {
               pageID: '{id}',
               secret: env('PREVIEW_TOKEN'),
+              tenant: env('ENVIRONMENT'),
             },
             openTarget: '_blank',
             copy: false,


### PR DESCRIPTION
As per title.

#### List of Changes
<!--- Describe your changes in detail -->
- Added `tenant` query parameter (needed for new architecture)
- Enabled Preview Button plugin

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Make Previews available again in new architecture.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested locally, also linking to online NextJS Preview Mode instance.

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
