### PR TITLE
[B2BP-1216] Make Footer's social links required

### DIFF
--- a/.changeset/green-actors-explode.md
+++ b/.changeset/green-actors-explode.md
@@ -1,0 +1,5 @@
+---
+"strapi-cms": patch
+---
+
+Make Footer's social links required

--- a/apps/strapi-cms/src/api/footer/content-types/footer/schema.json
+++ b/apps/strapi-cms/src/api/footer/content-types/footer/schema.json
@@ -87,7 +87,8 @@
         "i18n": {
           "localized": true
         }
-      }
+      },
+      "required": true
     }
   }
 }


### PR DESCRIPTION
NextJS requires Footer's social links to be input, while Strapi did not.
This PR fixes that by making the field required in Strapi as well.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Bug Fix

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran locally in dev

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
