### PR TITLE
[B2BP-1019] Add Strapi Plugin Copy Locales

### DIFF
--- a/.changeset/green-dots-juggle.md
+++ b/.changeset/green-dots-juggle.md
@@ -1,0 +1,5 @@
+---
+"strapi-cms": patch
+---
+
+Add Strapi Plugin Copy Locales

--- a/apps/strapi-cms/Dockerfile
+++ b/apps/strapi-cms/Dockerfile
@@ -8,11 +8,11 @@ ENV NODE_ENV=${NODE_ENV}
 
 WORKDIR /opt/
 COPY package*.json ./
-RUN npm config set fetch-retry-maxtimeout 600000 -g && npm install
+RUN yarn config set fetch-retry-maxtimeout 600000 -g && yarn
 ENV PATH /opt/node_modules/.bin:$PATH
 WORKDIR /opt/app
 COPY . .
-RUN npm run build
+RUN yarn build
 
 # Creating final production image
 FROM ${NODE_IMAGE} as buildfinal

--- a/apps/strapi-cms/config/plugins.ts
+++ b/apps/strapi-cms/config/plugins.ts
@@ -49,4 +49,13 @@ export default ({ env }: any) => ({
       ]
     }
   },
+  'copy-locales': {
+    enabled: true,
+    config: {
+      contentTypes: [
+        'api::page.page',
+        'api::page-switch-page.page-switch-page'
+      ]
+    }
+  }
 });

--- a/apps/strapi-cms/package.json
+++ b/apps/strapi-cms/package.json
@@ -33,6 +33,7 @@
     "axios": "^1.6.8",
     "better-sqlite3": "8.6.0",
     "pg": "^8.11.3",
+    "strapi-plugin-copy-locales": "^1.0.1",
     "strapi-plugin-preview-button": "^2.2.2",
     "strapi-plugin-update-static-content": "^1.0.8"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2300,6 +2300,7 @@
         "axios": "^1.6.8",
         "better-sqlite3": "8.6.0",
         "pg": "^8.11.3",
+        "strapi-plugin-copy-locales": "^1.0.1",
         "strapi-plugin-preview-button": "^2.2.2",
         "strapi-plugin-update-static-content": "^1.0.8"
       },
@@ -32109,6 +32110,95 @@
     "node_modules/strapi-cms": {
       "resolved": "apps/strapi-cms",
       "link": true
+    },
+    "node_modules/strapi-plugin-copy-locales": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strapi-plugin-copy-locales/-/strapi-plugin-copy-locales-1.0.1.tgz",
+      "integrity": "sha512-mb90OjAVfjz0cmBbaS5rNpVIDcRfYT+lHTSVytF55Snd39hOPUmwO+2QxlJ6+cblq/wp37ST8+eCGg4eGNropw==",
+      "dependencies": {
+        "@strapi/design-system": "^1.6.3",
+        "@strapi/helper-plugin": "^4.6.0",
+        "@strapi/icons": "^1.6.3",
+        "immer": "9.0.19",
+        "lodash": "4.17.21",
+        "prop-types": "^15.7.2",
+        "react-intl": "6.3.2",
+        "react-redux": "8.0.5",
+        "redux": "^4.2.1"
+      },
+      "engines": {
+        "node": ">=14.19.1 <=18.x.x",
+        "npm": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "@strapi/strapi": "^4.9.0",
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2",
+        "react-router-dom": "^5.3.4",
+        "styled-components": "^5.3.6"
+      }
+    },
+    "node_modules/strapi-plugin-copy-locales/node_modules/@formatjs/intl": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-2.6.9.tgz",
+      "integrity": "sha512-EtcMZ9O24YSASu/jGOaTQtArx7XROjlKiO4KmkxJ/3EyAQLCr5hrS+KKvNud0a7GIwBucOb3IFrZ7WiSm2A/Cw==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.14.3",
+        "@formatjs/fast-memoize": "2.0.1",
+        "@formatjs/icu-messageformat-parser": "2.3.0",
+        "@formatjs/intl-displaynames": "6.2.6",
+        "@formatjs/intl-listformat": "7.1.9",
+        "intl-messageformat": "10.3.3",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "typescript": "^4.7"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/strapi-plugin-copy-locales/node_modules/react-intl": {
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-6.3.2.tgz",
+      "integrity": "sha512-NT03zOHRAFGcZdTx4cXcVKZtnWBOM6RfLPK8Q67eA+Ba+pHdYb+cmrahncqAnevZKgO1r/nEauiVFKwQeudLIw==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.14.3",
+        "@formatjs/icu-messageformat-parser": "2.3.0",
+        "@formatjs/intl": "2.6.9",
+        "@formatjs/intl-displaynames": "6.2.6",
+        "@formatjs/intl-listformat": "7.1.9",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/react": "16 || 17 || 18",
+        "hoist-non-react-statics": "^3.3.2",
+        "intl-messageformat": "10.3.3",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || 17 || 18",
+        "typescript": "^4.7"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/strapi-plugin-copy-locales/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
     },
     "node_modules/strapi-plugin-preview-button": {
       "version": "2.2.2",


### PR DESCRIPTION
As per title.

Adding the plugin previously caused the "Deploy CMS" action to fail running `npm i`.

The problem has not been possible to replicate locally by simply running `npm i`.
However, running `docker build` does replicate the issue.

Adding the `--force` or `--legacy-peer-deps` options to `Dockerfile` did not solve the issue, however switching from npm to yarn did. That is the solution presented in this PR.

#### List of Changes
<!--- Describe your changes in detail -->
- Install and configure Strapi Plugin Copy Locales
- Switch from using npm to yarn in Strapi's `Dockerfile`

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Feature Request + Bug Fix

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran locally in dev.
Built locally using docker.

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
