### PR TITLE
[B2BP-1158] Mixpanel: Track page views manually

### DIFF
--- a/apps/nextjs-website/src/app/[[...slug]]/page.tsx
+++ b/apps/nextjs-website/src/app/[[...slug]]/page.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/lib/api';
 import PageSection from '@/components/PageSection/PageSection';
 import { Locale } from '@/lib/fetch/siteWideSEO';
+import TrackPageView from '@/components/TrackPageView';
 
 type PageParams = {
   params: { slug?: string[] };
@@ -125,7 +126,7 @@ const Page = async ({ params }: PageParams) => {
   }
 
   const { slug } = params;
-  const { defaultLocale, themeVariant } = await getSiteWideSEO();
+  const { defaultLocale, themeVariant, analytics } = await getSiteWideSEO();
 
   // Check if slug is undefined, which happens for the default locale's homepage due to generateStaticParams' internal logic
   // If it is, set the slug back to '' and locale to the default locale
@@ -163,6 +164,7 @@ const Page = async ({ params }: PageParams) => {
           }}
         />
       )}
+      {analytics?.mixpanel && <TrackPageView />}
       {sections.map((section) =>
         PageSection({
           ...section,

--- a/apps/nextjs-website/src/components/ConsentHandler.tsx
+++ b/apps/nextjs-website/src/components/ConsentHandler.tsx
@@ -52,7 +52,7 @@ const initMixpanel = (mixpanelConfig: NonNullable<MixpanelConfig>) =>
     ip: mixpanelConfig.ip,
     persistence: 'cookie',
     secure_cookie: true,
-    track_pageview: 'url-with-path',
+    opt_out_tracking_by_default: true,
   });
 
 const ConsentHandler = ({
@@ -60,6 +60,10 @@ const ConsentHandler = ({
   mixpanel: mixpanelConfig,
   matomoID,
 }: NonNullable<Analytics>) => {
+  if (mixpanelConfig) {
+    initMixpanel(mixpanelConfig);
+  }
+
   useEffect(() => {
     if (window.OptanonActiveGroups === undefined) {
       console.error('ERROR: Invalid OneTrust domain ID');
@@ -69,13 +73,15 @@ const ConsentHandler = ({
     window.OptanonWrapper = function () {
       window.OneTrust.OnConsentChanged(function () {
         if (hasConsent() && mixpanelConfig) {
-          initMixpanel(mixpanelConfig);
+          mixpanel.opt_in_tracking();
+          // Track page view of page where consent is given
+          mixpanel.track_pageview();
         }
       });
     };
 
     if (hasConsent() && mixpanelConfig) {
-      initMixpanel(mixpanelConfig);
+      mixpanel.opt_in_tracking();
     }
   }, [mixpanelConfig]);
 

--- a/apps/nextjs-website/src/components/TrackPageView.tsx
+++ b/apps/nextjs-website/src/components/TrackPageView.tsx
@@ -1,0 +1,21 @@
+'use client';
+import mixpanel from 'mixpanel-browser';
+import { useEffect } from 'react';
+
+const TrackPageView = () => {
+  useEffect(() => {
+    // eslint-disable-next-line functional/no-try-statements
+    try {
+      if (mixpanel.has_opted_in_tracking()) {
+        mixpanel.track_pageview();
+      }
+    } catch {
+      // This component should only be used if mixpanelConfig is defined
+      // Wrap calls in a try-catch anyway to prevent static website from breaking if the component is used incorrectly
+    }
+  }, []);
+
+  return null;
+};
+
+export default TrackPageView;


### PR DESCRIPTION
Automatic pageview tracking solutions offered by Mixpanel don't seem to work, possibly due to our sites being statically generated.

Change implementation to just initialize mixpanel with tracking disabled and track page views manually after consent is given.

#### List of Changes
<!--- Describe your changes in detail -->
- Remove automatic pageview tracking
- Modify initialization and separate it from tracking opt-in
- Call mixpanel.track_pageview inside each page

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Bug fix

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran locally in dev. Verified that opt in status gets saved correctly.

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
