### PR TITLE
[B2BP-931] Remove dev URL for icons

### DIFF
--- a/.changeset/wet-pumpkins-exercise.md
+++ b/.changeset/wet-pumpkins-exercise.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Remove dev URL for icons

--- a/apps/nextjs-website/src/components/Feature.tsx
+++ b/apps/nextjs-website/src/components/Feature.tsx
@@ -10,7 +10,7 @@ const makeFeatureProps = ({
   items: items.map((item) => ({
     title: item.title,
     subtitle: item.subtitle,
-    iconURL: 'http://127.0.0.1:1337' + item.icon.data.attributes.url,
+    iconURL: item.icon.data.attributes.url,
     ...(item.link && { link: item.link }),
   })),
   ...rest,

--- a/apps/nextjs-website/src/components/HowTo.tsx
+++ b/apps/nextjs-website/src/components/HowTo.tsx
@@ -14,7 +14,7 @@ const makeHowToProps = ({
     title: step.title,
     description: MarkdownRenderer({ markdown: step.description }),
     ...(step.icon.data && {
-      iconURL: 'http://127.0.0.1:1337' + step.icon.data.attributes.url,
+      iconURL: step.icon.data.attributes.url,
     }),
   })),
   ...rest,


### PR DESCRIPTION
As per title.

A dev-only workaround to make image urls work (prepending 'http://127.0.0.1:1337') 

#### List of Changes
<!--- Describe your changes in detail -->
- Remove 'http://127.0.0.1:1337' before image URLs

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
A dev-only workaround to make image URLs work (prepending 'http://127.0.0.1:1337') got through reviews.
This breaks prod as the image's url are then invalid.
This PR fixes that.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran locally.

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
