### PR TITLE
[B2BP-886] Bug fix: Make HeroCounter link optional

### DIFF
--- a/.changeset/soft-balloons-suffer.md
+++ b/.changeset/soft-balloons-suffer.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Bug fix: Make HeroCounter link optional

--- a/apps/nextjs-website/src/components/HeroCounter.tsx
+++ b/apps/nextjs-website/src/components/HeroCounter.tsx
@@ -7,11 +7,13 @@ import { HeroCounterSection } from '@/lib/fetch/types/PageSection';
 const makeHeroCounterProps = ({
   subtitle,
   background,
+  link,
   ...rest
 }: HeroCounterSection): HeroCounterProps => ({
   ...rest,
   ...(subtitle && { subtitle: MarkdownRenderer({ markdown: subtitle }) }),
   ...(background.data && { background: background.data.attributes.url }),
+  ...(link && { link }),
 });
 
 const HeroCounter = (props: HeroCounterSection) => (

--- a/apps/nextjs-website/src/lib/fetch/types/PageSection.ts
+++ b/apps/nextjs-website/src/lib/fetch/types/PageSection.ts
@@ -212,7 +212,7 @@ const HeroCounterSectionCodec = t.strict({
   sectionID: t.union([t.string, t.null]),
   background: StrapiImageSchema,
   counter: CounterCodec,
-  link: LinkCodec,
+  link: t.union([LinkCodec, t.null]),
 });
 
 const EditorialSwitchSectionCodec = t.strict({


### PR DESCRIPTION
Codec did not allow for link field to be optional.

In case a user did not input it into Strapi, build would break.

This PR fixes that issue.

#### List of Changes
<!--- Describe your changes in detail -->
- Made link field optional in PageSection Codec

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Bug fix

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested locally with data from deployed Strapi instance.

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
