### PR TITLE
[B2BP-1224] Update strapi-plugin-static-deploy to add RBAC

### DIFF
--- a/.changeset/rotten-badgers-flow.md
+++ b/.changeset/rotten-badgers-flow.md
@@ -1,0 +1,5 @@
+---
+"strapi-cms": patch
+---
+
+Update strapi-plugin-static-deploy to add RBAC

--- a/apps/strapi-cms/package.json
+++ b/apps/strapi-cms/package.json
@@ -35,7 +35,7 @@
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.0.0",
     "strapi-plugin-preview-button": "^3.0.0",
-    "strapi-plugin-static-deploy": "^0.0.2",
+    "strapi-plugin-static-deploy": "^0.0.4",
     "styled-components": "^6.0.0"
   },
   "strapi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -276,7 +276,7 @@
         "react-dom": "^18.0.0",
         "react-router-dom": "^6.0.0",
         "strapi-plugin-preview-button": "^3.0.0",
-        "strapi-plugin-static-deploy": "^0.0.2",
+        "strapi-plugin-static-deploy": "^0.0.4",
         "styled-components": "^6.0.0"
       },
       "devDependencies": {
@@ -33059,9 +33059,9 @@
       }
     },
     "node_modules/strapi-plugin-static-deploy": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/strapi-plugin-static-deploy/-/strapi-plugin-static-deploy-0.0.2.tgz",
-      "integrity": "sha512-KjwFY8DxOB0/ZpdpnPWwhIr/EBWddUtP0OxMsd4v8GKp+IAXR9+p4v33G58s09qL9iZv0cLcjUR88LOwfACbKQ==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/strapi-plugin-static-deploy/-/strapi-plugin-static-deploy-0.0.4.tgz",
+      "integrity": "sha512-TS4cRMfAja0DIAjOBQly4Xx6stpoDWVLLnNzyIEINkB4/FBmqkPaIg13vabv1pHRFxj7wbvBqbk88mnxDSNy8Q==",
       "dependencies": {
         "@strapi/design-system": "^2.0.0-rc.14",
         "@strapi/icons": "^2.0.0-rc.14",


### PR DESCRIPTION
As per title.
This update makes it so user will have to have specific permissions to see the deploy history and to trigger new builds.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
CMS UX

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran locally in dev

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
