### PR TITLE
[B2BP-1249] Update and utilize NotFoundPage

### DIFF
--- a/.changeset/curly-moose-beg.md
+++ b/.changeset/curly-moose-beg.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Update and utilize NotFoundPage

--- a/apps/nextjs-website/react-components/components/NotFoundPage/NotFoundPage.tsx
+++ b/apps/nextjs-website/react-components/components/NotFoundPage/NotFoundPage.tsx
@@ -4,11 +4,13 @@ import Image from 'next/image';
 import { Box, Typography, Link, Stack, useTheme } from '@mui/material';
 import { NotFoundPageProps } from '@react-components/types/NotFoundPage/NotFoundPage.types';
 import {
-  IoBackgroundColor,
   SendBackgroundColor,
   TextColor,
 } from '@react-components/components/common/Common.helpers';
 import EmptyImage from '@react-components/assets/Empty.png';
+import { usePathname, useRouter } from 'next/navigation';
+
+type Locale = NotFoundPageProps['defaultLocale'];
 
 const localizedTexts = {
   it: {
@@ -44,43 +46,49 @@ const localizedTexts = {
 };
 
 const NotFoundPage = ({
-  redirectUrl,
   disableRedirect,
-  theme,
-  themeVariant,
-  sectionID,
-  locale,
+  defaultLocale,
+  validLocales,
 }: NotFoundPageProps) => {
   const muiTheme = useTheme();
+  const pathname = usePathname();
+  const router = useRouter();
+
+  const isValidLocale = (locale: string): boolean => {
+    return validLocales.includes(locale as Locale);
+  };
+
+  const redirectUrl =
+    pathname.length < 5
+      ? // No locale (/x) or an invalid locale's homepage (/xx/)
+        // (If it was valid, we would not be here in the 404 page)
+        // Redirect to the default locale's homepage
+        '/'
+      : pathname[3] === '/' && isValidLocale(pathname.slice(1, 3))
+        ? // If a valid locale is present in the pathname
+          // Redirect to said locale's homepage
+          `/${pathname.slice(1, 3) === defaultLocale ? '' : pathname.slice(1, 3)}`
+        : // No locale has been specified, simply redirect to the default locale's homepage
+          '/';
+
+  const locale = redirectUrl === '/' ? defaultLocale : redirectUrl.slice(1, 3);
 
   useEffect(() => {
     if (disableRedirect) return;
     const timeout = setTimeout(() => {
-      window.location.href = redirectUrl;
+      router.replace(redirectUrl);
     }, 5000);
     return () => clearTimeout(timeout);
   }, []);
 
-  const backgroundColor =
-    themeVariant === 'SEND'
-      ? SendBackgroundColor(theme)
-      : IoBackgroundColor(theme);
+  const backgroundColor = SendBackgroundColor('light');
+  const textColor = TextColor('light');
+  const linkColor = muiTheme.palette.primary.main;
 
-  const textColor =
-    theme === 'dark' ? muiTheme.palette.primary.contrastText : TextColor(theme);
-
-  const linkColor =
-    theme === 'dark'
-      ? muiTheme.palette.custom.white
-      : themeVariant === 'SEND'
-        ? muiTheme.palette.primary.main
-        : muiTheme.palette.custom.primaryColorDark;
-
-  const texts = localizedTexts[locale];
+  const texts = localizedTexts[locale as Locale];
 
   return (
     <Box
-      id={sectionID ?? undefined}
       minHeight={{ xs: 'auto', md: '70vh' }}
       display='flex'
       justifyContent='center'

--- a/apps/nextjs-website/react-components/types/NotFoundPage/NotFoundPage.types.ts
+++ b/apps/nextjs-website/react-components/types/NotFoundPage/NotFoundPage.types.ts
@@ -1,7 +1,7 @@
-import { SectionProps } from '@react-components/types/common/Common.types';
+type Locale = 'it' | 'en' | 'fr' | 'de' | 'sl';
 
-export interface NotFoundPageProps extends SectionProps {
-  redirectUrl: string;
+export interface NotFoundPageProps {
   disableRedirect?: boolean;
-  locale: 'it' | 'en' | 'fr' | 'de' | 'sl';
+  defaultLocale: Locale;
+  validLocales: Array<Locale>;
 }

--- a/apps/nextjs-website/src/app/not-found.tsx
+++ b/apps/nextjs-website/src/app/not-found.tsx
@@ -1,30 +1,57 @@
-'use client';
-import { redirect, usePathname } from 'next/navigation';
+import { ThemeProvider } from '@mui/material';
+import NotFoundPage from '@react-components/components/NotFoundPage/NotFoundPage';
+import { theme } from './theme';
+import {
+  getFooterProps,
+  getHeaderProps,
+  getPreHeaderProps,
+  getSiteWideSEO,
+} from '@/lib/api';
+import PreHeader from '@/components/PreHeader';
+import Header from '@/components/Header';
+import Footer from '@/components/Footer';
+import { Locale } from '@/lib/fetch/siteWideSEO';
 
-const NotFound = () => {
-  const pathname = usePathname();
+const NotFound = async () => {
+  const { defaultLocale, locales, themeVariant } = await getSiteWideSEO();
 
-  if (pathname.length < 5) {
-    // No locale (/x) or an invalid locale's homepage (/xx/)
-    // Redirect to the default locale's homepage
-    redirect('/');
-  }
+  const preHeaderProps = await getPreHeaderProps(defaultLocale);
+  const headerProps = await getHeaderProps(defaultLocale, defaultLocale);
+  const footerProps = await getFooterProps(defaultLocale);
+  const localesArray = Object.keys(locales).filter(
+    (locale) => locales[locale as Locale],
+  );
 
-  if (pathname[3] === '/') {
-    // If an hypothetical locale is present in the pathname
-    // Redirect to said locale's homepage
-    const locale = pathname.slice(1, 3);
-    redirect(`/${locale}`);
-    /**
-     * We are not checking if the locale has a homepage
-     * because, if it doesn't, a new 404 page will be shown and
-     * the check at line 7 will redirect to the default locale's homepage.
-     * This is done in an effort to maintain the user's locale preference.
-     **/
-  }
-
-  // No locale has been specified, simply redirect to the default locale's homepage
-  redirect('/');
+  return (
+    <ThemeProvider theme={theme}>
+      <html lang={defaultLocale}>
+        <body style={{ margin: 0 }}>
+          {preHeaderProps && (
+            <PreHeader
+              {...preHeaderProps}
+              themeVariant={themeVariant}
+              locale={defaultLocale}
+              defaultLocale={defaultLocale}
+            />
+          )}
+          <Header
+            {...headerProps}
+            locale={defaultLocale}
+            defaultLocale={defaultLocale}
+          />
+          <NotFoundPage
+            defaultLocale={defaultLocale}
+            validLocales={localesArray as Array<Locale>}
+          />
+          <Footer
+            {...footerProps}
+            locales={localesArray as Array<Locale>}
+            defaultLocale={defaultLocale}
+          />
+        </body>
+      </html>
+    </ThemeProvider>
+  );
 };
 
 export default NotFound;

--- a/apps/nextjs-website/stories/Footer/light.stories.tsx
+++ b/apps/nextjs-website/stories/Footer/light.stories.tsx
@@ -21,7 +21,7 @@ export default meta;
 
 const Template: StoryFn<Props> = (args) => <StorybookFooter {...args} />;
 
-export const Default = Template.bind({});
+export const Default: StoryFn<typeof StorybookFooter> = Template.bind({});
 Default.args = {
   showFundedByNextGenerationEULogo: true,
 };

--- a/apps/nextjs-website/stories/MegaHeader/light.stories.tsx
+++ b/apps/nextjs-website/stories/MegaHeader/light.stories.tsx
@@ -39,7 +39,7 @@ const Template: StoryFn<StorybookMegaHeaderProps> = (args) => (
   <StorybookMegaHeader {...args} />
 );
 
-export const MegaHeaderFullWithLogo = Template.bind({});
+export const MegaHeaderFullWithLogo: StoryFn<typeof StorybookMegaHeader> = Template.bind({});
 MegaHeaderFullWithLogo.args = {
   customLogo: null,
   showCtaButton: true,

--- a/apps/nextjs-website/stories/NotFoundPage/NotFoundPage.stories.tsx
+++ b/apps/nextjs-website/stories/NotFoundPage/NotFoundPage.stories.tsx
@@ -1,58 +1,40 @@
 import { Meta, StoryFn } from '@storybook/react';
-import NotFoundPage from '@react-components/components/NotFoundPage/NotFoundPage';
-import { NotFoundPageProps } from '@react-components/types/NotFoundPage/NotFoundPage.types';
+import { StorybookNotFoundPage, StorybookNotFoundPageProps } from './component';
 
-const meta: Meta<typeof NotFoundPage> = {
+const meta: Meta<typeof StorybookNotFoundPage> = {
   title: 'Components/NotFoundPage/Default',
-  component: NotFoundPage,
+  component: StorybookNotFoundPage,
   tags: ['autodocs'],
+  args: {
+    defaultLocale: 'it',
+  },
   argTypes: {
-    theme: {
-      control: { type: 'radio' },
-      options: ['light', 'dark'],
-    },
-    themeVariant: {
-      control: { type: 'radio' },
-      options: ['SEND', 'IO'],
+    defaultLocale: {
+      name: 'Lingua',
+      control: {
+        type: 'select',
+        labels: {
+          it: 'Italiano',
+          en: 'English',
+          fr: 'Français',
+          de: 'Deutsch',
+          sl: 'Slovenščina',
+        },
+      },
+      options: ['it', 'en', 'fr', 'de', 'sl'],
+    }
+  },
+  parameters: {
+    nextjs: {
+      appDirectory: true,
     },
   },
 };
 
 export default meta;
 
-const Template: StoryFn<NotFoundPageProps> = (args) => (
-  <NotFoundPage {...args} />
+const Template: StoryFn<StorybookNotFoundPageProps> = (args) => (
+  <StorybookNotFoundPage {...args} />
 );
 
-export const Italian = Template.bind({});
-Italian.args = {
-  redirectUrl: '/',
-  disableRedirect: true,
-  theme: 'light',
-  themeVariant: 'SEND',
-  locale: 'it',
-};
-
-export const English = Template.bind({});
-English.args = {
-  ...Italian.args,
-  locale: 'en',
-};
-
-export const French = Template.bind({});
-French.args = {
-  ...Italian.args,
-  locale: 'fr',
-};
-
-export const German = Template.bind({});
-German.args = {
-  ...Italian.args,
-  locale: 'de',
-};
-
-export const Slovenian = Template.bind({});
-Slovenian.args = {
-  ...Italian.args,
-  locale: 'sl',
-};
+export const Default: StoryFn<typeof StorybookNotFoundPage> = Template.bind({});

--- a/apps/nextjs-website/stories/NotFoundPage/component.tsx
+++ b/apps/nextjs-website/stories/NotFoundPage/component.tsx
@@ -1,0 +1,12 @@
+import NotFoundPage from '@react-components/components/NotFoundPage/NotFoundPage';
+import { NotFoundPageProps } from '@react-components/types/NotFoundPage/NotFoundPage.types';
+
+export interface StorybookNotFoundPageProps {
+  defaultLocale: NotFoundPageProps['defaultLocale'];
+}
+
+export const StorybookNotFoundPage = ({
+  defaultLocale,
+}: StorybookNotFoundPageProps) => {
+  return <NotFoundPage defaultLocale={defaultLocale} disableRedirect={true} validLocales={['it', 'en', 'de', 'fr', 'sl']} />;
+};

--- a/apps/nextjs-website/stories/PreFooter/default.stories.tsx
+++ b/apps/nextjs-website/stories/PreFooter/default.stories.tsx
@@ -57,7 +57,7 @@ const Template: StoryFn<StorybookPreFooterProps> = (args) => (
   <StorybookPreFooter {...args} />
 );
 
-export const Default = Template.bind({});
+export const Default: StoryFn<typeof StorybookPreFooter> = Template.bind({});
 Default.args = {
   title: 'Scarica l’app IO',
   theme: 'light',

--- a/apps/nextjs-website/stories/PreHeader/light.stories.tsx
+++ b/apps/nextjs-website/stories/PreHeader/light.stories.tsx
@@ -34,7 +34,7 @@ const Template: StoryFn<StorybookPreHeaderProps> = (args) => (
   <StorybookPreHeader {...args} />
 );
 
-export const PreHeaderDefault = Template.bind({});
+export const PreHeaderDefault: StoryFn<typeof StorybookPreHeader> = Template.bind({});
 PreHeaderDefault.args = {
   leftText: 'PagoPA S.p.A.',
   rightText: 'Assistenza',


### PR DESCRIPTION
Utilize NotFoundPage component from react-components in NextJS's `notfound.tsx` file.

Update logic of both the component and the page it's used in to keep the 404 page statically generated (aka move all client-side logic to the component).

Add Header, Footer and PreHeader around the 404 page.

Update redirection logic to take locales and the default locale into account to prevent "404 page chains".

Fix build error introduced during Single Types' Storybook optimization.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Better website UX

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran locally in dev and storybook.
Built locally and served locally to verify localization and redirection work correctly.

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
