### PR TITLE
[B2BP-961] Extend og:description to 160 characters

### DIFF
--- a/.changeset/slimy-berries-wonder.md
+++ b/.changeset/slimy-berries-wonder.md
@@ -1,0 +1,5 @@
+---
+"strapi-cms": patch
+---
+
+Extend og:description to 160 characters

--- a/apps/strapi-cms/src/components/shared/seo.json
+++ b/apps/strapi-cms/src/components/shared/seo.json
@@ -32,7 +32,7 @@
     },
     "ogDescription": {
       "type": "string",
-      "maxLength": 65
+      "maxLength": 160
     }
   }
 }


### PR DESCRIPTION
As per title

#### List of Changes
<!--- Describe your changes in detail -->
Updated maxLength of ogDescription field from 65 to 160

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Consistency with metaDescription

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
