### PR TITLE
[BUG FIX] iFrame: Only insert section tag if sectionID exists

### DIFF
--- a/.changeset/great-toys-pump.md
+++ b/.changeset/great-toys-pump.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+iFrame: Only insert section tag if sectionID exists

--- a/apps/nextjs-website/react-components/components/IFrame/IFrame.tsx
+++ b/apps/nextjs-website/react-components/components/IFrame/IFrame.tsx
@@ -35,8 +35,8 @@ const IFrame = ({ src, sectionID }: IFrameProps) => {
     return () => window.removeEventListener('message', handleScrollMessage);
   }, []);
 
-  return (
-    <section {...(sectionID && { id: sectionID })}>
+  return sectionID ? (
+    <section id={sectionID}>
       <IframeResizer
         license='GPLv3' // Open Source License
         src={src}
@@ -46,6 +46,15 @@ const IFrame = ({ src, sectionID }: IFrameProps) => {
         allow='geolocation; clipboard-write'
       />
     </section>
+  ) : (
+    <IframeResizer
+      license='GPLv3' // Open Source License
+      src={src}
+      style={{ width: '100%', height: '100vh', border: 'none' }}
+      forwardRef={iframeRef}
+      onMessage={handleMessage}
+      allow='geolocation; clipboard-write'
+    />
   );
 };
 


### PR DESCRIPTION
As per title

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`section` tag seems to break automatic resizing

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
