### PR TITLE
[B2BP-1298] iFrame: Allow child page to request scrolling to a section outside of the iframe

### DIFF
--- a/.changeset/wise-dodos-listen.md
+++ b/.changeset/wise-dodos-listen.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+iFrame: Allow child page to request scrolling to a section outside of the iFrame

--- a/apps/nextjs-website/react-components/components/IFrame/IFrame.tsx
+++ b/apps/nextjs-website/react-components/components/IFrame/IFrame.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import {
   IFrameProps,
   IFrameResizerRef,
@@ -20,6 +20,20 @@ const IFrame = ({ src }: IFrameProps) => {
       iframeRef.current.getElement().style.height = `${newChildHeight}px`;
     }
   };
+
+  useEffect(() => {
+    const handleScrollMessage = (event: MessageEvent) => {
+      if (event.data?.type === 'scrollTo' && event.data?.target) {
+        const targetSection = document.getElementById(event.data.target);
+        if (targetSection) {
+          targetSection.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }
+      }
+    };
+
+    window.addEventListener('message', handleScrollMessage);
+    return () => window.removeEventListener('message', handleScrollMessage);
+  }, []);
 
   return (
     <IframeResizer


### PR DESCRIPTION
As per title.
Implemented using messages (parent.postMessage on child page and event handler for 'message' on parent).

Expected message is structured like so: `{ type: 'scrollTo', target: 'section-id' }`

#### List of Changes
<!--- Describe your changes in detail -->
- Add 'message' event handler to iFrame component

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Feature Request (SEND)

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
