### PR TITLE
[B2BP-917] Add PreFooter as site-wide component

### DIFF
--- a/apps/nextjs-website/react-components/components/PreFooter/PreFooter.tsx
+++ b/apps/nextjs-website/react-components/components/PreFooter/PreFooter.tsx
@@ -10,6 +10,7 @@ import googleBadgeDarkBase64 from './BadgeImages/googleBadgeDarkBase64';
 import appleBadgeDarkBase64 from './BadgeImages/appleBadgeDarkBase64';
 import ContainerRC from '../common/ContainerRC';
 import { CtaButtons } from '../common/Common';
+import { usePathname } from 'next/navigation';
 
 const styles = {
   main: (isSmallScreen: boolean, layout: 'left' | 'center') => ({
@@ -46,7 +47,14 @@ const PreFooter = (props: PreFooterProps) => {
     storeButtons,
     background,
     ctaButtons,
+    excludeSlugs,
   } = props;
+  const pathname = usePathname();
+  // Compare excluded slugs with current page slug (removing initial '/')
+  if (excludeSlugs && excludeSlugs.includes(pathname.slice(1))) {
+    return null;
+  }
+
   const muiTheme = useTheme();
   const isSmallScreen = useMediaQuery(muiTheme.breakpoints.down('sm'));
 
@@ -58,10 +66,7 @@ const PreFooter = (props: PreFooterProps) => {
   const backgroundColor = BackgroundColor(theme);
 
   return (
-    <Box
-      component='section'
-      sx={styles.backgroundImage(isSmallScreen, theme)}
-    >
+    <Box component='section' sx={styles.backgroundImage(isSmallScreen, theme)}>
       <Box sx={{ position: 'relative', overflow: 'hidden' }}>
         <Box
           role='presentation'

--- a/apps/nextjs-website/react-components/components/PreFooter/PreFooter.tsx
+++ b/apps/nextjs-website/react-components/components/PreFooter/PreFooter.tsx
@@ -40,13 +40,12 @@ const styles = {
 
 const PreFooter = (props: PreFooterProps) => {
   const {
-    theme,
     title,
+    theme,
+    layout,
     storeButtons,
     background,
-    sectionID,
     ctaButtons,
-    layout = 'left',
   } = props;
   const muiTheme = useTheme();
   const isSmallScreen = useMediaQuery(muiTheme.breakpoints.down('sm'));
@@ -62,7 +61,6 @@ const PreFooter = (props: PreFooterProps) => {
     <Box
       component='section'
       sx={styles.backgroundImage(isSmallScreen, theme)}
-      {...(sectionID && { id: sectionID })}
     >
       <Box sx={{ position: 'relative', overflow: 'hidden' }}>
         <Box

--- a/apps/nextjs-website/react-components/types/PreFooter/PreFooter.ts
+++ b/apps/nextjs-website/react-components/types/PreFooter/PreFooter.ts
@@ -11,6 +11,7 @@ export interface PreFooterProps extends PreFooterContentProps {
   readonly background?: string;
   readonly ctaButtons?: CtaButtonProps[];
   readonly layout: 'left' | 'center';
+  readonly excludeSlugs?: string[];
 }
 
 export interface PreFooterContentProps {

--- a/apps/nextjs-website/react-components/types/PreFooter/PreFooter.ts
+++ b/apps/nextjs-website/react-components/types/PreFooter/PreFooter.ts
@@ -1,4 +1,4 @@
-import { SectionProps, Theme } from '../common/Common.types';
+import { Theme } from '../common/Common.types';
 import { CtaButtonProps } from '../common/Common.types';
 
 export interface StoreButtonsProps {
@@ -6,11 +6,11 @@ export interface StoreButtonsProps {
   readonly hrefApple?: string;
 }
 
-export interface PreFooterProps extends SectionProps, PreFooterContentProps {
+export interface PreFooterProps extends PreFooterContentProps {
   readonly storeButtons?: StoreButtonsProps;
   readonly background?: string;
   readonly ctaButtons?: CtaButtonProps[];
-  readonly layout?: 'left' | 'center';
+  readonly layout: 'left' | 'center';
 }
 
 export interface PreFooterContentProps {

--- a/apps/nextjs-website/src/app/layout.tsx
+++ b/apps/nextjs-website/src/app/layout.tsx
@@ -10,7 +10,9 @@ import {
   getFooterProps,
   getSiteWideSEO,
   isPreviewMode,
+  getPreFooterProps,
 } from '@/lib/api';
+import PreFooter from '@/components/PreFooter';
 
 const MatomoScript = (id: string): string => `
 var _paq = (window._paq = window._paq || []);
@@ -55,6 +57,7 @@ export default async function RootLayout({
   const preHeaderProps = await getPreHeaderProps();
   const headerProps = await getHeaderProps();
   const footerProps = await getFooterProps();
+  const preFooterProps = await getPreFooterProps();
   const { matomoID } = await getSiteWideSEO();
 
   return (
@@ -64,6 +67,7 @@ export default async function RootLayout({
           {preHeaderProps && <PreHeader {...preHeaderProps} />}
           <Header {...headerProps} />
           {children}
+          {preFooterProps && <PreFooter {...preFooterProps} />}
           <Footer {...footerProps} />
           <Script
             src='/scripts/otnotice-1.0.min.js'

--- a/apps/nextjs-website/src/components/PreFooter.tsx
+++ b/apps/nextjs-website/src/components/PreFooter.tsx
@@ -7,6 +7,7 @@ const makePreFooterProps = ({
   storeButtons,
   background,
   ctaButtons,
+  exclude,
   ...rest
 }: PreFooterAttributes): PreFooterProps => ({
   ...(background.data && { background: background.data.attributes.url }),
@@ -17,6 +18,9 @@ const makePreFooterProps = ({
     },
   }),
   ...(ctaButtons.length > 0 && { ctaButtons }),
+  ...(exclude.data.length > 0 && {
+    excludeSlugs: exclude.data.map((obj) => obj.attributes.slug),
+  }),
   ...rest,
 });
 

--- a/apps/nextjs-website/src/components/PreFooter.tsx
+++ b/apps/nextjs-website/src/components/PreFooter.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { PreFooterSection } from '@/lib/fetch/types/PageSection';
+import { PreFooterAttributes } from '@/lib/fetch/preFooter';
 import { PreFooter as PreFooterRC } from '@react-components/components';
 import { PreFooterProps } from '@react-components/types';
 
@@ -8,7 +8,7 @@ const makePreFooterProps = ({
   background,
   ctaButtons,
   ...rest
-}: PreFooterSection): PreFooterProps => ({
+}: PreFooterAttributes): PreFooterProps => ({
   ...(background.data && { background: background.data.attributes.url }),
   ...(storeButtons && {
     storeButtons: {
@@ -20,7 +20,7 @@ const makePreFooterProps = ({
   ...rest,
 });
 
-const PreFooter = (props: PreFooterSection) => (
+const PreFooter = (props: PreFooterAttributes) => (
   <PreFooterRC {...makePreFooterProps(props)} />
 );
 

--- a/apps/nextjs-website/src/lib/api.ts
+++ b/apps/nextjs-website/src/lib/api.ts
@@ -10,6 +10,7 @@ import { SiteWideSEO, fetchSiteWideSEO } from './fetch/siteWideSEO';
 import { PageIDs, fetchAllPageIDs, fetchPageFromID } from './fetch/preview';
 import { PageSection } from './fetch/types/PageSection';
 import { removeHomepageSlugFromMenu } from './header';
+import { getPreFooter, PreFooterAttributes } from './fetch/preFooter';
 
 // create AppEnv given process env
 const appEnv = pipe(
@@ -67,6 +68,12 @@ export const getFooterProps = async (): Promise<
   } = await getFooter(appEnv);
   return attributes;
 };
+
+export const getPreFooterProps =
+  async (): Promise<PreFooterAttributes | null> => {
+    const { data } = await getPreFooter(appEnv);
+    return data?.attributes ?? null;
+  };
 
 // Return PageProps given the page path
 export const getPageProps = async (

--- a/apps/nextjs-website/src/lib/fetch/__tests__/preFooter.test.ts
+++ b/apps/nextjs-website/src/lib/fetch/__tests__/preFooter.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi } from 'vitest';
+import { getPreFooter } from '../preFooter';
+import { Config } from '@/AppEnv';
+
+const makeTestAppEnv = () => {
+  const config: Config = {
+    DEMO_STRAPI_API_TOKEN: 'demoStrapiToken',
+    DEMO_STRAPI_API_BASE_URL: 'demoStrapiApiBaseUrl',
+    SEND_STRAPI_API_BASE_URL: 'sendStrapiToken',
+    SEND_STRAPI_API_TOKEN: 'sendStrapiApiBaseUrl',
+    APPIO_STRAPI_API_BASE_URL: 'appioStrapiToken',
+    APPIO_STRAPI_API_TOKEN: 'appioStrapiApiBaseUrl',
+    FIRMA_STRAPI_API_BASE_URL: 'firmaStrapiToken',
+    FIRMA_STRAPI_API_TOKEN: 'firmaStrapiApiBaseUrl',
+    INTEROP_STRAPI_API_BASE_URL: 'interopStrapiToken',
+    INTEROP_STRAPI_API_TOKEN: 'interopStrapiApiBaseUrl',
+    ENVIRONMENT: 'demo',
+    PREVIEW_MODE: undefined,
+    PREVIEW_TOKEN: undefined,
+  };
+  const fetchMock = vi.fn(fetch);
+  const appEnv = { config, fetchFun: fetchMock };
+  return { appEnv, fetchMock };
+};
+
+// Response example for getPreFooter
+const preFooterResponse = {
+  data: {
+    id: 1,
+    attributes: {
+      title: 'Titolo Pre Footer Senza Bottoni',
+      theme: 'dark',
+      layout: 'center',
+      createdAt: '2024-10-10T15:56:53.564Z',
+      updatedAt: '2024-10-10T16:19:54.516Z',
+      background: { data: null },
+      ctaButtons: [
+        {
+          id: 15,
+          text: 'Bottone Primario',
+          href: '#',
+          variant: 'contained',
+          icon: null,
+          size: 'medium',
+        },
+        {
+          id: 14,
+          text: 'Bottone Secondario',
+          href: '#',
+          variant: 'outlined',
+          icon: null,
+          size: 'medium',
+        },
+      ],
+      storeButtons: {
+        id: 3,
+        hrefGoogle: '#',
+        hrefApple: '#',
+      },
+      exclude: {
+        data: [
+          {
+            id: 18,
+            attributes: {
+              slug: 'test',
+              createdAt: '2024-10-10T15:57:27.916Z',
+              updatedAt: '2024-10-10T15:57:36.790Z',
+              publishedAt: '2024-10-10T15:57:36.779Z',
+            },
+          },
+        ],
+      },
+    },
+  },
+};
+
+const emptyPreFooterResponse = {
+  data: null,
+};
+
+const preFooterResponseAfterCodec = {
+  data: {
+    attributes: {
+      title: 'Titolo Pre Footer Senza Bottoni',
+      theme: 'dark',
+      layout: 'center',
+      background: { data: null },
+      ctaButtons: [
+        {
+          text: 'Bottone Primario',
+          href: '#',
+          variant: 'contained',
+          icon: null,
+          size: 'medium',
+        },
+        {
+          text: 'Bottone Secondario',
+          href: '#',
+          variant: 'outlined',
+          icon: null,
+          size: 'medium',
+        },
+      ],
+      storeButtons: {
+        hrefGoogle: '#',
+        hrefApple: '#',
+      },
+      exclude: { data: [{ attributes: { slug: 'test' } }] },
+    },
+  },
+};
+
+describe('getPreFooter', () => {
+  it('should call /api/pre-footer type GET based on tenant', async () => {
+    const { appEnv, fetchMock } = makeTestAppEnv();
+    const { config } = appEnv;
+
+    fetchMock.mockResolvedValueOnce({
+      json: () => Promise.resolve(preFooterResponse),
+    } as unknown as Response);
+
+    await getPreFooter(appEnv);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${config.DEMO_STRAPI_API_BASE_URL}/api/pre-footer/?populate=background,ctaButtons,storeButtons,exclude`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${config.DEMO_STRAPI_API_TOKEN}`,
+        },
+      }
+    );
+  });
+
+  it('should parse preFooter response without error', async () => {
+    const { appEnv, fetchMock } = makeTestAppEnv();
+
+    fetchMock.mockResolvedValueOnce({
+      json: () => Promise.resolve(preFooterResponse),
+    } as unknown as Response);
+
+    const actual = getPreFooter(appEnv);
+
+    // Use preFooterResponse directly as the expected value
+    expect(await actual).toStrictEqual(preFooterResponseAfterCodec);
+  });
+
+  it('should allow for preFooter data to be null', async () => {
+    const { appEnv, fetchMock } = makeTestAppEnv();
+
+    fetchMock.mockResolvedValueOnce({
+      json: () => Promise.resolve(emptyPreFooterResponse),
+    } as unknown as Response);
+
+    const actual = getPreFooter(appEnv);
+
+    // Use preFooterResponse directly as the expected value
+    expect(await actual).toStrictEqual({ data: null });
+  });
+});

--- a/apps/nextjs-website/src/lib/fetch/preFooter.ts
+++ b/apps/nextjs-website/src/lib/fetch/preFooter.ts
@@ -7,7 +7,11 @@ import { StrapiImageSchema } from './types/StrapiImage';
 import { CTAButtonSimpleCodec } from './types/CTAButton';
 import { AppEnv } from '@/AppEnv';
 
-// TODO: Add tests for PreFooter
+const PageRelationCodec = t.strict({
+  attributes: t.strict({
+    slug: t.string,
+  }),
+});
 
 const PreFooterAttributesCodec = t.strict({
   title: t.string,
@@ -19,7 +23,9 @@ const PreFooterAttributesCodec = t.strict({
   background: StrapiImageSchema,
   ctaButtons: t.array(CTAButtonSimpleCodec),
   storeButtons: t.union([StoreButtonsCodec, t.null]),
-  // TODO: Implement "exclude" field
+  exclude: t.strict({
+    data: t.array(PageRelationCodec),
+  }),
 });
 
 const PreFooterDataCodec = t.strict({
@@ -42,7 +48,7 @@ export const getPreFooter = ({
     fetchFun(
       `${
         extractTenantStrapiApiData(config).baseUrl
-      }/api/pre-footer/?populate=background,ctaButtons,storeButtons`,
+      }/api/pre-footer/?populate=background,ctaButtons,storeButtons,exclude`,
       {
         method: 'GET',
         headers: {

--- a/apps/nextjs-website/src/lib/fetch/preFooter.ts
+++ b/apps/nextjs-website/src/lib/fetch/preFooter.ts
@@ -1,0 +1,54 @@
+import * as t from 'io-ts';
+import { extractFromResponse } from './extractFromResponse';
+import { extractTenantStrapiApiData } from './tenantApiData';
+import { ThemeCodec } from './types/Theme';
+import { StoreButtonsCodec } from './types/StoreButtons';
+import { StrapiImageSchema } from './types/StrapiImage';
+import { CTAButtonSimpleCodec } from './types/CTAButton';
+import { AppEnv } from '@/AppEnv';
+
+// TODO: Add tests for PreFooter
+
+const PreFooterAttributesCodec = t.strict({
+  title: t.string,
+  theme: ThemeCodec,
+  layout: t.keyof({
+    left: null,
+    center: null,
+  }),
+  background: StrapiImageSchema,
+  ctaButtons: t.array(CTAButtonSimpleCodec),
+  storeButtons: t.union([StoreButtonsCodec, t.null]),
+  // TODO: Implement "exclude" field
+});
+
+const PreFooterDataCodec = t.strict({
+  data: t.union([
+    t.null,
+    t.strict({
+      attributes: PreFooterAttributesCodec,
+    }),
+  ]),
+});
+
+type PreFooterData = t.TypeOf<typeof PreFooterDataCodec>;
+export type PreFooterAttributes = t.TypeOf<typeof PreFooterAttributesCodec>;
+
+export const getPreFooter = ({
+  config,
+  fetchFun,
+}: AppEnv): Promise<PreFooterData> =>
+  extractFromResponse(
+    fetchFun(
+      `${
+        extractTenantStrapiApiData(config).baseUrl
+      }/api/pre-footer/?populate=background,ctaButtons,storeButtons`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${extractTenantStrapiApiData(config).token}`,
+        },
+      }
+    ),
+    PreFooterDataCodec
+  );

--- a/apps/nextjs-website/src/lib/fetch/types/PageSection.ts
+++ b/apps/nextjs-website/src/lib/fetch/types/PageSection.ts
@@ -202,16 +202,6 @@ const FormSectionCodec = t.strict({
   notes: t.union([t.string, t.null]),
 });
 
-const PreFooterSectionCodec = t.strict({
-  __component: t.literal('sections.pre-footer'),
-  title: t.string,
-  theme: t.union([t.literal('light'), t.literal('dark')]),
-  storeButtons: t.union([StoreButtonsCodec, t.null]),
-  background: StrapiImageSchema,
-  sectionID: t.union([t.string, t.null]),
-  ctaButtons: t.array(CTAButtonSimpleCodec),
-});
-
 const CounterCodec = t.strict({
   number: t.number,
   text: t.string,
@@ -409,7 +399,6 @@ export const PageSectionCodec = t.union([
   OneTrustSectionPropsCodec,
   IFrameSectionCodec,
   FormSectionCodec,
-  PreFooterSectionCodec,
   HeroCounterSectionCodec,
   EditorialSwitchSectionCodec,
   VideoImageSectionCodec,
@@ -435,7 +424,6 @@ export type CardsSection = t.TypeOf<typeof CardsSectionCodec>;
 export type OneTrustSectionProps = t.TypeOf<typeof OneTrustSectionPropsCodec>;
 export type IFrameSectionProps = t.TypeOf<typeof IFrameSectionCodec>;
 export type FormSection = t.TypeOf<typeof FormSectionCodec>;
-export type PreFooterSection = t.TypeOf<typeof PreFooterSectionCodec>;
 export type HeroCounterSection = t.TypeOf<typeof HeroCounterSectionCodec>;
 export type EditorialSwitchSection = t.TypeOf<
   typeof EditorialSwitchSectionCodec

--- a/apps/strapi-cms/src/api/pre-footer/content-types/pre-footer/schema.json
+++ b/apps/strapi-cms/src/api/pre-footer/content-types/pre-footer/schema.json
@@ -1,0 +1,62 @@
+{
+  "kind": "singleType",
+  "collectionName": "pre_footers",
+  "info": {
+    "singularName": "pre-footer",
+    "pluralName": "pre-footers",
+    "displayName": "PreFooter",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "theme": {
+      "type": "enumeration",
+      "enum": [
+        "light",
+        "dark"
+      ],
+      "required": true,
+      "default": "light"
+    },
+    "layout": {
+      "type": "enumeration",
+      "enum": [
+        "left",
+        "center"
+      ],
+      "required": true,
+      "default": "left"
+    },
+    "background": {
+      "type": "media",
+      "multiple": false,
+      "required": false,
+      "allowedTypes": [
+        "images"
+      ]
+    },
+    "ctaButtons": {
+      "type": "component",
+      "repeatable": true,
+      "component": "components.cta-button-simple",
+      "required": false
+    },
+    "storeButtons": {
+      "type": "component",
+      "repeatable": false,
+      "component": "components.store-buttons"
+    },
+    "exclude": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::page.page"
+    }
+  }
+}

--- a/apps/strapi-cms/src/api/pre-footer/controllers/pre-footer.ts
+++ b/apps/strapi-cms/src/api/pre-footer/controllers/pre-footer.ts
@@ -1,0 +1,7 @@
+/**
+ * pre-footer controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::pre-footer.pre-footer');

--- a/apps/strapi-cms/src/api/pre-footer/routes/pre-footer.ts
+++ b/apps/strapi-cms/src/api/pre-footer/routes/pre-footer.ts
@@ -1,0 +1,7 @@
+/**
+ * pre-footer router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::pre-footer.pre-footer');

--- a/apps/strapi-cms/src/api/pre-footer/services/pre-footer.ts
+++ b/apps/strapi-cms/src/api/pre-footer/services/pre-footer.ts
@@ -1,0 +1,7 @@
+/**
+ * pre-footer service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::pre-footer.pre-footer');


### PR DESCRIPTION
As per title.

#### List of Changes
<!--- Describe your changes in detail -->
- Add `PreFooter` Single Type to Strapi
- In NextJS, convert PreFooter component to site-wide component
- Add field `exclude` to conditionally render PreFooter only on not-excluded pages

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
New component

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran locally in dev (being a site-wide component, PreFooter won't show in preview)

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
