### PR TITLE
Bug Fix: NextJS times out when building with 3 or more languages

### DIFF
--- a/.changeset/khaki-rabbits-switch.md
+++ b/.changeset/khaki-rabbits-switch.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Set timeout for SSG to 120 seconds

--- a/apps/nextjs-website/next.config.js
+++ b/apps/nextjs-website/next.config.js
@@ -9,6 +9,7 @@ const nextConfig =
       }
     : {
         output: 'export',
+        staticPageGenerationTimeout: 120,
         images: {
           unoptimized: true,
         },


### PR DESCRIPTION
The error seems to be a simple timeout due to the amount of data being fetched and built.

#### List of Changes
<!--- Describe your changes in detail -->
- Set timeout for SSG to 120 seconds (from default of 60)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Bug Fix

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Needs to be tested in prod, issue doesn't occur locally.

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
