### PR TITLE
Bug Fix - MixPanel: Opt in after init only if user was opted out

### DIFF
--- a/.changeset/chatty-eagles-brake.md
+++ b/.changeset/chatty-eagles-brake.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+MixPanel: Opt in after init only if user was opted out

--- a/apps/nextjs-website/src/components/ConsentHandler.tsx
+++ b/apps/nextjs-website/src/components/ConsentHandler.tsx
@@ -67,9 +67,11 @@ const ConsentHandler = ({
       secure_cookie: true,
     });
 
-    // Explicitely opt into tracking because init doesn't overwrite this value (wherever it's persisted)
-    // which means if the user previously opted out (when the code implemented the function), init won't change that
-    mixpanel.opt_in_tracking();
+    if (mixpanel.has_opted_out_tracking()) {
+      // Explicitely opt into tracking because init doesn't overwrite this value (wherever it's persisted)
+      // which means if the user previously opted out (when the code implemented the function), init won't change that
+      mixpanel.opt_in_tracking();
+    }
 
     // Track page view of page where consent is given
     mixpanel.track_pageview();


### PR DESCRIPTION
As per title

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Avoid flooding mixpanel with unnecessary opt_in events, while still making sure all users are explicitely opted_in, since the past implementation could have left them opted_out.

It's a small edge case, but we should address it, especially since the effort to do so is low.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran locally in dev

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
