### PR TITLE
[B2BP-1083] Include sectionID in MegaHeader links

### DIFF
--- a/.changeset/modern-bees-remember.md
+++ b/.changeset/modern-bees-remember.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Include sectionID in MegaHeader links

--- a/apps/nextjs-website/src/components/Header.tsx
+++ b/apps/nextjs-website/src/components/Header.tsx
@@ -9,7 +9,20 @@ import {
   HeaderData,
   StandardHeaderData,
   MegaHeaderData,
+  HeaderSublink,
 } from '@/lib/fetch/header';
+
+const makeSublink = (
+  sublink: HeaderSublink
+): {
+  label: string;
+  href: string;
+} => ({
+  label: sublink.label,
+  href:
+    sublink.page.data.attributes.slug +
+    (sublink.sectionID ? `#${sublink.sectionID}` : ''),
+});
 
 const makeHeaderProps = (
   { productName, menu, logo, beta, supportLink, drawer }: StandardHeaderData,
@@ -59,12 +72,7 @@ const makeHeaderProps = (
     href: link.page.data?.attributes.slug,
     alignRight: link.alignRight,
     ...(link.sublinks.length > 0 && {
-      items: link.sublinks.map((sublink) => ({
-        label: sublink.label,
-        href:
-          sublink.page.data.attributes.slug +
-          (sublink.sectionID ? `#${sublink.sectionID}` : ''),
-      })),
+      items: link.sublinks.map((sublink) => makeSublink(sublink)),
     }),
     ...(link.page.data && {
       active: pathname === link.page.data.attributes.slug,
@@ -97,10 +105,7 @@ const makeMegaHeaderProps = ({
     primary: link.label,
     secondary: link.sublinkGroups.map((sublinkGroup) => ({
       title: sublinkGroup.title,
-      items: sublinkGroup.sublinks.map((sublink) => ({
-        label: sublink.label,
-        href: sublink.page.data.attributes.slug,
-      })),
+      items: sublinkGroup.sublinks.map((sublink) => makeSublink(sublink)),
     })),
   })),
 });


### PR DESCRIPTION
As per title.

#### List of Changes
<!--- Describe your changes in detail -->
- Add sectionID (if present) as hash to links of MegaHeader

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Bug Fix / Missing Implementation NextJS-side

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran locally in dev

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
