### PR TITLE
[B2BP-1065] Extend preview feature to PressRelease Collection Type

### DIFF
--- a/.changeset/cuddly-cars-fold.md
+++ b/.changeset/cuddly-cars-fold.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Extend preview feature to PressRelease Collection Type

--- a/.changeset/real-swans-sparkle.md
+++ b/.changeset/real-swans-sparkle.md
@@ -1,0 +1,5 @@
+---
+"strapi-cms": patch
+---
+
+Activate Preview Button for PressRelease Collection Type

--- a/apps/nextjs-website/src/app/preview/page.tsx
+++ b/apps/nextjs-website/src/app/preview/page.tsx
@@ -2,7 +2,9 @@ import { Config } from '@/AppEnv';
 import PageSection from '@/components/PageSection/PageSection';
 import {
   getAllPageIDs,
+  getAllPressReleaseIDs,
   getPageDataFromID,
+  getPressReleaseDataFromID,
   getPressReleasePages,
   getPreviewToken,
   getSiteWideSEO,
@@ -27,6 +29,7 @@ const PreviewPage = async ({
   searchParams,
 }: {
   searchParams: {
+    type: 'page' | 'press-release' | undefined;
     secret: string | undefined;
     pageID: string | undefined;
     tenant: Config['ENVIRONMENT'] | undefined;
@@ -36,6 +39,7 @@ const PreviewPage = async ({
     return null;
   }
 
+  const type = searchParams.type;
   const secret = searchParams.secret;
   const pageID = Number(searchParams.pageID);
   const tenant = searchParams.tenant;
@@ -49,12 +53,16 @@ const PreviewPage = async ({
     return <div>404: Missing parameters</div>;
   }
 
-  const pageIDs = await getAllPageIDs(tenant);
+  const pageIDs = await (type === 'press-release'
+    ? getAllPressReleaseIDs(tenant)
+    : getAllPageIDs(tenant));
   if (!pageIDs.map((obj) => obj.id).includes(pageID)) {
     return <div>404: Missing page</div>;
   }
 
-  const { sections, locale } = await getPageDataFromID(tenant, pageID);
+  const { sections, locale } = await (type === 'press-release'
+    ? getPressReleaseDataFromID(tenant, pageID)
+    : getPageDataFromID(tenant, pageID));
   const themeVariant = await GetThemeVariantForPreview();
   const pressReleasePages = await getPressReleasePages(locale);
 

--- a/apps/nextjs-website/src/lib/api.ts
+++ b/apps/nextjs-website/src/lib/api.ts
@@ -12,12 +12,17 @@ import {
   PageIDs,
   PreviewPageData,
   fetchAllPageIDs,
+  fetchAllPressReleaseIDs,
   fetchPageFromID,
+  fetchPressReleaseFromID,
 } from './fetch/preview';
 import { formatHeaderLinks } from './header';
 import { getPreFooter, PreFooterAttributes } from './fetch/preFooter';
 import { getPressReleases, PressReleasePage } from './fetch/pressRelease';
-import { pressReleaseToPageDataArray } from './pressRelease';
+import {
+  pressReleaseToPageDataArray,
+  previewPressReleaseToPreviewPageData,
+} from './pressRelease';
 
 // create AppEnv given process env
 const appEnv = pipe(
@@ -135,6 +140,27 @@ export const getAllPageIDs = async (
   return [...pageIDs_it.data, ...pageIDs_en.data];
 };
 
+export const getAllPressReleaseIDs = async (
+  tenant: Config['ENVIRONMENT']
+): Promise<PageIDs['data']> => {
+  const appEnvWithRequestedTenant: AppEnv = {
+    config: {
+      ...appEnv.config,
+      ENVIRONMENT: tenant,
+    },
+    fetchFun: appEnv.fetchFun,
+  };
+  const pressReleaseIDs_it = await fetchAllPressReleaseIDs({
+    ...appEnvWithRequestedTenant,
+    locale: 'it',
+  });
+  const pressReleaseIDs_en = await fetchAllPressReleaseIDs({
+    ...appEnvWithRequestedTenant,
+    locale: 'en',
+  });
+  return [...pressReleaseIDs_it.data, ...pressReleaseIDs_en.data];
+};
+
 export const getPageDataFromID = async (
   tenant: Config['ENVIRONMENT'],
   pageID: number
@@ -151,6 +177,25 @@ export const getPageDataFromID = async (
   } = await fetchPageFromID({ ...appEnvWithRequestedTenant, pageID });
 
   return attributes;
+};
+
+export const getPressReleaseDataFromID = async (
+  tenant: Config['ENVIRONMENT'],
+  pressReleaseID: number
+): Promise<PreviewPageData['data']['attributes']> => {
+  const appEnvWithRequestedTenant: AppEnv = {
+    config: {
+      ...appEnv.config,
+      ENVIRONMENT: tenant,
+    },
+    fetchFun: appEnv.fetchFun,
+  };
+  const pressRelease = await fetchPressReleaseFromID({
+    ...appEnvWithRequestedTenant,
+    pressReleaseID,
+  });
+
+  return previewPressReleaseToPreviewPageData(pressRelease).data.attributes;
 };
 
 export const isPreviewMode = () => appEnv.config.PREVIEW_MODE === 'true';

--- a/apps/nextjs-website/src/lib/fetch/__tests__/preview.test.ts
+++ b/apps/nextjs-website/src/lib/fetch/__tests__/preview.test.ts
@@ -4,6 +4,9 @@ import {
   PageIDs,
   fetchAllPageIDs,
   fetchPageFromID,
+  fetchAllPressReleaseIDs,
+  fetchPressReleaseFromID,
+  PreviewPressReleaseData,
 } from '../preview';
 import { Config } from '@/AppEnv';
 
@@ -79,6 +82,21 @@ const pageDataResponse: PreviewPageData = {
   },
 };
 
+const pressReleaseDataResponse: PreviewPressReleaseData = {
+  data: {
+    attributes: {
+      locale: 'it',
+      pressRelease: {
+        sectionID: null,
+        title: 'Press Release Title',
+        subtitle: null,
+        body: 'Press Release Body',
+        date: '2024-10-12',
+      },
+    },
+  },
+};
+
 describe('fetchAllPageIDs', () => {
   it('should call /api/pages including unpublished content', async () => {
     const { appEnv, fetchMock } = makeTestAppEnv();
@@ -115,6 +133,42 @@ describe('fetchAllPageIDs', () => {
   });
 });
 
+describe('fetchAllPressReleaseIDs', () => {
+  it('should call /api/press-releases including unpublished content', async () => {
+    const { appEnv, fetchMock } = makeTestAppEnv();
+    const { config } = appEnv;
+
+    fetchMock.mockResolvedValueOnce({
+      json: () => Promise.resolve(pageIDsResponse),
+    } as unknown as Response);
+
+    await fetchAllPressReleaseIDs({ ...appEnv, locale: 'it' });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${config.DEMO_STRAPI_API_BASE_URL}/api/press-releases?locale=it&publicationState=preview&pagination[pageSize]=100`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${config.DEMO_STRAPI_API_TOKEN}`,
+        },
+        cache: 'no-cache',
+      }
+    );
+  });
+
+  it('should parse pageIDs without error', async () => {
+    const { appEnv, fetchMock } = makeTestAppEnv();
+
+    fetchMock.mockResolvedValueOnce({
+      json: () => Promise.resolve(pageIDsResponse),
+    } as unknown as Response);
+
+    const actual = fetchAllPressReleaseIDs({ ...appEnv, locale: 'it' });
+
+    expect(await actual).toStrictEqual(pageIDsResponse);
+  });
+});
+
 describe('fetchPageFromID', () => {
   it('should call /api/pages/[pageID] including unpublished content', async () => {
     const { appEnv, fetchMock } = makeTestAppEnv();
@@ -131,18 +185,18 @@ describe('fetchPageFromID', () => {
 
     expect(fetchMock).toHaveBeenCalledWith(
       `${config.DEMO_STRAPI_API_BASE_URL}/api/pages/${pageIDExample}?publicationState=preview
-      &populate[sections][populate][0]=ctaButtons,image,mobileImage,background,link,accordionItems,decoration,storeButtons,categories,counter,icon,chips
-      &populate[sections][populate][1]=items.links,items.link,items.icon
-      &populate[sections][populate][2]=sections.icon,sections.ctaButtons
-      &populate[sections][populate][3]=sections.content.image,sections.content.mobileImage,sections.content.ctaButtons,sections.content.storeButtons
-      &populate[sections][populate][4]=video.src
-      &populate[sections][populate][5]=steps.icon
-      &populate[sections][populate][6]=cards.image,cards.link
-      &populate[sections][populate][7]=text.link
-      &populate[sections][populate][8]=pages.sections.ctaButtons,pages.sections.image,pages.sections.mobileImage,pages.sections.storeButtons
-      &populate[sections][populate][9]=pages.sections.items.links,pages.sections.items.icon
-      &populate[sections][populate][10]=pages.sections.sections.ctaButtons,pages.sections.sections.icon
-      `,
+        &populate[sections][populate][0]=ctaButtons,image,mobileImage,background,link,accordionItems,decoration,storeButtons,categories,counter,icon,chips
+        &populate[sections][populate][1]=items.links,items.link,items.icon
+        &populate[sections][populate][2]=sections.icon,sections.ctaButtons
+        &populate[sections][populate][3]=sections.content.image,sections.content.mobileImage,sections.content.ctaButtons,sections.content.storeButtons
+        &populate[sections][populate][4]=video.src
+        &populate[sections][populate][5]=steps.icon
+        &populate[sections][populate][6]=cards.image,cards.link
+        &populate[sections][populate][7]=text.link
+        &populate[sections][populate][8]=pages.sections.ctaButtons,pages.sections.image,pages.sections.mobileImage,pages.sections.storeButtons
+        &populate[sections][populate][9]=pages.sections.items.links,pages.sections.items.icon
+        &populate[sections][populate][10]=pages.sections.sections.ctaButtons,pages.sections.sections.icon
+        `,
       {
         method: 'GET',
         headers: {
@@ -166,5 +220,47 @@ describe('fetchPageFromID', () => {
     });
 
     expect(await actual).toStrictEqual(pageDataResponse);
+  });
+});
+
+describe('fetchPressReleaseFromID', () => {
+  it('should call /api/press-releases/[pageID] including unpublished content', async () => {
+    const { appEnv, fetchMock } = makeTestAppEnv();
+    const { config } = appEnv;
+
+    fetchMock.mockResolvedValueOnce({
+      json: () => Promise.resolve(pressReleaseDataResponse),
+    } as unknown as Response);
+
+    await fetchPressReleaseFromID({
+      ...appEnv,
+      pressReleaseID: pageIDExample,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${config.DEMO_STRAPI_API_BASE_URL}/api/press-releases/${pageIDExample}?publicationState=preview&populate[pressRelease]=*`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${config.DEMO_STRAPI_API_TOKEN}`,
+        },
+        cache: 'no-cache',
+      }
+    );
+  });
+
+  it('should parse pageData without error', async () => {
+    const { appEnv, fetchMock } = makeTestAppEnv();
+
+    fetchMock.mockResolvedValueOnce({
+      json: () => Promise.resolve(pressReleaseDataResponse),
+    } as unknown as Response);
+
+    const actual = fetchPressReleaseFromID({
+      ...appEnv,
+      pressReleaseID: pageIDExample,
+    });
+
+    expect(await actual).toStrictEqual(pressReleaseDataResponse);
   });
 });

--- a/apps/nextjs-website/src/lib/fetch/preview.ts
+++ b/apps/nextjs-website/src/lib/fetch/preview.ts
@@ -1,5 +1,8 @@
 import * as t from 'io-ts';
-import { PageSectionCodec } from './types/PageSection';
+import {
+  PageSectionCodec,
+  PressReleaseSectionContentCodec,
+} from './types/PageSection';
 import { extractFromResponse } from './extractFromResponse';
 import { extractTenantStrapiApiData } from './tenantApiData';
 import { AppEnv } from '@/AppEnv';
@@ -21,8 +24,20 @@ const PreviewPageDataCodec = t.strict({
   }),
 });
 
+const PreviewPressReleaseDataCodec = t.strict({
+  data: t.strict({
+    attributes: t.strict({
+      locale: t.union([t.literal('it'), t.literal('en')]),
+      pressRelease: PressReleaseSectionContentCodec,
+    }),
+  }),
+});
+
 export type PageIDs = t.TypeOf<typeof PageIDsCodec>;
 export type PreviewPageData = t.TypeOf<typeof PreviewPageDataCodec>;
+export type PreviewPressReleaseData = t.TypeOf<
+  typeof PreviewPressReleaseDataCodec
+>;
 
 export const fetchAllPageIDs = ({
   config,
@@ -45,6 +60,27 @@ export const fetchAllPageIDs = ({
     PageIDsCodec
   );
 
+export const fetchAllPressReleaseIDs = ({
+  config,
+  fetchFun,
+  locale,
+}: AppEnv & { readonly locale: 'it' | 'en' }): Promise<PageIDs> =>
+  extractFromResponse(
+    fetchFun(
+      `${
+        extractTenantStrapiApiData(config).baseUrl
+      }/api/press-releases?locale=${locale}&publicationState=preview&pagination[pageSize]=100`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${extractTenantStrapiApiData(config).token}`,
+        },
+        cache: 'no-cache',
+      }
+    ),
+    PageIDsCodec
+  );
+
 export const fetchPageFromID = ({
   config,
   fetchFun,
@@ -55,18 +91,18 @@ export const fetchPageFromID = ({
       `${
         extractTenantStrapiApiData(config).baseUrl
       }/api/pages/${pageID}?publicationState=preview
-      &populate[sections][populate][0]=ctaButtons,image,mobileImage,background,link,accordionItems,decoration,storeButtons,categories,counter,icon,chips
-      &populate[sections][populate][1]=items.links,items.link,items.icon
-      &populate[sections][populate][2]=sections.icon,sections.ctaButtons
-      &populate[sections][populate][3]=sections.content.image,sections.content.mobileImage,sections.content.ctaButtons,sections.content.storeButtons
-      &populate[sections][populate][4]=video.src
-      &populate[sections][populate][5]=steps.icon
-      &populate[sections][populate][6]=cards.image,cards.link
-      &populate[sections][populate][7]=text.link
-      &populate[sections][populate][8]=pages.sections.ctaButtons,pages.sections.image,pages.sections.mobileImage,pages.sections.storeButtons
-      &populate[sections][populate][9]=pages.sections.items.links,pages.sections.items.icon
-      &populate[sections][populate][10]=pages.sections.sections.ctaButtons,pages.sections.sections.icon
-      `,
+        &populate[sections][populate][0]=ctaButtons,image,mobileImage,background,link,accordionItems,decoration,storeButtons,categories,counter,icon,chips
+        &populate[sections][populate][1]=items.links,items.link,items.icon
+        &populate[sections][populate][2]=sections.icon,sections.ctaButtons
+        &populate[sections][populate][3]=sections.content.image,sections.content.mobileImage,sections.content.ctaButtons,sections.content.storeButtons
+        &populate[sections][populate][4]=video.src
+        &populate[sections][populate][5]=steps.icon
+        &populate[sections][populate][6]=cards.image,cards.link
+        &populate[sections][populate][7]=text.link
+        &populate[sections][populate][8]=pages.sections.ctaButtons,pages.sections.image,pages.sections.mobileImage,pages.sections.storeButtons
+        &populate[sections][populate][9]=pages.sections.items.links,pages.sections.items.icon
+        &populate[sections][populate][10]=pages.sections.sections.ctaButtons,pages.sections.sections.icon
+        `,
       {
         method: 'GET',
         headers: {
@@ -76,4 +112,27 @@ export const fetchPageFromID = ({
       }
     ),
     PreviewPageDataCodec
+  );
+
+export const fetchPressReleaseFromID = ({
+  config,
+  fetchFun,
+  pressReleaseID,
+}: AppEnv & {
+  readonly pressReleaseID: number;
+}): Promise<PreviewPressReleaseData> =>
+  extractFromResponse(
+    fetchFun(
+      `${
+        extractTenantStrapiApiData(config).baseUrl
+      }/api/press-releases/${pressReleaseID}?publicationState=preview&populate[pressRelease]=*`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${extractTenantStrapiApiData(config).token}`,
+        },
+        cache: 'no-cache',
+      }
+    ),
+    PreviewPressReleaseDataCodec
   );

--- a/apps/nextjs-website/src/lib/pressRelease.ts
+++ b/apps/nextjs-website/src/lib/pressRelease.ts
@@ -1,4 +1,5 @@
 import { PressReleases } from './fetch/pressRelease';
+import { PreviewPageData, PreviewPressReleaseData } from './fetch/preview';
 import { PageData } from './navigation';
 
 export const pressReleaseToPageDataArray = (
@@ -14,3 +15,19 @@ export const pressReleaseToPageDataArray = (
       },
     ],
   }));
+
+export const previewPressReleaseToPreviewPageData = (
+  pressRelease: PreviewPressReleaseData
+): PreviewPageData => ({
+  data: {
+    attributes: {
+      locale: pressRelease.data.attributes.locale,
+      sections: [
+        {
+          __component: 'sections.press-release',
+          ...pressRelease.data.attributes.pressRelease,
+        },
+      ],
+    },
+  },
+});

--- a/apps/strapi-cms/config/plugins.ts
+++ b/apps/strapi-cms/config/plugins.ts
@@ -37,6 +37,22 @@ export default ({ env }: any) => ({
           draft: {
             url: env('PREVIEW_URL'),
             query: {
+              type: 'page',
+              pageID: '{id}',
+              secret: env('PREVIEW_TOKEN'),
+              tenant: env('ENVIRONMENT'),
+            },
+            openTarget: '_blank',
+            copy: false,
+            alwaysVisible: true,
+          },
+        },
+        {
+          uid: 'api::press-release.press-release',
+          draft: {
+            url: env('PREVIEW_URL'),
+            query: {
+              type: 'press-release',
               pageID: '{id}',
               secret: env('PREVIEW_TOKEN'),
               tenant: env('ENVIRONMENT'),


### PR DESCRIPTION
As per title.

#### List of Changes
<!--- Describe your changes in detail -->
- Update Strapi's Preview Button plugin configuration to be active for PressRelease Collection Type and to add a "type" query parameter to distinguish between standard pages and press releases (so NextJS knows which one to fetch since it cannot determine from the ID alone)
- Make NextJS fetch from PressRelease or Page Collection Type depending on the value of the "type" query parameter

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Better CMS UX

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran locally in preview for all current locales (it/en)

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
