### PR TITLE
[B2BP-1177] Handle Windows Phone user agent when opening app store from Header

### DIFF
--- a/.changeset/eleven-kiwis-wave.md
+++ b/.changeset/eleven-kiwis-wave.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Handle Windows Phone user agent when opening app store from Header

--- a/apps/nextjs-website/src/components/Header.tsx
+++ b/apps/nextjs-website/src/components/Header.tsx
@@ -43,10 +43,15 @@ const openAppStore = ({
 }): void => {
   // Detect OS
   const userAgent = navigator.userAgent || navigator.vendor || window.opera;
+  const isWindowsPhone = /windows phone/i.test(userAgent);
   const isIOS = /iPad|iPhone|iPod/.test(userAgent) && !window.MSStream;
   const isAndroid = /android/i.test(userAgent);
 
-  if (isIOS) {
+  if (isWindowsPhone) {
+    // Check windows phone first because recent windows phone user agents contain "Android" and "iPhone"
+    // eslint-disable-next-line functional/immutable-data
+    window.location.href = fallbackLink;
+  } else if (isIOS) {
     // eslint-disable-next-line functional/immutable-data
     window.location.href = appStoreLink;
   } else if (isAndroid) {


### PR DESCRIPTION
As per title.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Prevent Windows Phone users from being sent to Google Play

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran locally in dev

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
