### PR TITLE
[B2BP-853] Remove unique constraint from Form Category fields

### DIFF
--- a/.changeset/modern-starfishes-retire.md
+++ b/.changeset/modern-starfishes-retire.md
@@ -1,0 +1,5 @@
+---
+"strapi-cms": patch
+---
+
+Remove unique constraint from Form Category fields

--- a/apps/strapi-cms/src/components/components/form-category.json
+++ b/apps/strapi-cms/src/components/components/form-category.json
@@ -1,19 +1,20 @@
 {
   "collectionName": "components_components_form_categories",
   "info": {
-    "displayName": "Form Category"
+    "displayName": "Form Category",
+    "description": ""
   },
   "options": {},
   "attributes": {
     "categoryID": {
       "type": "string",
       "required": true,
-      "unique": true
+      "unique": false
     },
     "label": {
       "type": "string",
       "required": true,
-      "unique": true
+      "unique": false
     },
     "additionalInfo": {
       "type": "string"


### PR DESCRIPTION
Strapi's unique constraint handling seems to check against itself, forcing to always update all unique constraints to be able to save any changes.

This PR removes the unique constraints in the Form Category component to solve the problem.

#### List of Changes
<!--- Describe your changes in detail -->
- Remove unique constraints from Form Category fields

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Bug fix / Better UX

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested locally.

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
