### PR TITLE
[B2BP-1158] Mixpanel: Automatic pageview tracking set to url-with-path

### DIFF
--- a/.changeset/bright-taxis-turn.md
+++ b/.changeset/bright-taxis-turn.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Mixpanel: Automatic pageview tracking set to url-with-path

--- a/apps/nextjs-website/src/components/ConsentHandler.tsx
+++ b/apps/nextjs-website/src/components/ConsentHandler.tsx
@@ -52,7 +52,7 @@ const initMixpanel = (mixpanelConfig: NonNullable<MixpanelConfig>) =>
     ip: mixpanelConfig.ip,
     persistence: 'cookie',
     secure_cookie: true,
-    track_pageview: true,
+    track_pageview: 'url-with-path',
   });
 
 const ConsentHandler = ({


### PR DESCRIPTION
Setting track_pageview to 'url-with-path' makes it so mixpanel now tracks pageview when the URL changes, ignoring parameter and hash changes.

Before, the value of the field was 'true', which meant pageviews were only tracked on page load (which apparently does not include changing pages).

#### List of Changes
<!--- Describe your changes in detail -->
- Updated value in mixpanel initialization

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Bug fix

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran locally, needs prod testing by verifying correct data tracking on mixpanel

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
