### PR TITLE
[B2BP-802] Update BannerLink to add multiple sections

### DIFF
--- a/.changeset/smooth-clouds-help.md
+++ b/.changeset/smooth-clouds-help.md
@@ -1,0 +1,5 @@
+---
+"strapi-cms": patch
+---
+
+Update BannerLink to reflect changes made NextJS-side

--- a/.changeset/tidy-pens-smile.md
+++ b/.changeset/tidy-pens-smile.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Condense BannerLink body text into one field

--- a/apps/nextjs-website/react-components/components/BannerLink/Content.tsx
+++ b/apps/nextjs-website/react-components/components/BannerLink/Content.tsx
@@ -4,7 +4,7 @@ import { Title, Body } from '../common/Common';
 import { TextColor } from '../common/Common.helpers';
 import { useTheme } from '@mui/material/styles';
 
-export const Content = ({ title, normalText, boldText, extraNormalText, link, theme }: BannerLinkSectionProps & { theme: 'light' | 'dark' }) => {
+export const Content = ({ title, body, theme }: BannerLinkSectionProps & { theme: 'light' | 'dark' }) => {
   const { spacing } = useTheme();
   const { palette } = useTheme();
   const textColor = theme === 'dark' ? palette.primary.contrastText : TextColor(theme);
@@ -12,15 +12,12 @@ export const Content = ({ title, normalText, boldText, extraNormalText, link, th
   return (
     <Stack textAlign='center' gap={spacing(2)} alignItems='center'>
       <Title variant='h4' textColor={textColor} title={title} />
-      <Body variant='body2' textColor={textColor} body={
-        <>
-          <span style={{ color: textColor }}>{normalText}</span>{' '}
-          <a href={link} style={{ fontWeight: 'bold', textDecoration: 'none', color: textColor }}>
-            {boldText}
-          </a>
-          {extraNormalText && <span style={{ color: textColor }}> {extraNormalText}</span>}
-        </>
-      } />
+      <Body
+        variant='body2'
+        textColor={textColor}
+        body={body}
+        textAlign='center'
+      />
     </Stack>
   );
 };

--- a/apps/nextjs-website/react-components/types/BannerLink/BannerLink.types.ts
+++ b/apps/nextjs-website/react-components/types/BannerLink/BannerLink.types.ts
@@ -8,10 +8,7 @@ export type ImgProps = React.DetailedHTMLProps<
 
 export interface BannerLinkSectionProps {
   title: string;
-  normalText: string;
-  boldText: string;
-  link: string;
-  extraNormalText?: string;
+  body: JSX.Element;
   icon?: EIconProps;
   decoration?: ImgProps;
   ctaButtons?: CtaButtonProps[];

--- a/apps/nextjs-website/src/components/BannerLink.tsx
+++ b/apps/nextjs-website/src/components/BannerLink.tsx
@@ -1,4 +1,5 @@
 'use client';
+import MarkdownRenderer from './MarkdownRenderer';
 import { BannerLink as BannerLinkRC } from '@react-components/components';
 import { BannerLinkProps } from '@react-components/types/BannerLink/BannerLink.types';
 import { BannerLinkSection } from '@/lib/fetch/types/PageSection';
@@ -8,9 +9,9 @@ const makeBannerLinkProps = ({
   theme,
 }: BannerLinkSection): BannerLinkProps => ({
   sections: sections.map(
-    ({ extraNormalText, icon, decoration, ctaButtons, ...requiredFields }) => ({
+    ({ body, icon, decoration, ctaButtons, ...requiredFields }) => ({
       ...requiredFields,
-      ...(extraNormalText && { extraNormalText }),
+      body: MarkdownRenderer({ markdown: body, variant: 'body2' }),
       ...(icon && {
         icon: {
           icon,

--- a/apps/nextjs-website/src/lib/fetch/__tests__/navigation.test.ts
+++ b/apps/nextjs-website/src/lib/fetch/__tests__/navigation.test.ts
@@ -64,7 +64,7 @@ describe('getNavigation', () => {
     await getNavigation(appEnv);
 
     expect(fetchMock).toHaveBeenCalledWith(
-      `${config.DEMO_STRAPI_API_BASE_URL}/api/pages?pagination[pageSize]=100&populate[seo][populate][0]=metaTitle&populate[sections][populate][0]=ctaButtons&populate[sections][populate][1]=image&populate[sections][populate][2]=background&populate[sections][populate][3]=items.links&populate[sections][populate][4]=link&populate[sections][populate][5]=steps&populate[sections][populate][6]=accordionItems&populate[sections][populate][7]=decoration&populate[sections][populate][8]=storeButtons`,
+      `${config.DEMO_STRAPI_API_BASE_URL}/api/pages?pagination[pageSize]=100&populate[seo][populate][0]=metaTitle&populate[sections][populate][0]=ctaButtons&populate[sections][populate][1]=image&populate[sections][populate][2]=background&populate[sections][populate][3]=items.links&populate[sections][populate][4]=link&populate[sections][populate][5]=steps&populate[sections][populate][6]=accordionItems&populate[sections][populate][7]=decoration&populate[sections][populate][8]=storeButtons&populate[sections][populate][9]=sections.decoration&populate[sections][populate][10]=sections.ctaButtons`,
       {
         method: 'GET',
         headers: {

--- a/apps/nextjs-website/src/lib/fetch/navigation.ts
+++ b/apps/nextjs-website/src/lib/fetch/navigation.ts
@@ -35,7 +35,7 @@ export const getNavigation = ({
       // The pagination[pageSize] parameter has been set to 100 to realistically not have the need to fetch multiple pages
       `${
         extractTenantStrapiApiData(config).baseUrl
-      }/api/pages?pagination[pageSize]=100&populate[seo][populate][0]=metaTitle&populate[sections][populate][0]=ctaButtons&populate[sections][populate][1]=image&populate[sections][populate][2]=background&populate[sections][populate][3]=items.links&populate[sections][populate][4]=link&populate[sections][populate][5]=steps&populate[sections][populate][6]=accordionItems&populate[sections][populate][7]=decoration&populate[sections][populate][8]=storeButtons`,
+      }/api/pages?pagination[pageSize]=100&populate[seo][populate][0]=metaTitle&populate[sections][populate][0]=ctaButtons&populate[sections][populate][1]=image&populate[sections][populate][2]=background&populate[sections][populate][3]=items.links&populate[sections][populate][4]=link&populate[sections][populate][5]=steps&populate[sections][populate][6]=accordionItems&populate[sections][populate][7]=decoration&populate[sections][populate][8]=storeButtons&populate[sections][populate][9]=sections.decoration&populate[sections][populate][10]=sections.ctaButtons`,
       {
         method: 'GET',
         headers: {

--- a/apps/nextjs-website/src/lib/fetch/types/PageSection.ts
+++ b/apps/nextjs-website/src/lib/fetch/types/PageSection.ts
@@ -110,23 +110,16 @@ const HowToSectionCodec = t.strict({
 
 const BannerLinkSectionCodec = t.strict({
   __component: t.literal('sections.banner-link'),
-  title: t.string,
   theme: t.union([t.literal('light'), t.literal('dark')]),
   sections: t.array(
     t.strict({
       title: t.string,
-      normalText: t.string,
-      boldText: t.string,
-      extraNormalText: t.union([t.string, t.null]),
-      link: t.string,
+      body: t.string,
       ctaButtons: t.array(CTAButtonSimpleCodec),
       decoration: StrapiImageSchema,
       icon: t.union([FeatureItemMUIIconCodec, t.null]),
     })
   ),
-  ctaButtons: t.array(CTAButtonSimpleCodec),
-  decoration: StrapiImageSchema,
-  sectionID: t.union([t.string, t.null]),
 });
 
 const StripeLinkSectionCodec = t.strict({

--- a/apps/nextjs-website/stories/Bannerlink/bannerlinkCommons.tsx
+++ b/apps/nextjs-website/stories/Bannerlink/bannerlinkCommons.tsx
@@ -10,10 +10,7 @@ const generateDefaultProps = (theme: 'light' | 'dark'): Partial<BannerLinkProps>
   sections: [
     {
       title: 'Scrivici',
-      normalText: 'Richiedi assistenza via email scrivendo a',
-      boldText: 'destinatari-send@assistenza.pagopa.it',
-      extraNormalText: ': includi informazioni utili come il codice univoco della notifica (IUN).',
-      link: 'mailto:destinatari-send@assistenza.pagopa.it',
+      body: <p>Richiedi assistenza via email scrivendo a <a href='#'>destinatari-send@assistenza.pagopa.it</a>: includi informazioni utili come il codice univoco della notifica (IUN)</p>,
       icon: <MailIcon style={{ fontSize: 60 }} />,
       ctaButtons: [
         {
@@ -34,10 +31,7 @@ const generateTwoColumnProps = (theme: 'light' | 'dark'): Partial<BannerLinkProp
   sections: [
     {
       title: 'Scrivici',
-      normalText: 'Richiedi assistenza via email scrivendo a',
-      boldText: 'destinatari-send@assistenza.pagopa.it',
-      extraNormalText: ': includi informazioni utili come il codice univoco della notifica (IUN).',
-      link: 'mailto:destinatari-send@assistenza.pagopa.it',
+      body: <p>Richiedi assistenza via email scrivendo a <a href='#'>destinatari-send@assistenza.pagopa.it</a>: includi informazioni utili come il codice univoco della notifica (IUN)</p>,
       icon: <MailIcon style={{ fontSize: 60 }} />,
       ctaButtons: [
         {
@@ -49,10 +43,7 @@ const generateTwoColumnProps = (theme: 'light' | 'dark'): Partial<BannerLinkProp
     },
     {
       title: 'Chiamaci',
-      normalText: 'Il contact center di PagoPA S.p.A. è a tua disposizione al numero',
-      boldText: '06.4520.2323',
-      extraNormalText: ' per assistenza dedicata dal lunedì al venerdì dalle 08:00 alle 20:00 e il sabato dalle 08:00 alle 14:00.',
-      link: 'tel:0645202323',
+      body: <p>Il contact center di PagoPA S.p.A. è a tua disposizione al numero <a href='#'>06.4520.2323</a> per assistenza dedicata dal lunedì al venerdì dalle 08:00 alle 20:00 e il sabato dalle 08:00 alle 14:00.</p>,
       icon: <PhoneIcon style={{ fontSize: 60 }} />,
       ctaButtons: [
         {

--- a/apps/strapi-cms/src/components/components/banner-link-section.json
+++ b/apps/strapi-cms/src/components/components/banner-link-section.json
@@ -1,0 +1,43 @@
+{
+  "collectionName": "components_components_banner_link_sections",
+  "info": {
+    "displayName": "BannerLink Section",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "body": {
+      "type": "richtext",
+      "required": true
+    },
+    "icon": {
+      "type": "enumeration",
+      "enum": [
+        "HubOutlined",
+        "AutoFixHighOutlined",
+        "MarkunreadMailboxOutlined",
+        "CheckCircleOutlined",
+        "SavingsOutlined",
+        "HourglassEmptyRounded",
+        "EnergySavingsLeafOutlined",
+        "CloudOutlined"
+      ]
+    },
+    "decoration": {
+      "allowedTypes": [
+        "images"
+      ],
+      "type": "media",
+      "multiple": false
+    },
+    "ctaButtons": {
+      "type": "component",
+      "repeatable": true,
+      "component": "components.cta-button-simple"
+    }
+  }
+}

--- a/apps/strapi-cms/src/components/sections/banner-link.json
+++ b/apps/strapi-cms/src/components/sections/banner-link.json
@@ -6,10 +6,6 @@
   },
   "options": {},
   "attributes": {
-    "title": {
-      "type": "string",
-      "required": true
-    },
     "theme": {
       "type": "enumeration",
       "enum": [
@@ -19,27 +15,16 @@
       "default": "light",
       "required": true
     },
-    "decoration": {
-      "type": "media",
-      "multiple": false,
-      "required": false,
-      "allowedTypes": [
-        "images"
-      ]
-    },
-    "ctaButtons": {
-      "type": "component",
-      "repeatable": true,
-      "component": "components.cta-button-simple",
-      "max": 2
-    },
     "sectionID": {
       "type": "string",
       "regex": "^[a-z]+[a-z\\-]*$"
     },
-    "body": {
-      "type": "richtext",
-      "required": true
+    "sections": {
+      "type": "component",
+      "repeatable": true,
+      "component": "components.banner-link-section",
+      "required": true,
+      "min": 1
     }
   }
 }


### PR DESCRIPTION
As per title.

#### List of Changes
<!--- Describe your changes in detail -->
NextJS-side
- Removed normalText, boldText, link and extraNormalText variables in favor of single `body` field to be rendered from markdown
- Updated population parameters when fetching pages to be able to render every field of BannerLink's multiple sections (more specifically decoration and ctaButtons)
Strapi-side
- Updated BannerLink component to reflect new props structure

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
BannerLink now requires the capability for multiple sections.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested locally running from local Strapi instance.
Tested storybook working correctly after update.

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
