### PR TITLE
[B2BP-899] Make slugs unique and add Duplicate Button plugin

### DIFF
--- a/.changeset/ten-spiders-exercise.md
+++ b/.changeset/ten-spiders-exercise.md
@@ -1,0 +1,5 @@
+---
+"strapi-cms": patch
+---
+
+Make slugs unique and add Duplicate Button plugin

--- a/apps/strapi-cms/package.json
+++ b/apps/strapi-cms/package.json
@@ -34,6 +34,7 @@
     "better-sqlite3": "8.6.0",
     "pg": "^8.11.3",
     "strapi-plugin-copy-locales": "^1.0.1",
+    "strapi-plugin-duplicate-button": "^1.3.16",
     "strapi-plugin-preview-button": "^2.2.2",
     "strapi-plugin-update-static-content": "^1.0.8"
   },

--- a/apps/strapi-cms/src/api/page/content-types/page/schema.json
+++ b/apps/strapi-cms/src/api/page/content-types/page/schema.json
@@ -30,7 +30,7 @@
       "type": "string",
       "regex": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
       "required": true,
-      "unique": false,
+      "unique": true,
       "pluginOptions": {
         "i18n": {
           "localized": true

--- a/apps/strapi-cms/src/api/press-release/content-types/press-release/schema.json
+++ b/apps/strapi-cms/src/api/press-release/content-types/press-release/schema.json
@@ -34,7 +34,8 @@
       },
       "type": "string",
       "required": true,
-      "regex": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+      "regex": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+      "unique": true
     },
     "seo": {
       "type": "component",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2301,6 +2301,7 @@
         "better-sqlite3": "8.6.0",
         "pg": "^8.11.3",
         "strapi-plugin-copy-locales": "^1.0.1",
+        "strapi-plugin-duplicate-button": "^1.3.16",
         "strapi-plugin-preview-button": "^2.2.2",
         "strapi-plugin-update-static-content": "^1.0.8"
       },
@@ -32198,6 +32199,17 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "node_modules/strapi-plugin-duplicate-button": {
+      "version": "1.3.16",
+      "resolved": "https://registry.npmjs.org/strapi-plugin-duplicate-button/-/strapi-plugin-duplicate-button-1.3.16.tgz",
+      "integrity": "sha512-dLiYdsJVQJi6BmLSe8SLKunexpwW5HbV20EEvAccb2REO0nXwFlnsNzXvooWYVBjVSx8YJmwlauwZ0Btea96Cg==",
+      "engines": {
+        "node": ">=14.19.1 <=20.x.x"
+      },
+      "peerDependencies": {
+        "@strapi/strapi": "^4.0.0"
       }
     },
     "node_modules/strapi-plugin-preview-button": {


### PR DESCRIPTION
Made the slugs of Page and PressRelease unique.

This, however, breaks the clone/duplicate button function, so the Duplicate Button plugin has been added to maintain the functionality.

The plugin differs from Strapi's standard clone function in that the button is located in each Page's details page instead of the list view.

This plugin should be rendered moot when we'll upgrade to Strapi v5.

#### List of Changes
<!--- Describe your changes in detail -->
- Make Page and PressRelee slug unique
- Add Duplicate Button Strapi plugin

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
(Near) Guarantee slug uniqueness, while maintaining cloning functionality.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran locally.

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
