### PR TITLE
[B2BP-964] Add structuredData to page SEO

### DIFF
--- a/.changeset/eighty-gifts-camp.md
+++ b/.changeset/eighty-gifts-camp.md
@@ -1,0 +1,6 @@
+---
+"nextjs-website": patch
+"strapi-cms": patch
+---
+
+Add structuredData to page SEO

--- a/apps/nextjs-website/src/app/[[...slug]]/page.tsx
+++ b/apps/nextjs-website/src/app/[[...slug]]/page.tsx
@@ -83,7 +83,19 @@ const Page = async ({ params }: PageParams) => {
 
   const sections = pageProps.sections;
 
-  return <div>{sections.map(PageSection)}</div>;
+  return (
+    <main>
+      {pageProps.seo.structuredData && (
+        <script
+          type='application/ld+json'
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(pageProps.seo.structuredData),
+          }}
+        />
+      )}
+      {sections.map(PageSection)}
+    </main>
+  );
 };
 
 export default Page;

--- a/apps/nextjs-website/src/app/robots.ts
+++ b/apps/nextjs-website/src/app/robots.ts
@@ -4,7 +4,7 @@ export default function robots(): MetadataRoute.Robots {
   return {
     rules: {
       userAgent: '*',
-      disallow: '/', // Disallow: '/preview' --> Needed until /preview page is removed from rendering in SSG
+      allow: '/', // Disallow: '/preview' --> Needed until /preview page is removed from rendering in SSG
     },
   };
 }

--- a/apps/nextjs-website/src/lib/fetch/__tests__/navigation.test.ts
+++ b/apps/nextjs-website/src/lib/fetch/__tests__/navigation.test.ts
@@ -37,6 +37,7 @@ const navigationResponse = {
           canonicalURL: null,
           ogTitle: null,
           ogDescription: null,
+          structuredData: null,
         },
         sections: [
           {
@@ -109,6 +110,7 @@ describe('getNavigation', () => {
               canonicalURL: null,
               ogTitle: null,
               ogDescription: null,
+              structuredData: null,
             },
             sections: [
               {

--- a/apps/nextjs-website/src/lib/fetch/types/SEO.ts
+++ b/apps/nextjs-website/src/lib/fetch/types/SEO.ts
@@ -7,6 +7,7 @@ export const PageSEOCodec = t.strict({
   canonicalURL: t.union([t.string, t.null]),
   ogTitle: t.union([t.string, t.null]),
   ogDescription: t.union([t.string, t.null]),
+  structuredData: t.union([t.UnknownRecord, t.null]), // Currently implementing structuredData as any object to avoid being too restrictive before feedback or real-world use
 });
 
 export type PageSEO = t.TypeOf<typeof PageSEOCodec>;

--- a/apps/strapi-cms/src/components/shared/seo.json
+++ b/apps/strapi-cms/src/components/shared/seo.json
@@ -33,6 +33,9 @@
     "ogDescription": {
       "type": "string",
       "maxLength": 160
+    },
+    "structuredData": {
+      "type": "json"
     }
   }
 }


### PR DESCRIPTION
As per title

#### List of Changes
<!--- Describe your changes in detail -->
Strapi
- Add structuredData field as JSON to Page's `seo` section
NextJS
- Conditionally render structuredData following [NextJS docs](https://nextjs.org/docs/app/building-your-application/optimizing/metadata#json-ld)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Feature request

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested locally.
Needs prod testing using Google's [Rich Results Test](https://search.google.com/test/rich-results).

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
