### PR TITLE
[B2BP-1283] Update Strapi Deploy Plugin to fix production button enable logic

### DIFF
--- a/.changeset/long-bananas-sit.md
+++ b/.changeset/long-bananas-sit.md
@@ -1,0 +1,5 @@
+---
+"strapi-cms": patch
+---
+
+Update Strapi Deploy Plugin to fix production button enable logic

--- a/apps/strapi-cms/package.json
+++ b/apps/strapi-cms/package.json
@@ -36,7 +36,7 @@
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.0.0",
     "strapi-plugin-preview-button": "^3.0.0",
-    "strapi-plugin-static-deploy": "^0.0.8",
+    "strapi-plugin-static-deploy": "^0.0.9",
     "styled-components": "^6.0.0"
   },
   "strapi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -277,7 +277,7 @@
         "react-dom": "^18.0.0",
         "react-router-dom": "^6.0.0",
         "strapi-plugin-preview-button": "^3.0.0",
-        "strapi-plugin-static-deploy": "^0.0.8",
+        "strapi-plugin-static-deploy": "^0.0.9",
         "styled-components": "^6.0.0"
       },
       "devDependencies": {
@@ -33500,9 +33500,9 @@
       }
     },
     "node_modules/strapi-plugin-static-deploy": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/strapi-plugin-static-deploy/-/strapi-plugin-static-deploy-0.0.8.tgz",
-      "integrity": "sha512-P/ulZdwnFyiu7sYnCk5PMHFSZ4vvzrFvl6big6Ssyz8GGrUPFMfM9MU/FlMVqaLy4mCQet0HUME6g2jhDTkn2g==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/strapi-plugin-static-deploy/-/strapi-plugin-static-deploy-0.0.9.tgz",
+      "integrity": "sha512-LQyyuMLXg15xSaj2CE97Y4l4BYvik+xiAmdMXyAHGvqQUDfpoqVW0RX6JGB6rXDmAxAd6Aj5pAviADV3WVlW/w==",
       "dependencies": {
         "@strapi/design-system": "^2.0.0-rc.14",
         "@strapi/icons": "^2.0.0-rc.14",


### PR DESCRIPTION
As per title.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Bugs:
- Production deployment button was not enabled even under the correct circumstances (no updates and last staging workflow ended successfully).
- The flag for unstaged updates was not being removed after a successful staging workflow, making the production deployment prevent from starting even if the button was enabled (this was due to a still valid and present check at the click of the production button).

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran locally in dev using actual production workflows (demo tenant).

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
