### PR TITLE
Bug Fix: Switch MegaHeader's appCtaButton from using href to onClick to enable platform recognition

### DIFF
--- a/.changeset/real-pillows-whisper.md
+++ b/.changeset/real-pillows-whisper.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Switch MegaHeader's appCtaButton from using href to onClick to enable platform recognition

--- a/apps/nextjs-website/src/components/Header.tsx
+++ b/apps/nextjs-website/src/components/Header.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable functional/no-return-void */
 'use client';
 import { usePathname } from 'next/navigation';
 import Icon from './Icon';
@@ -18,6 +19,7 @@ declare global {
   interface Window {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     opera: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     MSStream: any;
   }
 }
@@ -30,7 +32,7 @@ const LinkLabelValues = {
   sl: 'NOVO',
 };
 
-const makeAppStoreHref = ({
+const openAppStore = ({
   appStoreLink,
   googleStoreLink,
   fallbackLink,
@@ -38,13 +40,22 @@ const makeAppStoreHref = ({
   appStoreLink: string;
   googleStoreLink: string;
   fallbackLink: string;
-}): string => {
+}): void => {
   // Detect OS
   const userAgent = navigator.userAgent || navigator.vendor || window.opera;
   const isIOS = /iPad|iPhone|iPod/.test(userAgent) && !window.MSStream;
   const isAndroid = /android/i.test(userAgent);
 
-  return isIOS ? appStoreLink : isAndroid ? googleStoreLink : fallbackLink;
+  if (isIOS) {
+    // eslint-disable-next-line functional/immutable-data
+    window.location.href = appStoreLink;
+  } else if (isAndroid) {
+    // eslint-disable-next-line functional/immutable-data
+    window.location.href = googleStoreLink;
+  } else {
+    // eslint-disable-next-line functional/immutable-data
+    window.location.href = fallbackLink;
+  }
 };
 
 const makeHeaderSublink = (
@@ -145,11 +156,7 @@ const makeMegaHeaderProps = (
       text: appCtaButton.text,
       variant: appCtaButton.variant,
       size: appCtaButton.size,
-      href: makeAppStoreHref({
-        appStoreLink: appCtaButton.appStoreLink,
-        googleStoreLink: appCtaButton.googleStoreLink,
-        fallbackLink: appCtaButton.fallbackLink,
-      }),
+      onClick: () => openAppStore(appCtaButton),
     },
   }),
   ...(drawer && {


### PR DESCRIPTION
Build would not succeed otherwise with an error of "navigation is not defined" due to trying to determine platform during static building

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Bug Fix

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran locally in dev

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
