### PR TITLE
[B2BP-780] - Avoid showing medialibrary objects list

### DIFF
--- a/.changeset/quick-singers-draw.md
+++ b/.changeset/quick-singers-draw.md
@@ -1,0 +1,5 @@
+---
+"infrastructure": minor
+---
+
+[B2BP-780] Avoid list of medialibrary objects to be served on medialibrary root url

--- a/apps/infrastructure/src/iam_policy.tf
+++ b/apps/infrastructure/src/iam_policy.tf
@@ -35,7 +35,7 @@ data "aws_iam_policy_document" "cms_multitenant_iam_policy" {
     key => config
   }
   statement {
-    actions = ["s3:GetObject"]
+    actions   = ["s3:GetObject"]
     resources = ["${aws_s3_bucket.cms_multitenant_medialibrary_bucket[each.key].arn}/*"]
 
     principals {

--- a/apps/infrastructure/src/iam_policy.tf
+++ b/apps/infrastructure/src/iam_policy.tf
@@ -35,10 +35,8 @@ data "aws_iam_policy_document" "cms_multitenant_iam_policy" {
     key => config
   }
   statement {
-    actions = ["s3:GetObject", "s3:ListBucket"]
-    resources = [aws_s3_bucket.cms_multitenant_medialibrary_bucket[each.key].arn,
-      "${aws_s3_bucket.cms_multitenant_medialibrary_bucket[each.key].arn}/*"
-    ]
+    actions = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.cms_multitenant_medialibrary_bucket[each.key].arn}/*"]
 
     principals {
       type        = "AWS"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
- Removed s3:ListBucket permission in bucket policies

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently, the list of objects contained in the medialibrary is publicly visible when reaching any of the medialibraries' cloudfront distributions

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
