### PR TITLE
[B2BP-897] Substitute MUI Icons in Feature, HowTo, Cards and StripeLink sections…

### DIFF
--- a/.changeset/warm-mirrors-invite.md
+++ b/.changeset/warm-mirrors-invite.md
@@ -1,0 +1,6 @@
+---
+"nextjs-website": minor
+"strapi-cms": minor
+---
+
+Substitute MUI Icons in Feature, HowTo, Cards and StripeLink sections with a simple image upload

--- a/apps/nextjs-website/react-components/components/Cards/CardsItem.tsx
+++ b/apps/nextjs-website/react-components/components/Cards/CardsItem.tsx
@@ -1,13 +1,13 @@
 import { Card, CardContent, Typography, Stack, Link, Box } from '@mui/material';
-import { EIcon } from '../common/EIcon';
 import ArrowRightAltIcon from '@mui/icons-material/ArrowRightAlt';
 import { CardsItemProps } from '../../types/Cards/Cards.types';
 import { Title, Body } from '../common/Common';
+import Image from 'next/image';
 
 const CardsItem = ({
   title,
   text,
-  cardIcon,
+  iconURL,
   links,
   textAlign,
   label,
@@ -27,7 +27,7 @@ const CardsItem = ({
       <CardContent>
         <Stack px={4} justifyContent='flex-start' alignItems='flex-start' fontFamily='"Titillium Web",sans-serif'>
           <Box mb={2} color='primary.dark'>
-            {cardIcon?.icon && <EIcon icon={cardIcon.icon} fontSize='large' />}
+            {iconURL && <Image src={iconURL} alt='' height={40} width={40} />}
           </Box>
           {label && (
             <Typography
@@ -73,7 +73,7 @@ const CardsItem = ({
                     fontSize={14}
                     fontWeight={600}
                   >
-                    {link.text}
+                    {link.label}
                   </Link>
                   <ArrowRightAltIcon sx={{ color: 'inherit', fontSize: 18, marginLeft: 1 }} />
                 </Stack>

--- a/apps/nextjs-website/react-components/components/Feature/FeatureStackItem.tsx
+++ b/apps/nextjs-website/react-components/components/Feature/FeatureStackItem.tsx
@@ -1,9 +1,9 @@
 import { Box, Stack } from '@mui/material';
 import { FeatureStackItemProps } from '../../types/Feature/Feature.types';
-import { EIcon } from '../common/EIcon';
 import { Title } from '../common/Common';
 import { TextColor, TextAlternativeColor } from '../common/Common.helpers';
 import Subtitle from './Subtitle';
+import Image from 'next/image';
 
 export const FeatureStackItem = ({ item, theme }: FeatureStackItemProps) => {
   const textColor = TextColor(theme);
@@ -32,7 +32,12 @@ export const FeatureStackItem = ({ item, theme }: FeatureStackItemProps) => {
         }}
         color={textColorAlternative}
       >
-        <EIcon {...item?.stackIcon} />
+        <Image
+          src={item.iconURL}
+          alt=''
+          height={64}
+          width={64}
+        />
       </Box>
       <Stack spacing={1} textAlign='center'>
         <Title

--- a/apps/nextjs-website/react-components/components/Feature/Subtitle.tsx
+++ b/apps/nextjs-website/react-components/components/Feature/Subtitle.tsx
@@ -21,13 +21,13 @@ const Subtitle = ({ item, theme }: FeatureStackItemProps) => {
         >
           <Link
             color='inherit'
-            href={item.link.url}
+            href={item.link.href}
             underline='none'
             sx={{
               fontWeight: 'bold',
             }}
           >
-            {item.link.text}
+            {item.link.label}
           </Link>
 
           <ArrowForwardIcon color='inherit'></ArrowForwardIcon>

--- a/apps/nextjs-website/react-components/components/HowTo/HowToStep.tsx
+++ b/apps/nextjs-website/react-components/components/HowTo/HowToStep.tsx
@@ -1,26 +1,15 @@
 import React from 'react';
-import * as MuiIcons from '@mui/icons-material';
 import { Stack, Box } from '@mui/material';
-import { EIcon } from '../common/EIcon';
-import { Generic } from '../../types/common/Common.types';
 import { HowToStepProps } from '../../types/HowTo/HowTo.types';
 import { ArrowIcon } from './HowTo.helpers';
 import { TextColor, TextAlternativeColor } from '../common/Common.helpers';
 import { Title, Body } from '../common/Common';
 import { HowToStepNum } from './HowTo.helpers';
-
-type IconProp = keyof typeof MuiIcons | Generic;
-
-function isIconProp(icon: IconProp | undefined): icon is IconProp {
-  return (
-    icon !== undefined &&
-    (typeof icon === 'string' || React.isValidElement(icon))
-  );
-}
+import Image from 'next/image';
 
 export const HowToStep = ({
   index,
-  stepIcon,
+  iconURL,
   title,
   description,
   theme,
@@ -39,7 +28,7 @@ export const HowToStep = ({
       sx={{ maxWidth: '15em', minWidth: 'auto' }}
     >
       {/** Step with icon */}
-      {stepIcon && (
+      {iconURL && (
         <Stack spacing={1.2}>
           <Stack spacing={1.2}>
             <HowToStepNum variant='overline' color={color2} stepNum={stepNum} />
@@ -49,14 +38,12 @@ export const HowToStep = ({
               direction='row'
               color={isDarkTheme ? 'white' : undefined}
             >
-              {stepIcon && isIconProp(stepIcon.icon) && (
-                <EIcon
-                  {...stepIcon}
-                  icon={stepIcon.icon}
-                  color={color2}
-                  sx={{ width: '64px', height: '64px' }}
-                />
-              )}
+              <Image
+                src={iconURL}
+                alt=''
+                height={64}
+                width={64}
+              />
               {!isLastStep && (
                 <Box
                   sx={{
@@ -85,7 +72,7 @@ export const HowToStep = ({
       )}
 
       {/** Step without icon */}
-      {!stepIcon && (
+      {!iconURL && (
         <Stack spacing={1.2}>
           <HowToStepNum
             variant='h6'

--- a/apps/nextjs-website/react-components/components/StripeLink/StripeLink.tsx
+++ b/apps/nextjs-website/react-components/components/StripeLink/StripeLink.tsx
@@ -1,6 +1,5 @@
 import { Grid, Stack, Button, Box } from '@mui/material';
 import ContainerRC from '../common/ContainerRC';
-import { EIcon } from '../common/EIcon';
 import { StripeLinkProps } from '../../types/StripeLink/StripeLink.types';
 import { Subtitle } from '../common/Common';
 import {
@@ -10,8 +9,9 @@ import {
   TextColor,
 } from '../common/Common.helpers';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import Image from 'next/image';
 
-const StripeLink = ({ icon, subtitle, theme, buttonText }: StripeLinkProps) => {
+const StripeLink = ({ iconURL, subtitle, theme, buttonText }: StripeLinkProps) => {
   const textAlternativeColor = TextAlternativeColor(theme);
   const textColorWhiteOnly = TextColor('dark');
   const backgroundColor = BackgroundColor(theme);
@@ -36,19 +36,10 @@ const StripeLink = ({ icon, subtitle, theme, buttonText }: StripeLinkProps) => {
               justifyContent: 'start',
               width: 'auto',
               alignItems: 'center',
+              gap:'.5rem'
             }}
           >
-            <EIcon
-              {...icon}
-              sx={{
-                display: 'flex',
-                justifyContent: 'center',
-                alignItems: 'center',
-
-                color: textColorWhiteOnly,
-                mr: 1,
-              }}
-            />
+            {iconURL && <Image src={iconURL} alt='' height={28} width={28} />}
             <Subtitle
               variant='body2'
               textColor={textColorWhiteOnly}

--- a/apps/nextjs-website/react-components/types/Cards/Cards.types.ts
+++ b/apps/nextjs-website/react-components/types/Cards/Cards.types.ts
@@ -1,4 +1,3 @@
-import { EIconProps } from '../../components/common/EIcon';
 import { CommonProps, CtaButtonProps, Generic } from '../common/Common.types';
 
 export interface CardsProps extends CommonProps {
@@ -14,13 +13,13 @@ export interface CardsProps extends CommonProps {
 
 export interface CardsItemProps {
   textAlign?: 'center' | 'left';
-  cardIcon?: EIconProps;
+  iconURL?: string;
   label?: string;
   title: string;
   text?: string;
   links?: Array<{
     href: string;
-    text: string;
+    label: string;
     title?: string;
   }>;
   masonry?: boolean;

--- a/apps/nextjs-website/react-components/types/Feature/Feature.types.ts
+++ b/apps/nextjs-website/react-components/types/Feature/Feature.types.ts
@@ -1,13 +1,12 @@
-import { EIconProps } from "../../components/common/EIcon";
 import { Theme } from "../common/Common.types";
 
 export interface FeatureItem {
-  readonly stackIcon?: EIconProps;
+  readonly iconURL: string;
   readonly title: string;
   readonly subtitle: string;
   readonly link?: {
-    readonly text: string;
-    readonly url: string;
+    readonly label: string;
+    readonly href: string;
   };
 }
 

--- a/apps/nextjs-website/react-components/types/HowTo/HowTo.types.ts
+++ b/apps/nextjs-website/react-components/types/HowTo/HowTo.types.ts
@@ -1,7 +1,5 @@
-import { EIconProps } from "../../components/common/EIcon";
-
 export interface Step {
-  readonly stepIcon?: EIconProps;
+  readonly iconURL?: string;
   readonly title: string;
   readonly description: string | JSX.Element;
 }

--- a/apps/nextjs-website/react-components/types/StripeLink/StripeLink.types.ts
+++ b/apps/nextjs-website/react-components/types/StripeLink/StripeLink.types.ts
@@ -1,9 +1,8 @@
-import { EIconProps } from "../../components/common/EIcon";
 import { Generic } from "../common/Common.types";
 
 export interface StripeLinkProps {
   theme: 'dark' | 'light';
   subtitle: Generic | string;
-  icon?: EIconProps;
+  iconURL?: string;
   buttonText?: string;
 }

--- a/apps/nextjs-website/src/components/Cards.tsx
+++ b/apps/nextjs-website/src/components/Cards.tsx
@@ -22,14 +22,12 @@ const makeCardsProps = ({
   },
   items: items.map(({ icon, label, text, title, links }) => ({
     title,
-    ...(icon && {
-      cardIcon: { icon },
+    ...(icon.data && {
+      iconURL: icon.data.attributes.url,
     }),
     ...(label && { label }),
     ...(text && { text }),
-    ...(links.length > 0 && {
-      links: links.map((link) => ({ href: link.href, text: link.label })),
-    }),
+    ...(links.length > 0 && { links }),
   })),
   ...(ctaButtons &&
     ctaButtons.length > 0 && {

--- a/apps/nextjs-website/src/components/Feature.tsx
+++ b/apps/nextjs-website/src/components/Feature.tsx
@@ -8,13 +8,13 @@ const makeFeatureProps = ({
   ...rest
 }: FeatureSection): FeatureProps => ({
   items: items.map((item) => ({
-    stackIcon: { icon: item.icon },
     title: item.title,
     subtitle: item.subtitle,
-    ...(item.linkText &&
-      item.linkURL && {
-        link: { text: item.linkText, url: item.linkURL },
-      }),
+    iconURL: (rest.theme === 'dark'
+      ? item.themedIcon.dark
+      : item.themedIcon.light
+    ).data.attributes.url,
+    ...(item.link && { link: item.link }),
   })),
   ...rest,
 });

--- a/apps/nextjs-website/src/components/HowTo.tsx
+++ b/apps/nextjs-website/src/components/HowTo.tsx
@@ -13,10 +13,11 @@ const makeHowToProps = ({
   steps: steps.map((step) => ({
     title: step.title,
     description: MarkdownRenderer({ markdown: step.description }),
-    ...(step.icon && {
-      stepIcon: {
-        icon: step.icon,
-      },
+    ...(step.themedIcon && {
+      iconURL: (rest.theme === 'dark'
+        ? step.themedIcon.dark
+        : step.themedIcon.light
+      ).data.attributes.url,
     }),
   })),
   ...rest,

--- a/apps/nextjs-website/src/components/StripeLink.tsx
+++ b/apps/nextjs-website/src/components/StripeLink.tsx
@@ -11,10 +11,8 @@ const makeStripeLinkProps = ({
   ...rest
 }: StripeLinkSection): StripeLinkProps => ({
   subtitle: MarkdownRenderer({ markdown: subtitle, variant: 'body2' }),
-  ...(icon && {
-    icon: {
-      icon,
-    },
+  ...(icon.data && {
+    iconURL: icon.data.attributes.url,
   }),
   ...(buttonText && { buttonText }),
   ...rest,

--- a/apps/nextjs-website/src/lib/fetch/__tests__/navigation.test.ts
+++ b/apps/nextjs-website/src/lib/fetch/__tests__/navigation.test.ts
@@ -43,7 +43,9 @@ const navigationResponse = {
             __component: 'sections.stripe-link',
             theme: 'dark',
             subtitle: 'subtitle',
-            icon: null,
+            icon: {
+              data: null,
+            },
             buttonText: null,
           },
         ],
@@ -64,7 +66,14 @@ describe('getNavigation', () => {
     await getNavigation(appEnv);
 
     expect(fetchMock).toHaveBeenCalledWith(
-      `${config.DEMO_STRAPI_API_BASE_URL}/api/pages?pagination[pageSize]=100&populate[seo][populate][0]=metaTitle&populate[sections][populate][0]=ctaButtons&populate[sections][populate][1]=image&populate[sections][populate][2]=background&populate[sections][populate][3]=items.links&populate[sections][populate][4]=link&populate[sections][populate][5]=steps&populate[sections][populate][6]=accordionItems&populate[sections][populate][7]=decoration&populate[sections][populate][8]=storeButtons&populate[sections][populate][9]=sections.decoration&populate[sections][populate][10]=sections.ctaButtons&populate[sections][populate][11]=mobileImage&populate[sections][populate][12]=categories&populate[sections][populate][13]=sections.content.image&populate[sections][populate][14]=sections.content.mobileImage&populate[sections][populate][15]=sections.content.ctaButtons&populate[sections][populate][16]=sections.content.storeButtons&populate[sections][populate][17]=video.src&populate[sections][populate][18]=counter`,
+      `${config.DEMO_STRAPI_API_BASE_URL}/api/pages?pagination[pageSize]=100
+      &populate[seo][populate][0]=metaTitle
+      &populate[sections][populate][0]=ctaButtons,image,mobileImage,background,link,accordionItems,decoration,storeButtons,categories,counter,icon
+      &populate[sections][populate][1]=items.links,items.link,items.icon,items.themedIcon.light,items.themedIcon.dark
+      &populate[sections][populate][2]=sections.decoration,sections.ctaButtons
+      &populate[sections][populate][3]=sections.content.image,sections.content.mobileImage,sections.content.ctaButtons,sections.content.storeButtons
+      &populate[sections][populate][4]=video.src
+      &populate[sections][populate][5]=steps.themedIcon.light,steps.themedIcon.dark`,
       {
         method: 'GET',
         headers: {
@@ -100,7 +109,9 @@ describe('getNavigation', () => {
                 __component: 'sections.stripe-link',
                 theme: 'dark',
                 subtitle: 'subtitle',
-                icon: null,
+                icon: {
+                  data: null,
+                },
                 buttonText: null,
               },
             ],

--- a/apps/nextjs-website/src/lib/fetch/__tests__/preview.test.ts
+++ b/apps/nextjs-website/src/lib/fetch/__tests__/preview.test.ts
@@ -129,7 +129,13 @@ describe('fetchPageFromID', () => {
     });
 
     expect(fetchMock).toHaveBeenCalledWith(
-      `${config.DEMO_STRAPI_API_BASE_URL}/api/pages/${pageIDExample}?publicationState=preview&populate[sections][populate][0]=ctaButtons&populate[sections][populate][1]=image&populate[sections][populate][2]=background&populate[sections][populate][3]=items.links&populate[sections][populate][4]=link&populate[sections][populate][5]=steps&populate[sections][populate][6]=accordionItems&populate[sections][populate][7]=decoration&populate[sections][populate][8]=storeButtons&populate[sections][populate][9]=sections.decoration&populate[sections][populate][10]=sections.ctaButtons&populate[sections][populate][11]=mobileImage&populate[sections][populate][12]=categories&populate[sections][populate][13]=sections.content.image&populate[sections][populate][14]=sections.content.mobileImage&populate[sections][populate][15]=sections.content.ctaButtons&populate[sections][populate][16]=sections.content.storeButtons&populate[sections][populate][17]=video.src&populate[sections][populate][18]=counter`,
+      `${config.DEMO_STRAPI_API_BASE_URL}/api/pages/${pageIDExample}?publicationState=preview
+      &populate[sections][populate][0]=ctaButtons,image,mobileImage,background,link,accordionItems,decoration,storeButtons,categories,counter,icon
+      &populate[sections][populate][1]=items.links,items.link,items.icon,items.themedIcon.light,items.themedIcon.dark
+      &populate[sections][populate][2]=sections.decoration,sections.ctaButtons
+      &populate[sections][populate][3]=sections.content.image,sections.content.mobileImage,sections.content.ctaButtons,sections.content.storeButtons
+      &populate[sections][populate][4]=video.src
+      &populate[sections][populate][5]=steps.themedIcon.light,steps.themedIcon.dark`,
       {
         method: 'GET',
         headers: {

--- a/apps/nextjs-website/src/lib/fetch/navigation.ts
+++ b/apps/nextjs-website/src/lib/fetch/navigation.ts
@@ -35,7 +35,14 @@ export const getNavigation = ({
       // The pagination[pageSize] parameter has been set to 100 to realistically not have the need to fetch multiple pages
       `${
         extractTenantStrapiApiData(config).baseUrl
-      }/api/pages?pagination[pageSize]=100&populate[seo][populate][0]=metaTitle&populate[sections][populate][0]=ctaButtons&populate[sections][populate][1]=image&populate[sections][populate][2]=background&populate[sections][populate][3]=items.links&populate[sections][populate][4]=link&populate[sections][populate][5]=steps&populate[sections][populate][6]=accordionItems&populate[sections][populate][7]=decoration&populate[sections][populate][8]=storeButtons&populate[sections][populate][9]=sections.decoration&populate[sections][populate][10]=sections.ctaButtons&populate[sections][populate][11]=mobileImage&populate[sections][populate][12]=categories&populate[sections][populate][13]=sections.content.image&populate[sections][populate][14]=sections.content.mobileImage&populate[sections][populate][15]=sections.content.ctaButtons&populate[sections][populate][16]=sections.content.storeButtons&populate[sections][populate][17]=video.src&populate[sections][populate][18]=counter`,
+      }/api/pages?pagination[pageSize]=100
+      &populate[seo][populate][0]=metaTitle
+      &populate[sections][populate][0]=ctaButtons,image,mobileImage,background,link,accordionItems,decoration,storeButtons,categories,counter,icon
+      &populate[sections][populate][1]=items.links,items.link,items.icon,items.themedIcon.light,items.themedIcon.dark
+      &populate[sections][populate][2]=sections.decoration,sections.ctaButtons
+      &populate[sections][populate][3]=sections.content.image,sections.content.mobileImage,sections.content.ctaButtons,sections.content.storeButtons
+      &populate[sections][populate][4]=video.src
+      &populate[sections][populate][5]=steps.themedIcon.light,steps.themedIcon.dark`,
       {
         method: 'GET',
         headers: {

--- a/apps/nextjs-website/src/lib/fetch/preview.ts
+++ b/apps/nextjs-website/src/lib/fetch/preview.ts
@@ -52,7 +52,13 @@ export const fetchPageFromID = ({
     fetchFun(
       `${
         extractTenantStrapiApiData(config).baseUrl
-      }/api/pages/${pageID}?publicationState=preview&populate[sections][populate][0]=ctaButtons&populate[sections][populate][1]=image&populate[sections][populate][2]=background&populate[sections][populate][3]=items.links&populate[sections][populate][4]=link&populate[sections][populate][5]=steps&populate[sections][populate][6]=accordionItems&populate[sections][populate][7]=decoration&populate[sections][populate][8]=storeButtons&populate[sections][populate][9]=sections.decoration&populate[sections][populate][10]=sections.ctaButtons&populate[sections][populate][11]=mobileImage&populate[sections][populate][12]=categories&populate[sections][populate][13]=sections.content.image&populate[sections][populate][14]=sections.content.mobileImage&populate[sections][populate][15]=sections.content.ctaButtons&populate[sections][populate][16]=sections.content.storeButtons&populate[sections][populate][17]=video.src&populate[sections][populate][18]=counter`,
+      }/api/pages/${pageID}?publicationState=preview
+      &populate[sections][populate][0]=ctaButtons,image,mobileImage,background,link,accordionItems,decoration,storeButtons,categories,counter,icon
+      &populate[sections][populate][1]=items.links,items.link,items.icon,items.themedIcon.light,items.themedIcon.dark
+      &populate[sections][populate][2]=sections.decoration,sections.ctaButtons
+      &populate[sections][populate][3]=sections.content.image,sections.content.mobileImage,sections.content.ctaButtons,sections.content.storeButtons
+      &populate[sections][populate][4]=video.src
+      &populate[sections][populate][5]=steps.themedIcon.light,steps.themedIcon.dark`,
       {
         method: 'GET',
         headers: {

--- a/apps/nextjs-website/src/lib/fetch/types/PageSection.ts
+++ b/apps/nextjs-website/src/lib/fetch/types/PageSection.ts
@@ -2,14 +2,16 @@ import * as t from 'io-ts';
 import { CTAButtonSimpleCodec } from './CTAButton';
 import { StrapiImageRequiredSchema, StrapiImageSchema } from './StrapiImage';
 import { FeatureItemMUIIconCodec } from './icons/FeatureItemIcon';
-import { HowToStepMUIIconCodec } from './icons/HowToStepIcon';
-import { StripeLinkMUIIconCodec } from './icons/StripeLinkIcon';
-import { CardsItemMUIIconCodec } from './icons/CardsItemIcon';
 import { StoreButtonsCodec } from './StoreButtons';
 
 const LinkCodec = t.strict({
   label: t.string,
   href: t.string,
+});
+
+const ThemedIconCodec = t.strict({
+  light: StrapiImageRequiredSchema,
+  dark: StrapiImageRequiredSchema,
 });
 
 const HeroSectionCodec = t.strict({
@@ -79,11 +81,10 @@ const AccordionSectionCodec = t.strict({
 
 const FeatureItemCodec = t.strict({
   id: t.number,
-  icon: FeatureItemMUIIconCodec,
+  themedIcon: ThemedIconCodec,
   title: t.string,
   subtitle: t.string,
-  linkText: t.union([t.string, t.null]),
-  linkURL: t.union([t.string, t.null]),
+  link: t.union([LinkCodec, t.null]),
 });
 
 const FeatureSectionCodec = t.strict({
@@ -98,7 +99,7 @@ const FeatureSectionCodec = t.strict({
 const StepCodec = t.strict({
   title: t.string,
   description: t.string,
-  icon: t.union([HowToStepMUIIconCodec, t.null]),
+  themedIcon: t.union([ThemedIconCodec, t.null]),
 });
 
 const HowToSectionCodec = t.strict({
@@ -134,7 +135,7 @@ const StripeLinkSectionCodec = t.strict({
   __component: t.literal('sections.stripe-link'),
   theme: t.union([t.literal('light'), t.literal('dark')]),
   subtitle: t.string,
-  icon: t.union([StripeLinkMUIIconCodec, t.null]),
+  icon: StrapiImageSchema,
   buttonText: t.union([t.string, t.null]),
 });
 
@@ -143,7 +144,7 @@ const CardsItemCodec = t.strict({
   title: t.string,
   text: t.union([t.string, t.null]),
   links: t.array(LinkCodec),
-  icon: t.union([CardsItemMUIIconCodec, t.null]),
+  icon: StrapiImageSchema,
 });
 
 const CardsSectionCodec = t.strict({

--- a/apps/nextjs-website/stories/Cards/cardsCommons.tsx
+++ b/apps/nextjs-website/stories/Cards/cardsCommons.tsx
@@ -8,9 +8,7 @@ export const generateItems = (count: number): CardsItemProps[] =>
   Array.from({ length: count }, (_, i) => ({
     title: `Card ${i + 1}`,
     text: `This is card ${i + 1}`,
-    cardIcon: {
-      icon: 'AccessAlarm',
-    }
+    iconURL: 'https://d2mk0pc4ejgxx6.cloudfront.net/light_icon_f76dbe7883.svg',
   })
 );
 
@@ -19,12 +17,10 @@ export const generateItemsWithLinks = (count: number): CardsItemProps[] =>
   Array.from({ length: count }, (_, i) => ({
     title: `Card ${i + 1}`,
     text: `This is card ${i + 1}`,
-    cardIcon: {
-      icon: 'AccessAlarm',
-    },
+    iconURL: 'https://d2mk0pc4ejgxx6.cloudfront.net/light_icon_f76dbe7883.svg',
     links: [
       {
-        text: `Link ${i + 1}`,
+        label: `Link ${i + 1}`,
         href: '#',
       },
     ],

--- a/apps/nextjs-website/stories/Feature/featureCommons.tsx
+++ b/apps/nextjs-website/stories/Feature/featureCommons.tsx
@@ -7,21 +7,19 @@ import { FeatureItem } from '@react-components/types/Feature/Feature.types';
 export const FeatureTemplate: StoryFn<FeatureProps> = (args) => <Feature {...args} />;
 
 // Function to generate items
-const generateItems = (count: number, withLinks: boolean): FeatureItem[] =>
+const generateItems = (count: number, withLinks: boolean, theme: 'dark' | 'light'): FeatureItem[] =>
   Array.from({ length: count }, (_, i) => ({
     title: `Feature ${i + 1}`,
     subtitle: `This is feature ${i + 1}`,
-    stackIcon: {
-      icon: 'AccessAlarm',
-    },
-    ...(withLinks ? { link: { text: `Link ${i + 1}`, url: `https://example.com/link${i + 1}` } } : {}),
+    iconURL: theme === 'dark' ? 'https://d2mk0pc4ejgxx6.cloudfront.net/dark_icon_dee9ab4f99.svg' : 'https://d2mk0pc4ejgxx6.cloudfront.net/light_icon_f76dbe7883.svg',
+    ...(withLinks ? { link: { label: `Link ${i + 1}`, href: `https://example.com/link${i + 1}` } } : {}),
   }));
 
 // Function to generate default props
 const generateDefaultProps = (theme: 'dark' | 'light', withLinks: boolean): Partial<FeatureProps> => ({
   theme,
   title: 'Feature Title',
-  items: generateItems(3, withLinks),
+  items: generateItems(3, withLinks, theme),
 });
 
 // Define the default props

--- a/apps/nextjs-website/stories/HowTo/howtoCommons.tsx
+++ b/apps/nextjs-website/stories/HowTo/howtoCommons.tsx
@@ -11,7 +11,7 @@ const generateSteps = (count: number, theme: 'dark' | 'light', withIcons: boolea
   Array.from({ length: count }, (_, i) => ({
     title: `Step ${i + 1}`,
     description: `This is step ${i + 1}`,
-    ...(withIcons ? { stepIcon: { icon: 'MarkEmailReadOutlined' } } : {}),
+    ...(withIcons && { iconURL: theme === 'dark' ? 'https://d2mk0pc4ejgxx6.cloudfront.net/dark_icon_dee9ab4f99.svg' : 'https://d2mk0pc4ejgxx6.cloudfront.net/light_icon_f76dbe7883.svg' }),
     index: i,
     theme,
     isLastStep: i === count - 1,

--- a/apps/nextjs-website/stories/StripeLink/dark.stories.tsx
+++ b/apps/nextjs-website/stories/StripeLink/dark.stories.tsx
@@ -12,9 +12,7 @@ export default meta;
 export const DarkStripeLinkFull: StoryFn<typeof StripeLink> = StripeLinkTemplate.bind({});
 DarkStripeLinkFull.args = {
   ...defaultPropsDark,
-  icon: {
-    icon: 'MarkEmailReadOutlined',
-  },
+  iconURL: 'https://d2mk0pc4ejgxx6.cloudfront.net/dark_icon_dee9ab4f99.svg',
   buttonText: 'Click Me',
 };
 
@@ -27,9 +25,7 @@ DarkStripeLinkNoIcon.args = {
 export const DarkStripeLinkNoButton: StoryFn<typeof StripeLink> = StripeLinkTemplate.bind({});
 DarkStripeLinkNoButton.args = {
   ...defaultPropsDark,
-  icon: {
-    icon: 'MarkEmailReadOutlined',
-  },
+  iconURL: 'https://d2mk0pc4ejgxx6.cloudfront.net/dark_icon_dee9ab4f99.svg',
 };
 
 export const DarkStripeLinkNoIconNoButton: StoryFn<typeof StripeLink> = StripeLinkTemplate.bind({});

--- a/apps/nextjs-website/stories/StripeLink/light.stories.tsx
+++ b/apps/nextjs-website/stories/StripeLink/light.stories.tsx
@@ -12,9 +12,7 @@ export default meta;
 export const LightStripeLinkFull: StoryFn<typeof StripeLink> = StripeLinkTemplate.bind({});
 LightStripeLinkFull.args = {
   ...defaultPropsLight,
-  icon: {
-    icon: 'MarkEmailReadOutlined',
-  },
+  iconURL: 'https://d2mk0pc4ejgxx6.cloudfront.net/dark_icon_dee9ab4f99.svg',
   buttonText: 'Click Me',
 };
 
@@ -27,9 +25,7 @@ LightStripeLinkNoIcon.args = {
 export const LightStripeLinkNoButton: StoryFn<typeof StripeLink> = StripeLinkTemplate.bind({});
 LightStripeLinkNoButton.args = {
   ...defaultPropsLight,
-  icon: {
-    icon: 'MarkEmailReadOutlined',
-  },
+  iconURL: 'https://d2mk0pc4ejgxx6.cloudfront.net/dark_icon_dee9ab4f99.svg',
 };
 
 export const LightStripeLinkNoIconNoButton: StoryFn<typeof StripeLink> = StripeLinkTemplate.bind({});

--- a/apps/strapi-cms/src/components/components/cards-item.json
+++ b/apps/strapi-cms/src/components/components/cards-item.json
@@ -17,18 +17,19 @@
       "type": "text",
       "required": false
     },
-    "icon": {
-      "type": "enumeration",
-      "enum": [
-        "AccessAlarm"
-      ]
-    },
     "links": {
       "type": "component",
       "repeatable": true,
       "component": "components.link",
       "required": false,
       "max": 2
+    },
+    "icon": {
+      "allowedTypes": [
+        "images"
+      ],
+      "type": "media",
+      "multiple": false
     }
   }
 }

--- a/apps/strapi-cms/src/components/components/feature-item.json
+++ b/apps/strapi-cms/src/components/components/feature-item.json
@@ -14,25 +14,17 @@
       "type": "string",
       "required": true
     },
-    "linkText": {
-      "type": "string"
-    },
-    "linkURL": {
-      "type": "string"
-    },
-    "icon": {
-      "type": "enumeration",
-      "enum": [
-        "HubOutlined",
-        "AutoFixHighOutlined",
-        "MarkunreadMailboxOutlined",
-        "CheckCircleOutlined",
-        "SavingsOutlined",
-        "HourglassEmptyRounded",
-        "EnergySavingsLeafOutlined",
-        "CloudOutlined"
-      ],
+    "themedIcon": {
+      "type": "component",
+      "repeatable": false,
+      "component": "components.themed-icon",
       "required": true
+    },
+    "link": {
+      "type": "component",
+      "repeatable": false,
+      "component": "components.link",
+      "required": false
     }
   }
 }

--- a/apps/strapi-cms/src/components/components/step.json
+++ b/apps/strapi-cms/src/components/components/step.json
@@ -14,18 +14,11 @@
       "type": "richtext",
       "required": true
     },
-    "icon": {
-      "type": "enumeration",
-      "enum": [
-        "UploadFileOutlined",
-        "CachedRounded",
-        "ForwardToInboxOutlined",
-        "MarkEmailReadOutlined",
-        "NotificationsActiveOutlined",
-        "GradingOutlined",
-        "AccountBalanceWalletOutlined",
-        "GroupAddOutlined"
-      ]
+    "themedIcon": {
+      "type": "component",
+      "repeatable": false,
+      "component": "components.themed-icon",
+      "required": false
     }
   }
 }

--- a/apps/strapi-cms/src/components/components/themed-icon.json
+++ b/apps/strapi-cms/src/components/components/themed-icon.json
@@ -1,0 +1,25 @@
+{
+  "collectionName": "components_components_themed_icons",
+  "info": {
+    "displayName": "Themed Icon"
+  },
+  "options": {},
+  "attributes": {
+    "light": {
+      "allowedTypes": [
+        "images"
+      ],
+      "type": "media",
+      "multiple": false,
+      "required": true
+    },
+    "dark": {
+      "allowedTypes": [
+        "images"
+      ],
+      "type": "media",
+      "multiple": false,
+      "required": true
+    }
+  }
+}

--- a/apps/strapi-cms/src/components/sections/stripe-link.json
+++ b/apps/strapi-cms/src/components/sections/stripe-link.json
@@ -18,16 +18,16 @@
     "buttonText": {
       "type": "string"
     },
-    "icon": {
-      "type": "enumeration",
-      "enum": [
-        "Code",
-        "SpeakerNotes"
-      ]
-    },
     "subtitle": {
       "type": "richtext",
       "required": true
+    },
+    "icon": {
+      "allowedTypes": [
+        "images"
+      ],
+      "type": "media",
+      "multiple": false
     }
   }
 }


### PR DESCRIPTION
… with a simple image upload

As per title.

#### List of Changes
<!--- Describe your changes in detail -->
- Subbed all Icon / EIcon implementation with a simple Next Image component.
- Added "Themed Icon" component to Strapi. To be used when icons need to be different in light and dark mode.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Feature request: upload any icon, not restricted to MUI.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran locally in dev and storybook.

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
