### PR TITLE
[B2BP-1003] Implement themeVariant in Strapi and setup NextJS

### DIFF
--- a/.changeset/rich-jokes-tickle.md
+++ b/.changeset/rich-jokes-tickle.md
@@ -1,0 +1,6 @@
+---
+"nextjs-website": patch
+"strapi-cms": patch
+---
+
+Implement themeVariant (IO/SEND)

--- a/apps/nextjs-website/react-components/components/Hero/Hero.tsx
+++ b/apps/nextjs-website/react-components/components/Hero/Hero.tsx
@@ -17,7 +17,11 @@ const Hero = (props: HeroProps) => {
     image,
     altText = '',
     sectionID,
+    themeVariant,
   } = props;
+
+  // TODO: Substitute this console.log with themeVariant use logic
+  console.log(themeVariant);
 
   const minHeight = getMinHeight(size);
   const overlay = getOverlay(useHoverlay, theme);

--- a/apps/nextjs-website/react-components/components/VideoImage/VideoImage.helpers.tsx
+++ b/apps/nextjs-website/react-components/components/VideoImage/VideoImage.helpers.tsx
@@ -144,37 +144,6 @@ export const ImageText = ({
   return (
     <>
       {title && (
-        <Typography variant="h5" mb={4} color={textColor}>
-          {title}
-        </Typography>
-      )}
-      {subtitle && (
-        <Typography
-          paragraph
-          sx={{ fontSize: '16px' }}
-          mb={3}
-          color={textColor}
-        >
-          {subtitle}
-        </Typography>
-      )}
-    </>
-  );
-};
-
-export const ImageText = ({
-  title,
-  subtitle,
-  theme = 'dark',
-}: {
-  title?: string;
-  subtitle?: string;
-  theme: 'dark' | 'light';
-}) => {
-  const textColor = TextColor(theme);
-  return (
-    <>
-      {title && (
         <Typography variant='h5' mb={4} color={textColor}>
           {title}
         </Typography>

--- a/apps/nextjs-website/react-components/types/common/Common.types.ts
+++ b/apps/nextjs-website/react-components/types/common/Common.types.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 import { type ButtonProps } from '@mui/material';
+import { ThemeVariant } from '@/lib/fetch/siteWideSEO';
 
 export type Theme = Readonly<'dark' | 'light'>;
 
@@ -10,8 +11,9 @@ export type Theme = Readonly<'dark' | 'light'>;
 export type Generic = JSX.Element;
 
 export interface SectionProps {
-  readonly theme: Theme;
   readonly sectionID: string | null;
+  readonly theme: Theme;
+  readonly themeVariant: ThemeVariant;
 }
 
 /**

--- a/apps/nextjs-website/src/app/[[...slug]]/page.tsx
+++ b/apps/nextjs-website/src/app/[[...slug]]/page.tsx
@@ -82,6 +82,7 @@ const Page = async ({ params }: PageParams) => {
   }
 
   const sections = pageProps.sections;
+  const { themeVariant } = await getSiteWideSEO();
 
   return (
     <main>
@@ -93,7 +94,7 @@ const Page = async ({ params }: PageParams) => {
           }}
         />
       )}
-      {sections.map(PageSection)}
+      {sections.map((section) => PageSection({ ...section, themeVariant }))}
     </main>
   );
 };

--- a/apps/nextjs-website/src/app/preview/page.tsx
+++ b/apps/nextjs-website/src/app/preview/page.tsx
@@ -4,8 +4,23 @@ import {
   getAllPageIDs,
   getPageSectionsFromID,
   getPreviewToken,
+  getSiteWideSEO,
   isPreviewMode,
 } from '@/lib/api';
+import { ThemeVariant } from '@/lib/fetch/siteWideSEO';
+
+// Fetch themeVariant from General
+// Default to 'SEND' if General isn't present
+const GetThemeVariantForPreview = async (): Promise<ThemeVariant> => {
+  // Disable eslint because making the preview work when General has not been filled by the CMS user is more important
+  // eslint-disable-next-line functional/no-try-statements
+  try {
+    const { themeVariant } = await getSiteWideSEO();
+    return themeVariant;
+  } catch {
+    return 'SEND';
+  }
+};
 
 const PreviewPage = async ({
   searchParams,
@@ -39,8 +54,13 @@ const PreviewPage = async ({
   }
 
   const sections = await getPageSectionsFromID(tenant, pageID);
+  const themeVariant = await GetThemeVariantForPreview();
 
-  return <div>{sections.map(PageSection)}</div>;
+  return (
+    <div>
+      {sections.map((section) => PageSection({ ...section, themeVariant }))}
+    </div>
+  );
 };
 
 export default PreviewPage;

--- a/apps/nextjs-website/src/components/Accordion.tsx
+++ b/apps/nextjs-website/src/components/Accordion.tsx
@@ -4,6 +4,7 @@ import MarkdownRenderer from './MarkdownRenderer';
 import { Accordion as AccordionRC } from '@react-components/components';
 import { AccordionProps } from '@react-components/types';
 import { AccordionSection } from '@/lib/fetch/types/PageSection';
+import { ThemeVariant } from '@/lib/fetch/siteWideSEO';
 
 const makeAccordionProps = ({
   subtitle,
@@ -11,7 +12,7 @@ const makeAccordionProps = ({
   accordionItems,
   textAlignment,
   ...rest
-}: AccordionSection): AccordionProps => ({
+}: AccordionSection & { themeVariant: ThemeVariant }): AccordionProps => ({
   ...(subtitle && { subtitle }),
   ...(description && {
     description: MarkdownRenderer({ markdown: description, variant: 'body2' }),
@@ -25,8 +26,8 @@ const makeAccordionProps = ({
   ...rest,
 });
 
-const Accordion = (props: AccordionSection) => (
-  <AccordionRC {...makeAccordionProps(props)} />
-);
+const Accordion = (
+  props: AccordionSection & { themeVariant: ThemeVariant }
+) => <AccordionRC {...makeAccordionProps(props)} />;
 
 export default Accordion;

--- a/apps/nextjs-website/src/components/BannerLink.tsx
+++ b/apps/nextjs-website/src/components/BannerLink.tsx
@@ -3,11 +3,12 @@ import MarkdownRenderer from './MarkdownRenderer';
 import { BannerLink as BannerLinkRC } from '@react-components/components';
 import { BannerLinkProps } from '@react-components/types/BannerLink/BannerLink.types';
 import { BannerLinkSection } from '@/lib/fetch/types/PageSection';
+import { ThemeVariant } from '@/lib/fetch/siteWideSEO';
 
 export const makeBannerLinkProps = ({
   sections,
   ...rest
-}: BannerLinkSection): BannerLinkProps => ({
+}: BannerLinkSection & { themeVariant: ThemeVariant }): BannerLinkProps => ({
   sections: sections.map(({ body, icon, ctaButtons, ...requiredFields }) => ({
     ...requiredFields,
     body: MarkdownRenderer({ markdown: body, variant: 'body2' }),
@@ -19,8 +20,8 @@ export const makeBannerLinkProps = ({
   ...rest,
 });
 
-const BannerLink = (props: BannerLinkSection) => (
-  <BannerLinkRC {...makeBannerLinkProps(props)} />
-);
+const BannerLink = (
+  props: BannerLinkSection & { themeVariant: ThemeVariant }
+) => <BannerLinkRC {...makeBannerLinkProps(props)} />;
 
 export default BannerLink;

--- a/apps/nextjs-website/src/components/Cards.tsx
+++ b/apps/nextjs-website/src/components/Cards.tsx
@@ -4,6 +4,7 @@ import Icon from './Icon';
 import { Cards as CardsRC } from '@react-components/components';
 import { CardsProps } from '@react-components/types';
 import { CardsSection } from '@/lib/fetch/types/PageSection';
+import { ThemeVariant } from '@/lib/fetch/siteWideSEO';
 
 export const makeCardsProps = ({
   items,
@@ -12,7 +13,7 @@ export const makeCardsProps = ({
   body,
   ctaButtons,
   ...rest
-}: CardsSection): CardsProps => ({
+}: CardsSection & { themeVariant: ThemeVariant }): CardsProps => ({
   text: {
     title,
     ...(subtitle && { subtitle }),
@@ -39,6 +40,8 @@ export const makeCardsProps = ({
   ...rest,
 });
 
-const Cards = (props: CardsSection) => <CardsRC {...makeCardsProps(props)} />;
+const Cards = (props: CardsSection & { themeVariant: ThemeVariant }) => (
+  <CardsRC {...makeCardsProps(props)} />
+);
 
 export default Cards;

--- a/apps/nextjs-website/src/components/Editorial.tsx
+++ b/apps/nextjs-website/src/components/Editorial.tsx
@@ -5,6 +5,7 @@ import { Editorial as EditorialRC } from '@react-components/components';
 import { EditorialProps } from '@react-components/types';
 import { EditorialSection } from '@/lib/fetch/types/PageSection';
 import Icon from '@/components/Icon';
+import { ThemeVariant } from '@/lib/fetch/siteWideSEO';
 
 export const makeEditorialProps = ({
   eyelet,
@@ -14,7 +15,7 @@ export const makeEditorialProps = ({
   ctaButtons,
   storeButtons,
   ...rest
-}: EditorialSection): EditorialProps => ({
+}: EditorialSection & { themeVariant: ThemeVariant }): EditorialProps => ({
   ...(eyelet && { eyelet }),
   body: MarkdownRenderer({ markdown: body, variant: 'body2' }),
   image: (
@@ -49,8 +50,8 @@ export const makeEditorialProps = ({
   ...rest,
 });
 
-const Editorial = (props: EditorialSection) => (
-  <EditorialRC {...makeEditorialProps(props)} />
-);
+const Editorial = (
+  props: EditorialSection & { themeVariant: ThemeVariant }
+) => <EditorialRC {...makeEditorialProps(props)} />;
 
 export default Editorial;

--- a/apps/nextjs-website/src/components/EditorialSwitch.tsx
+++ b/apps/nextjs-website/src/components/EditorialSwitch.tsx
@@ -5,25 +5,29 @@ import MarkdownRenderer from './MarkdownRenderer';
 import { EditorialSwitch as EditorialSwitchRC } from '@react-components/components';
 import { EditorialSwitchProps } from '@react-components/types';
 import { EditorialSwitchSection } from '@/lib/fetch/types/PageSection';
+import { ThemeVariant } from '@/lib/fetch/siteWideSEO';
 
 const makeEditorialSwitchProps = ({
   subtitle,
   sections,
   ...rest
-}: EditorialSwitchSection): EditorialSwitchProps => ({
+}: EditorialSwitchSection & {
+  themeVariant: ThemeVariant;
+}): EditorialSwitchProps => ({
   ...(subtitle && { subtitle: MarkdownRenderer({ markdown: subtitle }) }),
   sections: sections.map(({ content, ...section }) => ({
     ...section,
     content: makeEditorialProps({
       __component: 'sections.editorial',
       ...content,
+      themeVariant: rest.themeVariant,
     }),
   })),
   ...rest,
 });
 
-const EditorialSwitch = (props: EditorialSwitchSection) => (
-  <EditorialSwitchRC {...makeEditorialSwitchProps(props)} />
-);
+const EditorialSwitch = (
+  props: EditorialSwitchSection & { themeVariant: ThemeVariant }
+) => <EditorialSwitchRC {...makeEditorialSwitchProps(props)} />;
 
 export default EditorialSwitch;

--- a/apps/nextjs-website/src/components/Feature.tsx
+++ b/apps/nextjs-website/src/components/Feature.tsx
@@ -2,11 +2,12 @@
 import { Feature as FeatureRC } from '@react-components/components';
 import { FeatureProps } from '@react-components/types';
 import { FeatureSection } from '@/lib/fetch/types/PageSection';
+import { ThemeVariant } from '@/lib/fetch/siteWideSEO';
 
 const makeFeatureProps = ({
   items,
   ...rest
-}: FeatureSection): FeatureProps => ({
+}: FeatureSection & { themeVariant: ThemeVariant }): FeatureProps => ({
   items: items.map((item) => ({
     title: item.title,
     subtitle: item.subtitle,
@@ -16,7 +17,7 @@ const makeFeatureProps = ({
   ...rest,
 });
 
-const Feature = (props: FeatureSection) => (
+const Feature = (props: FeatureSection & { themeVariant: ThemeVariant }) => (
   <FeatureRC {...makeFeatureProps(props)} />
 );
 

--- a/apps/nextjs-website/src/components/Form.tsx
+++ b/apps/nextjs-website/src/components/Form.tsx
@@ -3,6 +3,7 @@ import MarkdownRenderer from './MarkdownRenderer';
 import { Form as FormRC } from '@react-components/components';
 import { FormProps } from '@react-components/types';
 import { FormSection } from '@/lib/fetch/types/PageSection';
+import { ThemeVariant } from '@/lib/fetch/siteWideSEO';
 
 const makeFormProps = ({
   subtitle,
@@ -12,7 +13,7 @@ const makeFormProps = ({
   notes,
   background,
   ...rest
-}: FormSection): FormProps => ({
+}: FormSection & { themeVariant: ThemeVariant }): FormProps => ({
   categories: categories.map(({ additionalInfo, ...category }) => ({
     ...(additionalInfo && { additionalInfo }),
     ...category,
@@ -25,6 +26,8 @@ const makeFormProps = ({
   ...rest,
 });
 
-const Form = (props: FormSection) => <FormRC {...makeFormProps(props)} />;
+const Form = (props: FormSection & { themeVariant: ThemeVariant }) => (
+  <FormRC {...makeFormProps(props)} />
+);
 
 export default Form;

--- a/apps/nextjs-website/src/components/FramedVideo.tsx
+++ b/apps/nextjs-website/src/components/FramedVideo.tsx
@@ -2,21 +2,22 @@
 import { FramedVideo as FramedVideoRC } from '@react-components/components';
 import { FramedVideoProps } from '@react-components/types';
 import { FramedVideoSection } from '@/lib/fetch/types/PageSection';
+import { ThemeVariant } from '@/lib/fetch/siteWideSEO';
 
 const makeFramedVideoProps = ({
   videoURL,
   video,
   text,
   ...rest
-}: FramedVideoSection): FramedVideoProps => ({
+}: FramedVideoSection & { themeVariant: ThemeVariant }): FramedVideoProps => ({
   ...(videoURL && { videoURL }),
   ...(video.data && { videoURL: video.data.attributes.url }),
   ...(text && { text }),
   ...rest,
 });
 
-const FramedVideo = (props: FramedVideoSection) => (
-  <FramedVideoRC {...makeFramedVideoProps(props)} />
-);
+const FramedVideo = (
+  props: FramedVideoSection & { themeVariant: ThemeVariant }
+) => <FramedVideoRC {...makeFramedVideoProps(props)} />;
 
 export default FramedVideo;

--- a/apps/nextjs-website/src/components/Hero.tsx
+++ b/apps/nextjs-website/src/components/Hero.tsx
@@ -4,6 +4,7 @@ import { Hero as HeroRC } from '@react-components/components';
 import { HeroProps } from '@react-components/types';
 import { HeroSection } from '@/lib/fetch/types/PageSection';
 import Icon from '@/components/Icon';
+import { ThemeVariant } from '@/lib/fetch/siteWideSEO';
 
 const makeHeroProps = ({
   subtitle,
@@ -13,7 +14,7 @@ const makeHeroProps = ({
   storeButtons,
   link,
   ...rest
-}: HeroSection): HeroProps => ({
+}: HeroSection & { themeVariant: ThemeVariant }): HeroProps => ({
   ...rest,
   useHoverlay: false,
   ...(subtitle && { subtitle: MarkdownRenderer({ markdown: subtitle }) }),
@@ -39,6 +40,8 @@ const makeHeroProps = ({
   ...(link && { link }),
 });
 
-const Hero = (props: HeroSection) => <HeroRC {...makeHeroProps(props)} />;
+const Hero = (props: HeroSection & { themeVariant: ThemeVariant }) => (
+  <HeroRC {...makeHeroProps(props)} />
+);
 
 export default Hero;

--- a/apps/nextjs-website/src/components/HeroChips.tsx
+++ b/apps/nextjs-website/src/components/HeroChips.tsx
@@ -3,12 +3,13 @@ import MarkdownRenderer from './MarkdownRenderer';
 import { HeroChips as HeroChipsRC } from '@react-components/components';
 import { HeroChipsProps } from '@react-components/types';
 import { HeroChipsSection } from '@/lib/fetch/types/PageSection';
+import { ThemeVariant } from '@/lib/fetch/siteWideSEO';
 
 const makeHeroChipsProps = ({
   subtitle,
   background,
   ...rest
-}: HeroChipsSection): HeroChipsProps => ({
+}: HeroChipsSection & { themeVariant: ThemeVariant }): HeroChipsProps => ({
   ...rest,
   ...(subtitle && { subtitle: MarkdownRenderer({ markdown: subtitle }) }),
   ...(background.data && { background: background.data.attributes.url }),
@@ -16,8 +17,8 @@ const makeHeroChipsProps = ({
   // TODO: implement chips
 });
 
-const HeroChips = (props: HeroChipsSection) => (
-  <HeroChipsRC {...makeHeroChipsProps(props)} />
-);
+const HeroChips = (
+  props: HeroChipsSection & { themeVariant: ThemeVariant }
+) => <HeroChipsRC {...makeHeroChipsProps(props)} />;
 
 export default HeroChips;

--- a/apps/nextjs-website/src/components/HeroCounter.tsx
+++ b/apps/nextjs-website/src/components/HeroCounter.tsx
@@ -3,21 +3,22 @@ import MarkdownRenderer from './MarkdownRenderer';
 import { HeroCounter as HeroCounterRC } from '@react-components/components';
 import { HeroCounterProps } from '@react-components/types';
 import { HeroCounterSection } from '@/lib/fetch/types/PageSection';
+import { ThemeVariant } from '@/lib/fetch/siteWideSEO';
 
 const makeHeroCounterProps = ({
   subtitle,
   background,
   link,
   ...rest
-}: HeroCounterSection): HeroCounterProps => ({
+}: HeroCounterSection & { themeVariant: ThemeVariant }): HeroCounterProps => ({
   ...rest,
   ...(subtitle && { subtitle: MarkdownRenderer({ markdown: subtitle }) }),
   ...(background.data && { background: background.data.attributes.url }),
   ...(link && { link }),
 });
 
-const HeroCounter = (props: HeroCounterSection) => (
-  <HeroCounterRC {...makeHeroCounterProps(props)} />
-);
+const HeroCounter = (
+  props: HeroCounterSection & { themeVariant: ThemeVariant }
+) => <HeroCounterRC {...makeHeroCounterProps(props)} />;
 
 export default HeroCounter;

--- a/apps/nextjs-website/src/components/HowTo.tsx
+++ b/apps/nextjs-website/src/components/HowTo.tsx
@@ -3,12 +3,13 @@ import MarkdownRenderer from './MarkdownRenderer';
 import { HowTo as HowToRC } from '@react-components/components';
 import { HowToProps } from '@react-components/types';
 import { HowToSection } from '@/lib/fetch/types/PageSection';
+import { ThemeVariant } from '@/lib/fetch/siteWideSEO';
 
 const makeHowToProps = ({
   link,
   steps,
   ...rest
-}: HowToSection): HowToProps => ({
+}: HowToSection & { themeVariant: ThemeVariant }): HowToProps => ({
   ...(link && { link }),
   steps: steps.map((step) => ({
     title: step.title,
@@ -20,6 +21,8 @@ const makeHowToProps = ({
   ...rest,
 });
 
-const HowTo = (props: HowToSection) => <HowToRC {...makeHowToProps(props)} />;
+const HowTo = (props: HowToSection & { themeVariant: ThemeVariant }) => (
+  <HowToRC {...makeHowToProps(props)} />
+);
 
 export default HowTo;

--- a/apps/nextjs-website/src/components/PageSection/PageSection.tsx
+++ b/apps/nextjs-website/src/components/PageSection/PageSection.tsx
@@ -22,8 +22,11 @@ import TextSection from '../TextSection';
 import PageSwitch from '../PageSwitch';
 import FramedVideo from '../FramedVideo';
 import { PageSection as PageSectionData } from '@/lib/fetch/types/PageSection';
+import { ThemeVariant } from '@/lib/fetch/siteWideSEO';
 // eslint-disable-next-line complexity
-const PageSection = (props: PageSectionData) => {
+const PageSection = (
+  props: PageSectionData & { themeVariant: ThemeVariant }
+) => {
   // eslint-disable-next-line no-underscore-dangle
   switch (props.__component) {
     case 'sections.hero':

--- a/apps/nextjs-website/src/components/PageSwitch.tsx
+++ b/apps/nextjs-website/src/components/PageSwitch.tsx
@@ -7,12 +7,14 @@ import MarkdownRenderer from './MarkdownRenderer';
 import { PageSwitch as PageSwitchRC } from '@react-components/components';
 import { PageSwitchProps } from '@react-components/types';
 import { PageSwitchSection } from '@/lib/fetch/types/PageSection';
+import { ThemeVariant } from '@/lib/fetch/siteWideSEO';
 
 const makePageSwitchProps = ({
   subtitle,
   sections,
+  themeVariant,
   ...rest
-}: PageSwitchSection): PageSwitchProps => ({
+}: PageSwitchSection & { themeVariant: ThemeVariant }): PageSwitchProps => ({
   ...(subtitle && { subtitle: MarkdownRenderer({ markdown: subtitle }) }),
   sections: sections.map((section) => ({
     id: section.id,
@@ -23,17 +25,17 @@ const makePageSwitchProps = ({
         case 'sections.editorial':
           return {
             type: 'Editorial',
-            props: makeEditorialProps(props),
+            props: makeEditorialProps({ ...props, themeVariant }),
           };
         case 'sections.cards':
           return {
             type: 'Cards',
-            props: makeCardsProps(props),
+            props: makeCardsProps({ ...props, themeVariant }),
           };
         case 'sections.banner-link':
           return {
             type: 'BannerLink',
-            props: makeBannerLinkProps(props),
+            props: makeBannerLinkProps({ ...props, themeVariant }),
           };
       }
     }),
@@ -41,8 +43,8 @@ const makePageSwitchProps = ({
   ...rest,
 });
 
-const PageSwitch = (props: PageSwitchSection) => (
-  <PageSwitchRC {...makePageSwitchProps(props)} />
-);
+const PageSwitch = (
+  props: PageSwitchSection & { themeVariant: ThemeVariant }
+) => <PageSwitchRC {...makePageSwitchProps(props)} />;
 
 export default PageSwitch;

--- a/apps/nextjs-website/src/components/ServiceCarousel.tsx
+++ b/apps/nextjs-website/src/components/ServiceCarousel.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { ThemeVariant } from '@/lib/fetch/siteWideSEO';
 import { ServiceCarouselSection } from '@/lib/fetch/types/PageSection';
 import { ServiceCarousel as ServiceCarouselRC } from '@react-components/components';
 import { ServiceCarouselProps } from '@react-components/types';
@@ -8,7 +9,9 @@ const makeServiceCarouselProps = ({
   description,
   cards,
   ...rest
-}: ServiceCarouselSection): ServiceCarouselProps => ({
+}: ServiceCarouselSection & {
+  themeVariant: ThemeVariant;
+}): ServiceCarouselProps => ({
   ...rest,
   ...(eyelet && { eyelet }),
   ...(description && { description }),
@@ -20,8 +23,8 @@ const makeServiceCarouselProps = ({
   })),
 });
 
-const ServiceCarousel = (props: ServiceCarouselSection) => (
-  <ServiceCarouselRC {...makeServiceCarouselProps(props)} />
-);
+const ServiceCarousel = (
+  props: ServiceCarouselSection & { themeVariant: ThemeVariant }
+) => <ServiceCarouselRC {...makeServiceCarouselProps(props)} />;
 
 export default ServiceCarousel;

--- a/apps/nextjs-website/src/components/Stats.tsx
+++ b/apps/nextjs-website/src/components/Stats.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { ThemeVariant } from '@/lib/fetch/siteWideSEO';
 import { StatsSection } from '@/lib/fetch/types/PageSection';
 import { Stats as StatsRC } from '@react-components/components';
 import { StatsProps } from '@react-components/types';
@@ -8,7 +9,7 @@ const makeStatsProps = ({
   body,
   items,
   ...rest
-}: StatsSection): StatsProps => ({
+}: StatsSection & { themeVariant: ThemeVariant }): StatsProps => ({
   ...(eyelet && { eyelet }),
   ...(body && { body }),
   items: items.map((item) => ({
@@ -19,6 +20,8 @@ const makeStatsProps = ({
   ...rest,
 });
 
-const Stats = (props: StatsSection) => <StatsRC {...makeStatsProps(props)} />;
+const Stats = (props: StatsSection & { themeVariant: ThemeVariant }) => (
+  <StatsRC {...makeStatsProps(props)} />
+);
 
 export default Stats;

--- a/apps/nextjs-website/src/components/StripeLink.tsx
+++ b/apps/nextjs-website/src/components/StripeLink.tsx
@@ -3,13 +3,14 @@ import MarkdownRenderer from './MarkdownRenderer';
 import { StripeLink as StripeLinkRC } from '@react-components/components';
 import { StripeLinkProps } from '@react-components/types';
 import { StripeLinkSection } from '@/lib/fetch/types/PageSection';
+import { ThemeVariant } from '@/lib/fetch/siteWideSEO';
 
 const makeStripeLinkProps = ({
   subtitle,
   icon,
   link,
   ...rest
-}: StripeLinkSection): StripeLinkProps => ({
+}: StripeLinkSection & { themeVariant: ThemeVariant }): StripeLinkProps => ({
   subtitle: MarkdownRenderer({ markdown: subtitle, variant: 'body2' }),
   ...(icon.data && {
     iconURL: icon.data.attributes.url,
@@ -18,8 +19,8 @@ const makeStripeLinkProps = ({
   ...rest,
 });
 
-const StripeLink = (props: StripeLinkSection) => (
-  <StripeLinkRC {...makeStripeLinkProps(props)} />
-);
+const StripeLink = (
+  props: StripeLinkSection & { themeVariant: ThemeVariant }
+) => <StripeLinkRC {...makeStripeLinkProps(props)} />;
 
 export default StripeLink;

--- a/apps/nextjs-website/src/components/VideoImage.tsx
+++ b/apps/nextjs-website/src/components/VideoImage.tsx
@@ -2,6 +2,7 @@
 import { VideoImage as VideoImageRC } from '@react-components/components';
 import { VideoImageProps } from '@react-components/types';
 import { VideoImageSection } from '@/lib/fetch/types/PageSection';
+import { ThemeVariant } from '@/lib/fetch/siteWideSEO';
 
 const makeVideoImageProps = ({
   title,
@@ -11,7 +12,7 @@ const makeVideoImageProps = ({
   mobileImage,
   video,
   ...rest
-}: VideoImageSection): VideoImageProps => ({
+}: VideoImageSection & { themeVariant: ThemeVariant }): VideoImageProps => ({
   ...rest,
   ...(title && { title }),
   ...(subtitle && { subtitle }),
@@ -44,8 +45,8 @@ const makeVideoImageProps = ({
     }),
 });
 
-const VideoImage = (props: VideoImageSection) => (
-  <VideoImageRC {...makeVideoImageProps(props)} />
-);
+const VideoImage = (
+  props: VideoImageSection & { themeVariant: ThemeVariant }
+) => <VideoImageRC {...makeVideoImageProps(props)} />;
 
 export default VideoImage;

--- a/apps/nextjs-website/src/lib/fetch/__tests__/siteWideSEO.test.ts
+++ b/apps/nextjs-website/src/lib/fetch/__tests__/siteWideSEO.test.ts
@@ -65,6 +65,7 @@ const siteWideSEOResponse = {
         shortName: 'SEND-PagoPA',
       },
       matomoID: '12',
+      themeVariant: 'SEND',
     },
   },
 };

--- a/apps/nextjs-website/src/lib/fetch/siteWideSEO.ts
+++ b/apps/nextjs-website/src/lib/fetch/siteWideSEO.ts
@@ -4,6 +4,11 @@ import { StrapiImageRequiredSchema } from './types/StrapiImage';
 import { extractTenantStrapiApiData } from './tenantApiData';
 import { AppEnv } from '@/AppEnv';
 
+export const ThemeVariantCodec = t.keyof({
+  IO: null,
+  SEND: null,
+});
+
 const SiteWideSEOCodec = t.strict({
   data: t.strict({
     attributes: t.strict({
@@ -15,11 +20,13 @@ const SiteWideSEOCodec = t.strict({
         shortName: t.string,
       }),
       matomoID: t.union([t.string, t.null]),
+      themeVariant: ThemeVariantCodec,
     }),
   }),
 });
 
 export type SiteWideSEO = t.TypeOf<typeof SiteWideSEOCodec>;
+export type ThemeVariant = t.TypeOf<typeof ThemeVariantCodec>;
 
 export const fetchSiteWideSEO = ({
   config,

--- a/apps/nextjs-website/stories/Accordion/accordionCommons.tsx
+++ b/apps/nextjs-website/stories/Accordion/accordionCommons.tsx
@@ -5,7 +5,7 @@ import { AccordionItemProps } from '@react-components/types/Accordion/Accordion.
 
 // Define a 'Template' function that sets how args map to rendering
 export const AccordionTemplate: StoryFn<AccordionProps> = (args) => (
-  <Accordion {...args} />
+  <Accordion {...args} themeVariant='SEND' />
 );
 
 // Function to generate accordion items with a given theme

--- a/apps/nextjs-website/stories/Bannerlink/bannerlinkCommons.tsx
+++ b/apps/nextjs-website/stories/Bannerlink/bannerlinkCommons.tsx
@@ -3,7 +3,7 @@ import { BannerLink } from '@react-components/components';
 import { BannerLinkProps } from '@react-components/types';
 
 export const BannerLinkTemplate: StoryFn<BannerLinkProps> = (args) => (
-  <BannerLink {...args} />
+  <BannerLink {...args} themeVariant='SEND' />
 );
 
 const generateDefaultProps = (

--- a/apps/nextjs-website/stories/Cards/cardsCommons.tsx
+++ b/apps/nextjs-website/stories/Cards/cardsCommons.tsx
@@ -28,7 +28,7 @@ export const generateItemsWithLinks = (count: number): CardsItemProps[] =>
 );
 
 // Define a "Template" function that sets how args map to rendering
-export const CardsTemplate: StoryFn<CardsProps> = (args) => <Cards {...args} />;
+export const CardsTemplate: StoryFn<CardsProps> = (args) => <Cards {...args} themeVariant='SEND' />;
 
 // Function to generate default props
 const generateDefaultProps = (

--- a/apps/nextjs-website/stories/Editorial-Switch/editorialCommons.tsx
+++ b/apps/nextjs-website/stories/Editorial-Switch/editorialCommons.tsx
@@ -29,7 +29,8 @@ const generateDefaultProps = (theme: 'light' | 'dark'): Partial<EditorialSwitchP
         body: 'Light Editorial',
         width: 'standard',
         image: <img src='https://notifichedigitali.pagopa.it/static/images/pa-infoblock-5.png' alt="placeholder" />,
-        mobileImage: <img src='https://notifichedigitali.pagopa.it/static/images/pi-infoblock-1.png' alt="placeholder" />
+        mobileImage: <img src='https://notifichedigitali.pagopa.it/static/images/pi-infoblock-1.png' alt="placeholder" />,
+        themeVariant: 'SEND'
       },
     },
     {
@@ -42,7 +43,8 @@ const generateDefaultProps = (theme: 'light' | 'dark'): Partial<EditorialSwitchP
         body: 'Dark Editorial',
         width: 'standard',
         image: <img src='https://notifichedigitali.pagopa.it/static/images/pa-infoblock-5.png' alt="placeholder" />,
-        mobileImage: <img src='https://notifichedigitali.pagopa.it/static/images/pi-infoblock-1.png' alt="placeholder" />
+        mobileImage: <img src='https://notifichedigitali.pagopa.it/static/images/pi-infoblock-1.png' alt="placeholder" />,
+        themeVariant: 'SEND'
       },
     },
   ],

--- a/apps/nextjs-website/stories/Editorial/editorialCommons.tsx
+++ b/apps/nextjs-website/stories/Editorial/editorialCommons.tsx
@@ -4,7 +4,7 @@ import { EditorialProps } from '@react-components/types/Editorial/Editorial.type
 import { CtaButtonProps } from '@react-components/types/common/Common.types';
 
 // Define a "Template" function that sets how args map to rendering
-export const EditorialTemplate: StoryFn<EditorialProps> = (args) => <Editorial {...args} />;
+export const EditorialTemplate: StoryFn<EditorialProps> = (args) => <Editorial {...args} themeVariant='SEND' />;
 
 // Function to generate CTA buttons
 export const generateCtaButtons = (count: number): CtaButtonProps[] =>

--- a/apps/nextjs-website/stories/Feature/featureCommons.tsx
+++ b/apps/nextjs-website/stories/Feature/featureCommons.tsx
@@ -4,7 +4,7 @@ import { FeatureProps } from '@react-components/types';
 import { FeatureItem } from '@react-components/types/Feature/Feature.types';
 
 // Define a "Template" function that sets how args map to rendering
-export const FeatureTemplate: StoryFn<FeatureProps> = (args) => <Feature {...args} />;
+export const FeatureTemplate: StoryFn<FeatureProps> = (args) => <Feature {...args} themeVariant='SEND' />;
 
 // Function to generate items
 const generateItems = (count: number, withLinks: boolean, theme: 'dark' | 'light'): FeatureItem[] =>

--- a/apps/nextjs-website/stories/Form/formCommons.tsx
+++ b/apps/nextjs-website/stories/Form/formCommons.tsx
@@ -34,6 +34,7 @@ const generateFormProps = (theme: 'light' | 'dark'): FormProps => ({
       applicati.
     </p>
   ),
+  themeVariant: 'SEND'
 });
 
 export const FormTemplate: StoryFn<FormProps> = (args) => <Form {...args} />;

--- a/apps/nextjs-website/stories/FramedVideo/framedVideoCommons.tsx
+++ b/apps/nextjs-website/stories/FramedVideo/framedVideoCommons.tsx
@@ -14,6 +14,7 @@ const createFramedVideoDefaults = (
   sectionID: null,
   autoplay: false,
   loop: false,
+  themeVariant: 'SEND'
 });
 
 export const defaultsDark = createFramedVideoDefaults('dark');

--- a/apps/nextjs-website/stories/Hero/heroCommons.tsx
+++ b/apps/nextjs-website/stories/Hero/heroCommons.tsx
@@ -3,7 +3,7 @@ import { Hero } from "@react-components/components";
 import { HeroProps } from "@react-components/types";
 
 // Define a "Template" function that sets how args map to rendering
-export const HeroTemplate: StoryFn<HeroProps> = (args) => <Hero {...args} />;
+export const HeroTemplate: StoryFn<HeroProps> = (args) => <Hero {...args} themeVariant='SEND' />;
 
 const title = 'Lorem ipsum dolor sit amet, consectetur';
 const subtitle = `Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`;

--- a/apps/nextjs-website/stories/HeroChips/herochipsCommons.tsx
+++ b/apps/nextjs-website/stories/HeroChips/herochipsCommons.tsx
@@ -3,7 +3,7 @@ import { HeroChips } from "@react-components/components";
 import { HeroChipsProps } from "@react-components/types";
 
 // Define a "Template" function that sets how args map to rendering
-export const HeroChipsTemplate: StoryFn<HeroChipsProps> = (args) => <HeroChips {...args} />;
+export const HeroChipsTemplate: StoryFn<HeroChipsProps> = (args) => <HeroChips {...args} themeVariant='SEND' />;
 
 const title = 'Enti locali';
 const subtitle = `In questa pagina puoi consultare la lista in costante aggiornamento di tutti gli Enti nazionali e locali che sono saliti a bordo di IO, con il dettaglio dei rispettivi servizi già a disposizione dei cittadini.`;

--- a/apps/nextjs-website/stories/HeroCounter/herocounterCommons.tsx
+++ b/apps/nextjs-website/stories/HeroCounter/herocounterCommons.tsx
@@ -4,7 +4,7 @@ import { HeroCounterProps } from "@react-components/types";
 import MarkdownRenderer from '@/components/MarkdownRenderer';
 
 // Define a "Template" function that sets how args map to rendering
-export const HeroCounterTemplate: StoryFn<HeroCounterProps> = (args) => <HeroCounter {...args} />;
+export const HeroCounterTemplate: StoryFn<HeroCounterProps> = (args) => <HeroCounter {...args} themeVariant='SEND' />;
 
 const title = 'Enti locali';
 const subtitle = `In questa pagina puoi consultare la lista in costante aggiornamento di tutti gli Enti nazionali e locali che sono saliti a bordo di IO, con il dettaglio dei rispettivi servizi già a disposizione dei cittadini.`;

--- a/apps/nextjs-website/stories/HowTo/howtoCommons.tsx
+++ b/apps/nextjs-website/stories/HowTo/howtoCommons.tsx
@@ -4,7 +4,7 @@ import { HowToProps } from '@react-components/types';
 import { HowToStepProps } from '@react-components/types/HowTo/HowTo.types';
 
 // Define a "Template" function that sets how args map to rendering
-export const HowToTemplate: StoryFn<HowToProps> = (args) => <HowTo {...args} />;
+export const HowToTemplate: StoryFn<HowToProps> = (args) => <HowTo {...args} themeVariant='SEND' />;
 
 // Function to generate steps
 const generateSteps = (count: number, theme: 'dark' | 'light', withIcons: boolean): HowToStepProps[] =>

--- a/apps/nextjs-website/stories/Page-Switch/pageSwitchCommons.tsx
+++ b/apps/nextjs-website/stories/Page-Switch/pageSwitchCommons.tsx
@@ -41,6 +41,7 @@ const generateDefaultProps = (
               />
             ),
             sectionID: '',
+            themeVariant: 'SEND',
           },
         },
         {
@@ -68,6 +69,7 @@ const generateDefaultProps = (
             },
             sectionID: '',
             textPosition: 'left',
+            themeVariant: 'SEND',
           },
         },
         {
@@ -96,6 +98,7 @@ const generateDefaultProps = (
               },
             ],
             sectionID: '',
+            themeVariant: 'SEND',
           },
         },
       ],
@@ -124,6 +127,7 @@ const generateDefaultProps = (
               />
             ),
             sectionID: '',
+            themeVariant: 'SEND',
           },
         },
         {
@@ -151,6 +155,7 @@ const generateDefaultProps = (
             },
             sectionID: '',
             textPosition: 'left',
+            themeVariant: 'SEND',
           },
         },
         {
@@ -179,6 +184,7 @@ const generateDefaultProps = (
               },
             ],
             sectionID: '',
+            themeVariant: 'SEND',
           },
         },
       ],
@@ -207,6 +213,7 @@ const generateDefaultProps = (
               />
             ),
             sectionID: '',
+            themeVariant: 'SEND',
           },
         },
         {
@@ -234,6 +241,7 @@ const generateDefaultProps = (
             },
             sectionID: '',
             textPosition: 'left',
+            themeVariant: 'SEND',
           },
         },
         {
@@ -262,6 +270,7 @@ const generateDefaultProps = (
               },
             ],
             sectionID: '',
+            themeVariant: 'SEND',
           },
         },
       ],

--- a/apps/nextjs-website/stories/ServiceCarousel/default.stories.tsx
+++ b/apps/nextjs-website/stories/ServiceCarousel/default.stories.tsx
@@ -11,7 +11,7 @@ export default meta;
 
 // Define a "Template" function that sets how args map to rendering
 const ServiceCarouselTemplate: StoryFn<ServiceCarouselProps> = (args) => (
-  <ServiceCarousel {...args} />
+  <ServiceCarousel {...args} themeVariant='SEND' />
 );
 
 export const ServiceCarouselFull: StoryFn<typeof ServiceCarousel> =

--- a/apps/nextjs-website/stories/Stats/default.stories.tsx
+++ b/apps/nextjs-website/stories/Stats/default.stories.tsx
@@ -11,7 +11,7 @@ export default meta;
 
 // Define a 'Template' function that sets how args map to rendering
 const StatsTemplate: StoryFn<StatsProps> = (args) => {
-  return <Stats {...args} />;
+  return <Stats {...args} themeVariant='SEND' />;
 };
 
 export const StatsFull: StoryFn<typeof Stats> = StatsTemplate.bind({});

--- a/apps/nextjs-website/stories/StripeLink/stripelinkCommons.tsx
+++ b/apps/nextjs-website/stories/StripeLink/stripelinkCommons.tsx
@@ -4,7 +4,7 @@ import { StripeLinkProps } from '@react-components/types';
 
 // Define a 'Template' function that sets how args map to rendering
 export const StripeLinkTemplate: StoryFn<StripeLinkProps> = (args) => (
-  <StripeLink {...args} />
+  <StripeLink {...args} themeVariant='SEND' />
 );
 
 // Function to generate default props

--- a/apps/nextjs-website/stories/VideoImage/videoImageCommons.tsx
+++ b/apps/nextjs-website/stories/VideoImage/videoImageCommons.tsx
@@ -9,6 +9,7 @@ const createVideoImageDefaults = (theme: 'dark' | 'light'): VideoImageProps => (
   theme,
   isCentered: false,
   sectionID: null,
+  themeVariant: 'SEND',
 });
 
 // Usage example

--- a/apps/strapi-cms/src/api/general/content-types/general/schema.json
+++ b/apps/strapi-cms/src/api/general/content-types/general/schema.json
@@ -44,6 +44,15 @@
     },
     "matomoID": {
       "type": "string"
+    },
+    "themeVariant": {
+      "type": "enumeration",
+      "enum": [
+        "IO",
+        "SEND"
+      ],
+      "default": "SEND",
+      "required": true
     }
   }
 }


### PR DESCRIPTION
This PR adds the possibility to set the `themeVariant`.
Current variants:
- SEND (default): Lighter blue
- IO: Darker blue

#### List of Changes
<!--- Describe your changes in detail -->
Strapi
- Add `themeVariant` to Strapi's `General` Single Type
NextJS
- Add themeVariant to SectionProps
- Pass themeVariant to all components that implement SectionProps
- Fetch themeVariant when rendering sections in standard and preview mode
- Add function to allow preview mode to work even if General (hence themeVariant) has not been filled by CMS user
- Add default SEND themeVariant to Storybook

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Feature Request.
Allow use of different variants of the main MUI Italia theme.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran locally in dev and preview.

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
