### PR TITLE
[B2BP-1210] Update mixpanel configuration and implementation to work on iOS and track links

### DIFF
--- a/.changeset/thick-pandas-behave.md
+++ b/.changeset/thick-pandas-behave.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Update mixpanel configuration and implementation to work on iOS

--- a/apps/nextjs-website/package.json
+++ b/apps/nextjs-website/package.json
@@ -24,7 +24,7 @@
     "html-react-parser": "^5.0.11",
     "io-ts": "^2.2.20",
     "marked": "^11.1.0",
-    "mixpanel-browser": "^2.58.0",
+    "mixpanel-browser": "^2.61.1",
     "next": "14.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/apps/nextjs-website/react-components/components/Accordion/AccordionItem.tsx
+++ b/apps/nextjs-website/react-components/components/Accordion/AccordionItem.tsx
@@ -8,13 +8,9 @@ import { AccordionItemProps } from '../../types/Accordion/Accordion.types';
 import { useTheme } from '@mui/material/styles';
 import mixpanel from 'mixpanel-browser';
 
-export const AccordionItem: React.FC<AccordionItemProps & { trackItemOpen: boolean }> = ({
-  itemID,
-  header,
-  content,
-  themeVariant,
-  trackItemOpen,
-}) => {
+export const AccordionItem: React.FC<
+  AccordionItemProps & { trackItemOpen: boolean }
+> = ({ itemID, header, content, themeVariant, trackItemOpen }) => {
   const controlsId = React.useId() + '-controls';
   const headerId = React.useId() + '-header';
   const { palette } = useTheme();
@@ -34,14 +30,13 @@ export const AccordionItem: React.FC<AccordionItemProps & { trackItemOpen: boole
     if (trackItemOpen && itemID) {
       try {
         if (!mixpanel.has_opted_out_tracking()) {
-          mixpanel.track('FAQ', { 'FAQ Name': itemID })
-          alert('TRACKED FAQ');
+          mixpanel.track('FAQ', { 'FAQ Name': itemID });
         }
       } catch {
         // Mixpanel is not initialized
       }
     }
-  }
+  };
 
   useLayoutEffect(() => {
     if (itemID && window.location.hash === `#${itemID}`) {

--- a/apps/nextjs-website/react-components/components/Accordion/AccordionItem.tsx
+++ b/apps/nextjs-website/react-components/components/Accordion/AccordionItem.tsx
@@ -33,8 +33,9 @@ export const AccordionItem: React.FC<AccordionItemProps & { trackItemOpen: boole
   const triggerMixpanelFAQEvent = () => {
     if (trackItemOpen && itemID) {
       try {
-        if (mixpanel.has_opted_in_tracking()) {
+        if (!mixpanel.has_opted_out_tracking()) {
           mixpanel.track('FAQ', { 'FAQ Name': itemID })
+          alert('TRACKED FAQ');
         }
       } catch {
         // Mixpanel is not initialized

--- a/apps/nextjs-website/react-components/components/MegaHeader/MegaHeader.tsx
+++ b/apps/nextjs-website/react-components/components/MegaHeader/MegaHeader.tsx
@@ -58,7 +58,7 @@ const MegaHeader = ({
 
   const mixpanelTrackActiveCtaClick = (buttonOnClick?: Function) => {
     try {
-      if (activeCta?.trackEvent && mixpanel.has_opted_in_tracking()) {
+      if (activeCta?.trackEvent && !mixpanel.has_opted_out_tracking()) {
         mixpanel.track(activeCta.trackEvent, {
           Page: window.location.pathname,
         });
@@ -75,7 +75,7 @@ const MegaHeader = ({
 
   const mixpanelTrackSublinkClick = (tab: string, href: string) => {
     try {
-      if (trackSublinkClickEvent && mixpanel.has_opted_in_tracking()) {
+      if (trackSublinkClickEvent && !mixpanel.has_opted_out_tracking()) {
         mixpanel.track(trackSublinkClickEvent, {
           Tab: tab,
           Link: href,

--- a/apps/nextjs-website/react-components/components/common/StoreButtons.tsx
+++ b/apps/nextjs-website/react-components/components/common/StoreButtons.tsx
@@ -7,27 +7,40 @@ import GoogleStoreOutlinedDark from '../../assets/googleStoreOutlinedDark.png';
 import GoogleStoreBadge from '../../assets/googleStoreBadge.png';
 import AppleStoreBadge from '../../assets/appleStoreBadge.png';
 import mixpanel from 'mixpanel-browser';
+import { useEffect, useState } from 'react';
 
 export const AppStoreButton = ({
   badge,
   darkTheme,
   ...linkProps
 }: Omit<LinkProps, 'onClick'> & { darkTheme?: boolean; badge?: boolean }) => {
-  const mixpanelTrackEvent = () => {
+  const [randomID, setRandomID] = useState<string | undefined>(undefined);
+
+  // Generate randomID for tracking
+  // This has to be done inside useEffect (client side)
+  // Otherwise the server will generate a different randomID when building statically / generating server side
+  useEffect(() => {
+    setRandomID(Math.random().toString(36).substring(7));
+  }, []);
+
+  useEffect(() => {
     try {
-      if (mixpanel.has_opted_in_tracking()) {
-        // Hard-coding appio event name since no other tenant is currently using storeButtons
-        mixpanel.track('IO_WEBSITE_HP_DOWNLOAD_APPSTORE', {
-          Page: window.location.pathname,
-        });
+      if (randomID && !mixpanel.has_opted_out_tracking()) {
+        mixpanel.track_links(
+          `#${randomID}`,
+          'IO_WEBSITE_HP_DOWNLOAD_APPSTORE',
+          {
+            Page: window.location.pathname,
+          },
+        );
       }
     } catch {
       // Mixpanel is not initialized
     }
-  };
+  }, [randomID]);
 
   return (
-    <Link {...linkProps} target='_blank' onClick={mixpanelTrackEvent}>
+    <Link id={randomID} {...linkProps}>
       <Image
         src={
           badge
@@ -50,21 +63,33 @@ export const GooglePlayButton = ({
   darkTheme,
   ...linkProps
 }: Omit<LinkProps, 'onClick'> & { darkTheme?: boolean; badge?: boolean }) => {
-  const mixpanelTrackEvent = () => {
+  const [randomID, setRandomID] = useState<string | undefined>(undefined);
+
+  // Generate randomID for tracking
+  // This has to be done inside useEffect (client side)
+  // Otherwise the server will generate a different randomID when building statically / generating server side
+  useEffect(() => {
+    setRandomID(Math.random().toString(36).substring(7));
+  }, []);
+
+  useEffect(() => {
     try {
-      if (mixpanel.has_opted_in_tracking()) {
-        // Hard-coding appio event name since no other tenant is currently using storeButtons
-        mixpanel.track('IO_WEBSITE_HP_DOWNLOAD_GOOGLEPLAY', {
-          Page: window.location.pathname,
-        });
+      if (randomID && !mixpanel.has_opted_out_tracking()) {
+        mixpanel.track_links(
+          `#${randomID}`,
+          'IO_WEBSITE_HP_DOWNLOAD_GOOGLEPLAY',
+          {
+            Page: window.location.pathname,
+          },
+        );
       }
     } catch {
       // Mixpanel is not initialized
     }
-  };
+  }, [randomID]);
 
   return (
-    <Link {...linkProps} target='_blank' onClick={mixpanelTrackEvent}>
+    <Link id={randomID} {...linkProps}>
       <Image
         src={
           badge

--- a/apps/nextjs-website/src/components/ConsentHandler.tsx
+++ b/apps/nextjs-website/src/components/ConsentHandler.tsx
@@ -65,13 +65,8 @@ const ConsentHandler = ({
       ip: mixpanelConfig.ip,
       persistence: 'cookie',
       secure_cookie: true,
+      batch_requests: false,
     });
-
-    if (mixpanel.has_opted_out_tracking()) {
-      // Explicitely opt into tracking because init doesn't overwrite this value (wherever it's persisted)
-      // which means if the user previously opted out (when the code implemented the function), init won't change that
-      mixpanel.opt_in_tracking();
-    }
 
     // Track page view of page where consent is given
     mixpanel.track_pageview();

--- a/apps/nextjs-website/src/components/TrackPageView.tsx
+++ b/apps/nextjs-website/src/components/TrackPageView.tsx
@@ -7,7 +7,7 @@ const TrackPageView = () => {
     // eslint-disable-next-line functional/no-try-statements
     try {
       // Check opt in status to be sure
-      if (mixpanel.has_opted_in_tracking()) {
+      if (!mixpanel.has_opted_out_tracking()) {
         mixpanel.track_pageview();
       }
     } catch {

--- a/package-lock.json
+++ b/package-lock.json
@@ -221,7 +221,7 @@
         "html-react-parser": "^5.0.11",
         "io-ts": "^2.2.20",
         "marked": "^11.1.0",
-        "mixpanel-browser": "^2.58.0",
+        "mixpanel-browser": "^2.61.1",
         "next": "14.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -27364,9 +27364,9 @@
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
     },
     "node_modules/mixpanel-browser": {
-      "version": "2.58.0",
-      "resolved": "https://registry.npmjs.org/mixpanel-browser/-/mixpanel-browser-2.58.0.tgz",
-      "integrity": "sha512-ZayNE4augjSJh5RxYKRPhFe1jzS9HZnoowvZaN4DaUeCezbLGVck46L+N9X8VLtK74UgLUYfehPgCr41rtgpRA==",
+      "version": "2.61.1",
+      "resolved": "https://registry.npmjs.org/mixpanel-browser/-/mixpanel-browser-2.61.1.tgz",
+      "integrity": "sha512-M1yanr4T6TDn0wupEKdPVEcNtoMOGnFBcETMkU1O9gfLhvmPlt/GXZb2jY7sA3LmYLtH3o+uXRSETSdLSjb38Q==",
       "dependencies": {
         "rrweb": "2.0.0-alpha.13"
       }


### PR DESCRIPTION
As per title.

#### List of Changes
<!--- Describe your changes in detail -->
- Disabled mixpanel's default batching behaviour which prevented link tracking event to immediately be sent to the mixpanel dashboard
- Refactored storeButtons to use track_links function instead of standard track
- Removed checks on mixpanel.has_opted_in_tracking and substituted them with checks on !mixpanel.has_opted_out_tracking, this because both values can be false and this way we can check the user has not explicitely opted out of tracking, while not removing tracking is has_opted_in_tracking wrongfully returns false as it did until now

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Bug Fix

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran locally in dev and on iOS (Safari and Chrome)

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
