### PR TITLE
[B2BP-1067] Make PressReleaseList fetch correct PressReleases in Preview

### DIFF
--- a/.changeset/famous-clouds-study.md
+++ b/.changeset/famous-clouds-study.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Make PressReleaseList fetch correct PressReleases in Preview

--- a/apps/nextjs-website/src/app/preview/page.tsx
+++ b/apps/nextjs-website/src/app/preview/page.tsx
@@ -2,7 +2,7 @@ import { Config } from '@/AppEnv';
 import PageSection from '@/components/PageSection/PageSection';
 import {
   getAllPageIDs,
-  getPageSectionsFromID,
+  getPageDataFromID,
   getPressReleasePages,
   getPreviewToken,
   getSiteWideSEO,
@@ -54,9 +54,9 @@ const PreviewPage = async ({
     return <div>404: Missing page</div>;
   }
 
-  const sections = await getPageSectionsFromID(tenant, pageID);
+  const { sections, locale } = await getPageDataFromID(tenant, pageID);
   const themeVariant = await GetThemeVariantForPreview();
-  const pressReleasePages = await getPressReleasePages('it'); // TODO: Define which locale the page we are previewing is from and insert it here
+  const pressReleasePages = await getPressReleasePages(locale);
 
   return (
     <div>
@@ -64,8 +64,8 @@ const PreviewPage = async ({
         PageSection({
           ...section,
           themeVariant,
-          locale: 'it', // Doesn't matter in preview
-          defaultLocale: 'it', // Doesn't matter in preview
+          locale,
+          defaultLocale: locale, // Doesn't matter in preview
           pressReleasePages,
         })
       )}

--- a/apps/nextjs-website/src/lib/api.ts
+++ b/apps/nextjs-website/src/lib/api.ts
@@ -8,8 +8,12 @@ import { PreHeaderAttributes, getPreHeader } from './fetch/preHeader';
 import { FooterData, getFooter } from './fetch/footer';
 import { getHeader, HeaderData } from './fetch/header';
 import { SiteWideSEO, fetchSiteWideSEO } from './fetch/siteWideSEO';
-import { PageIDs, fetchAllPageIDs, fetchPageFromID } from './fetch/preview';
-import { PageSection } from './fetch/types/PageSection';
+import {
+  PageIDs,
+  PreviewPageData,
+  fetchAllPageIDs,
+  fetchPageFromID,
+} from './fetch/preview';
 import { formatHeaderLinks } from './header';
 import { getPreFooter, PreFooterAttributes } from './fetch/preFooter';
 import { getPressReleases, PressReleasePage } from './fetch/pressRelease';
@@ -131,10 +135,10 @@ export const getAllPageIDs = async (
   return [...pageIDs_it.data, ...pageIDs_en.data];
 };
 
-export const getPageSectionsFromID = async (
+export const getPageDataFromID = async (
   tenant: Config['ENVIRONMENT'],
   pageID: number
-): Promise<ReadonlyArray<PageSection>> => {
+): Promise<PreviewPageData['data']['attributes']> => {
   const appEnvWithRequestedTenant: AppEnv = {
     config: {
       ...appEnv.config,
@@ -146,7 +150,7 @@ export const getPageSectionsFromID = async (
     data: { attributes },
   } = await fetchPageFromID({ ...appEnvWithRequestedTenant, pageID });
 
-  return attributes.sections;
+  return attributes;
 };
 
 export const isPreviewMode = () => appEnv.config.PREVIEW_MODE === 'true';

--- a/apps/nextjs-website/src/lib/fetch/__tests__/preview.test.ts
+++ b/apps/nextjs-website/src/lib/fetch/__tests__/preview.test.ts
@@ -48,6 +48,7 @@ const pageIDsResponse: PageIDs = {
 const pageDataResponse: PreviewPageData = {
   data: {
     attributes: {
+      locale: 'it',
       sections: [
         {
           __component: 'sections.hero',

--- a/apps/nextjs-website/src/lib/fetch/preview.ts
+++ b/apps/nextjs-website/src/lib/fetch/preview.ts
@@ -15,6 +15,7 @@ const PageIDsCodec = t.strict({
 const PreviewPageDataCodec = t.strict({
   data: t.strict({
     attributes: t.strict({
+      locale: t.union([t.literal('it'), t.literal('en')]),
       sections: t.array(PageSectionCodec),
     }),
   }),


### PR DESCRIPTION
As per title.

#### List of Changes
<!--- Describe your changes in detail -->
- Converted function `getPageSectionsFromID` to `getPageDataFromID` which now returns the page's locale as well
- Used the updated function to fetch the correct set of PressReleases in Preview mode

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Make preview more closely represent the build output

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran locally with pages of both locales (it/en)

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
