### PR TITLE
[B2BP-913] Strapi Accordion add two-column layout

### DIFF
--- a/.changeset/popular-paws-stare.md
+++ b/.changeset/popular-paws-stare.md
@@ -1,0 +1,5 @@
+---
+"strapi-cms": patch
+---
+
+Accordion: Add option to have text beside questions

--- a/apps/strapi-cms/src/components/sections/accordion.json
+++ b/apps/strapi-cms/src/components/sections/accordion.json
@@ -30,10 +30,9 @@
       "type": "enumeration",
       "enum": [
         "left",
-        "center",
-        "right"
+        "center"
       ],
-      "default": "left",
+      "default": "center",
       "required": true
     },
     "accordionItems": {
@@ -47,6 +46,16 @@
       "type": "string",
       "regex": "^[a-z]+[a-z\\-]*$",
       "unique": false
+    },
+    "textAlignment": {
+      "type": "enumeration",
+      "enum": [
+        "left",
+        "center",
+        "right"
+      ],
+      "required": true,
+      "default": "center"
     }
   }
 }


### PR DESCRIPTION
As per title.

Give the ability to CMS user to choose whether the Accordion title sits on top or beside the questions in desktop view.

#### List of Changes
<!--- Describe your changes in detail -->
- Repurpose layout field to indicate where the title will be (left of questions or centered above them)
- Add textAlignment field to indicate text alignment when layout is 'center'

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Feature request

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran locally

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
