### PR TITLE
[B2BP-879] Officialize admin password-recovery email

### DIFF
--- a/.changeset/nine-sloths-mate.md
+++ b/.changeset/nine-sloths-mate.md
@@ -1,0 +1,5 @@
+---
+"strapi-cms": patch
+---
+
+Officialize admin password recovery email

--- a/apps/strapi-cms/config/admin.ts
+++ b/apps/strapi-cms/config/admin.ts
@@ -13,9 +13,19 @@ export default ({ env }: any) => ({
   autoOpen: false,
   forgotPassword: {
     emailTemplate: {
-      subject: "Strapi - Password Reset",
-      text: 'Admin configuration template testing',
-      html: '<p>Admin configuration <em>template</em> testing</p>'
+      subject: 'Strapi - Recupero Password',
+      text: `Abbiamo ricevuto una richiesta di reimpostazione della password per il tuo account.
+      Per crearne una nuova, clicca sul link qui sotto:
+      
+      <%= url %>
+      
+      Se non hai richiesto tu questa operazione, consigliamo di notificare un amministratore: la tua password attuale resterà invariata.
+      
+      Buon lavoro!`,
+      html: `<p>Abbiamo ricevuto una richiesta di reimpostazione della password per il tuo account.<br/>Per crearne una nuova, clicca sul link qui sotto:</p>
+      <a href='<%= url %>'><%= url %></a>
+      <p>Se non hai richiesto tu questa operazione, consigliamo di notificare un amministratore: la tua password attuale resterà invariata.</p>
+      <p>Buon lavoro!</p>`
     }
   }
 });

--- a/apps/strapi-cms/config/server.ts
+++ b/apps/strapi-cms/config/server.ts
@@ -1,6 +1,7 @@
 export default ({ env }: any) => ({
   host: env('HOST', '0.0.0.0'),
   port: env.int('PORT', 1337),
+  url: env('ADMIN_PANEL_URL'),
   app: {
     keys: env.array('APP_KEYS'),
   },


### PR DESCRIPTION
Implemented password recovery for CMS users.

#### List of Changes
<!--- Describe your changes in detail -->
- Configure Amazon SES
- Update config/admin's forgotPassword.emailTemplate field
- Add env variable containing CMS's admin panel's URL to be used in the password recovery email

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
CMS user autonomy

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested locally using MailDev

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
