### PR TITLE
[B2BP-1104] BUG FIX: Newsletter subscription fails with a 400 error

### DIFF
--- a/.changeset/silent-parrots-learn.md
+++ b/.changeset/silent-parrots-learn.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Make it so Form optional fields (name, surname, organization) are either all passed or none is passed

--- a/apps/nextjs-website/react-components/components/Form/Form.tsx
+++ b/apps/nextjs-website/react-components/components/Form/Form.tsx
@@ -96,8 +96,8 @@ const Form = ({
       email: !validateRequired(formData.email)
         ? 'Campo obbligatorio'
         : !validateEmail(formData.email)
-        ? 'Email non valida'
-        : null,
+          ? 'Email non valida'
+          : null,
     };
 
     setValidationErrors(inputErrors);
@@ -142,11 +142,14 @@ const Form = ({
                 ? [formData.category]
                 : [defaultCategoryID],
             email: formData.email,
-            ...(showName && { name: formData.name }),
-            ...(showSurname && { surname: formData.surname }),
-            ...(showOrganization && { organization: formData.organization }),
+            // Optional fields must be all present or all absent (default values are inconsequential)
+            ...((showName || showSurname || showOrganization) && {
+              name: showName ? formData.name : 'none',
+              surname: showSurname ? formData.surname : 'none',
+              organization: showOrganization ? formData.organization : 'none',
+            }),
           }),
-        }
+        },
       );
 
       const { email } = await res.json();
@@ -359,8 +362,8 @@ const Form = ({
               theme === 'dark'
                 ? palette.custom.white
                 : themeVariant === 'SEND'
-                ? palette.primary.main
-                : palette.custom.blueIO[500],
+                  ? palette.primary.main
+                  : palette.custom.blueIO[500],
             color:
               theme === 'dark'
                 ? themeVariant === 'SEND'
@@ -372,8 +375,8 @@ const Form = ({
                 theme === 'dark'
                   ? palette.custom.white
                   : themeVariant === 'SEND'
-                  ? palette.primary.main
-                  : palette.custom.blueIO[500],
+                    ? palette.primary.main
+                    : palette.custom.blueIO[500],
             },
           }}
           onClick={handleSubmit}


### PR DESCRIPTION
Make it so Form optional fields (name, surname, organization) are either all passed or none is passed.

This is a limitation of the current middle man server / API we send requests to: the name, surname and organization fields have to either all be there or none at all.

The homepage forum (which subscribes people to the newsletter) currently only asks for name and surname, as such the API was sending no data to the mailup newsletter service, generating the 400 error.

#### List of Changes
<!--- Describe your changes in detail -->
- Update conditional and add default values for non-user-entered optional values

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Bug fix

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran locally in dev

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
