### PR TITLE
[B2BP-1004] Strapi RowText: Turned body field into Rich Text

### DIFF
--- a/.changeset/clever-flowers-hunt.md
+++ b/.changeset/clever-flowers-hunt.md
@@ -1,0 +1,5 @@
+---
+"strapi-cms": patch
+---
+
+RowText: Turned body field into Rich Text

--- a/apps/strapi-cms/src/components/sections/row-text.json
+++ b/apps/strapi-cms/src/components/sections/row-text.json
@@ -13,9 +13,6 @@
     "subtitle": {
       "type": "text"
     },
-    "body": {
-      "type": "text"
-    },
     "layout": {
       "type": "enumeration",
       "enum": [
@@ -28,6 +25,9 @@
     "sectionID": {
       "type": "string",
       "regex": "^[a-z]+[a-z\\-]*$"
+    },
+    "body": {
+      "type": "richtext"
     }
   }
 }


### PR DESCRIPTION
Depends on #490 

As per title.

#### List of Changes
<!--- Describe your changes in detail -->
- Changed RowText's "body" field to be a Rich Text (markdown)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Feature Request

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran locally in dev and preview

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
