### PR TITLE
[B2BP-921] Substitute Themed Icon with a simple Icon

### DIFF
--- a/.changeset/serious-bottles-serve.md
+++ b/.changeset/serious-bottles-serve.md
@@ -1,0 +1,6 @@
+---
+"nextjs-website": patch
+"strapi-cms": patch
+---
+
+Substitute Themed Icon for simple Icon

--- a/apps/nextjs-website/src/components/Feature.tsx
+++ b/apps/nextjs-website/src/components/Feature.tsx
@@ -10,10 +10,7 @@ const makeFeatureProps = ({
   items: items.map((item) => ({
     title: item.title,
     subtitle: item.subtitle,
-    iconURL: (rest.theme === 'dark'
-      ? item.themedIcon.dark
-      : item.themedIcon.light
-    ).data.attributes.url,
+    iconURL: 'http://127.0.0.1:1337' + item.icon.data.attributes.url,
     ...(item.link && { link: item.link }),
   })),
   ...rest,

--- a/apps/nextjs-website/src/components/HowTo.tsx
+++ b/apps/nextjs-website/src/components/HowTo.tsx
@@ -13,11 +13,8 @@ const makeHowToProps = ({
   steps: steps.map((step) => ({
     title: step.title,
     description: MarkdownRenderer({ markdown: step.description }),
-    ...(step.themedIcon && {
-      iconURL: (rest.theme === 'dark'
-        ? step.themedIcon.dark
-        : step.themedIcon.light
-      ).data.attributes.url,
+    ...(step.icon.data && {
+      iconURL: 'http://127.0.0.1:1337' + step.icon.data.attributes.url,
     }),
   })),
   ...rest,

--- a/apps/nextjs-website/src/lib/fetch/__tests__/navigation.test.ts
+++ b/apps/nextjs-website/src/lib/fetch/__tests__/navigation.test.ts
@@ -70,11 +70,11 @@ describe('getNavigation', () => {
       `${config.DEMO_STRAPI_API_BASE_URL}/api/pages?pagination[pageSize]=100
       &populate[seo][populate][0]=metaTitle
       &populate[sections][populate][0]=ctaButtons,image,mobileImage,background,link,accordionItems,decoration,storeButtons,categories,counter,icon
-      &populate[sections][populate][1]=items.links,items.link,items.icon,items.themedIcon.light,items.themedIcon.dark
+      &populate[sections][populate][1]=items.links,items.link,items.icon
       &populate[sections][populate][2]=sections.decoration,sections.ctaButtons
       &populate[sections][populate][3]=sections.content.image,sections.content.mobileImage,sections.content.ctaButtons,sections.content.storeButtons
       &populate[sections][populate][4]=video.src
-      &populate[sections][populate][5]=steps.themedIcon.light,steps.themedIcon.dark
+      &populate[sections][populate][5]=steps.icon
       &populate[sections][populate][6]=cards.image,cards.link`,
       {
         method: 'GET',

--- a/apps/nextjs-website/src/lib/fetch/__tests__/preview.test.ts
+++ b/apps/nextjs-website/src/lib/fetch/__tests__/preview.test.ts
@@ -131,11 +131,11 @@ describe('fetchPageFromID', () => {
     expect(fetchMock).toHaveBeenCalledWith(
       `${config.DEMO_STRAPI_API_BASE_URL}/api/pages/${pageIDExample}?publicationState=preview
       &populate[sections][populate][0]=ctaButtons,image,mobileImage,background,link,accordionItems,decoration,storeButtons,categories,counter,icon
-      &populate[sections][populate][1]=items.links,items.link,items.icon,items.themedIcon.light,items.themedIcon.dark
+      &populate[sections][populate][1]=items.links,items.link,items.icon
       &populate[sections][populate][2]=sections.decoration,sections.ctaButtons
       &populate[sections][populate][3]=sections.content.image,sections.content.mobileImage,sections.content.ctaButtons,sections.content.storeButtons
       &populate[sections][populate][4]=video.src
-      &populate[sections][populate][5]=steps.themedIcon.light,steps.themedIcon.dark
+      &populate[sections][populate][5]=steps.icon
       &populate[sections][populate][6]=cards.image,cards.link`,
       {
         method: 'GET',

--- a/apps/nextjs-website/src/lib/fetch/navigation.ts
+++ b/apps/nextjs-website/src/lib/fetch/navigation.ts
@@ -38,11 +38,11 @@ export const getNavigation = ({
       }/api/pages?pagination[pageSize]=100
       &populate[seo][populate][0]=metaTitle
       &populate[sections][populate][0]=ctaButtons,image,mobileImage,background,link,accordionItems,decoration,storeButtons,categories,counter,icon
-      &populate[sections][populate][1]=items.links,items.link,items.icon,items.themedIcon.light,items.themedIcon.dark
+      &populate[sections][populate][1]=items.links,items.link,items.icon
       &populate[sections][populate][2]=sections.decoration,sections.ctaButtons
       &populate[sections][populate][3]=sections.content.image,sections.content.mobileImage,sections.content.ctaButtons,sections.content.storeButtons
       &populate[sections][populate][4]=video.src
-      &populate[sections][populate][5]=steps.themedIcon.light,steps.themedIcon.dark
+      &populate[sections][populate][5]=steps.icon
       &populate[sections][populate][6]=cards.image,cards.link`,
       {
         method: 'GET',

--- a/apps/nextjs-website/src/lib/fetch/preview.ts
+++ b/apps/nextjs-website/src/lib/fetch/preview.ts
@@ -54,11 +54,11 @@ export const fetchPageFromID = ({
         extractTenantStrapiApiData(config).baseUrl
       }/api/pages/${pageID}?publicationState=preview
       &populate[sections][populate][0]=ctaButtons,image,mobileImage,background,link,accordionItems,decoration,storeButtons,categories,counter,icon
-      &populate[sections][populate][1]=items.links,items.link,items.icon,items.themedIcon.light,items.themedIcon.dark
+      &populate[sections][populate][1]=items.links,items.link,items.icon
       &populate[sections][populate][2]=sections.decoration,sections.ctaButtons
       &populate[sections][populate][3]=sections.content.image,sections.content.mobileImage,sections.content.ctaButtons,sections.content.storeButtons
       &populate[sections][populate][4]=video.src
-      &populate[sections][populate][5]=steps.themedIcon.light,steps.themedIcon.dark
+      &populate[sections][populate][5]=steps.icon
       &populate[sections][populate][6]=cards.image,cards.link`,
       {
         method: 'GET',

--- a/apps/nextjs-website/src/lib/fetch/types/PageSection.ts
+++ b/apps/nextjs-website/src/lib/fetch/types/PageSection.ts
@@ -9,11 +9,6 @@ const LinkCodec = t.strict({
   href: t.string,
 });
 
-const ThemedIconCodec = t.strict({
-  light: StrapiImageRequiredSchema,
-  dark: StrapiImageRequiredSchema,
-});
-
 const HeroSectionCodec = t.strict({
   __component: t.literal('sections.hero'),
   title: t.string,
@@ -81,7 +76,7 @@ const AccordionSectionCodec = t.strict({
 
 const FeatureItemCodec = t.strict({
   id: t.number,
-  themedIcon: ThemedIconCodec,
+  icon: StrapiImageRequiredSchema,
   title: t.string,
   subtitle: t.string,
   link: t.union([LinkCodec, t.null]),
@@ -99,7 +94,7 @@ const FeatureSectionCodec = t.strict({
 const StepCodec = t.strict({
   title: t.string,
   description: t.string,
-  themedIcon: t.union([ThemedIconCodec, t.null]),
+  icon: StrapiImageSchema,
 });
 
 const HowToSectionCodec = t.strict({

--- a/apps/strapi-cms/src/components/components/feature-item.json
+++ b/apps/strapi-cms/src/components/components/feature-item.json
@@ -14,17 +14,19 @@
       "type": "string",
       "required": true
     },
-    "themedIcon": {
-      "type": "component",
-      "repeatable": false,
-      "component": "components.themed-icon",
-      "required": true
-    },
     "link": {
       "type": "component",
       "repeatable": false,
       "component": "components.link",
       "required": false
+    },
+    "icon": {
+      "allowedTypes": [
+        "images"
+      ],
+      "type": "media",
+      "multiple": false,
+      "required": true
     }
   }
 }

--- a/apps/strapi-cms/src/components/components/step.json
+++ b/apps/strapi-cms/src/components/components/step.json
@@ -14,11 +14,12 @@
       "type": "richtext",
       "required": true
     },
-    "themedIcon": {
-      "type": "component",
-      "repeatable": false,
-      "component": "components.themed-icon",
-      "required": false
+    "icon": {
+      "allowedTypes": [
+        "images"
+      ],
+      "type": "media",
+      "multiple": false
     }
   }
 }


### PR DESCRIPTION
As per title.

#### List of Changes
<!--- Describe your changes in detail -->
Subbed `themedIcon` for `icon` in Feature and HowTo components both in Strapi and NextJS.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Better UX.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran locally in dev and preview.

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
