### PR TITLE
[B2BP-967] Strapi substitute Stripelink buttonText with full link

### DIFF
--- a/.changeset/lemon-spiders-battle.md
+++ b/.changeset/lemon-spiders-battle.md
@@ -1,0 +1,5 @@
+---
+"strapi-cms": patch
+---
+
+Sub Stripelink buttonText with full link

--- a/apps/strapi-cms/src/components/sections/stripe-link.json
+++ b/apps/strapi-cms/src/components/sections/stripe-link.json
@@ -15,23 +15,27 @@
       "default": "light",
       "required": true
     },
-    "buttonText": {
-      "type": "string"
-    },
     "subtitle": {
       "type": "richtext",
       "required": true
     },
     "icon": {
+      "type": "media",
+      "multiple": false,
+      "required": false,
       "allowedTypes": [
         "images"
-      ],
-      "type": "media",
-      "multiple": false
+      ]
     },
     "sectionID": {
       "type": "string",
       "regex": "^[a-z]+[a-z\\-]*$"
+    },
+    "link": {
+      "type": "component",
+      "repeatable": false,
+      "component": "components.link",
+      "required": true
     }
   }
 }


### PR DESCRIPTION
As per title.

#### List of Changes
<!--- Describe your changes in detail -->
- Remove buttonText field
- Add link field

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Users requested to be able to edit the CTA's link (href)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran locally

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
