### PR TITLE
[B2BP-1271] [B2BP-1275] Add email notifications upon workflow trigger and end

### DIFF
--- a/.changeset/warm-lions-shop.md
+++ b/.changeset/warm-lions-shop.md
@@ -1,0 +1,5 @@
+---
+"strapi-cms": patch
+---
+
+Add email notifications upon workflow trigger and end

--- a/.github/workflows/notify_prod_workflow_end.yaml
+++ b/.github/workflows/notify_prod_workflow_end.yaml
@@ -1,0 +1,56 @@
+name: Notify of Production Workflow End
+
+on:
+  workflow_run:
+    workflows: ["Promote Website to Production"]
+    types:
+      - completed
+
+jobs:
+  call-api-demo:
+    if: ${{ github.event.workflow_run.inputs.environment == 'demo' }}
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Call Strapi API - DEMO
+        shell: bash
+        run: |
+            curl -X POST ${{ vars.DEMO_STRAPI_URL }}/static-deploy/notify-workflow-end \
+              -H "Content-Type: application/json" \
+              -H "Authorization: Bearer ${{ secrets.DEMO_WORKFLOW_NOTIFICATIONS_BEARER_TOKEN }}" \
+              -d '{"event": "prod-end"}'
+  
+  call-api-send:
+    if: ${{ github.event.workflow_run.inputs.environment == 'send' }}
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Call Strapi API - SEND
+        shell: bash
+        run: |
+            curl -X POST ${{ vars.SEND_STRAPI_URL }}/static-deploy/notify-workflow-end \
+              -H "Content-Type: application/json" \
+              -H "Authorization: Bearer ${{ secrets.SEND_WORKFLOW_NOTIFICATIONS_BEARER_TOKEN }}" \
+              -d '{"event": "prod-end"}'
+  
+  call-api-appio:
+    if: ${{ github.event.workflow_run.inputs.environment == 'appio' }}
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Call Strapi API - APPIO
+        shell: bash
+        run: |
+            curl -X POST ${{ vars.APPIO_STRAPI_URL }}/static-deploy/notify-workflow-end \
+              -H "Content-Type: application/json" \
+              -H "Authorization: Bearer ${{ secrets.APPIO_WORKFLOW_NOTIFICATIONS_BEARER_TOKEN }}" \
+              -d '{"event": "prod-end"}'
+  
+  call-api-interop:
+    if: ${{ github.event.workflow_run.inputs.environment == 'interop' }}
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Call Strapi API - INTEROP
+        shell: bash
+        run: |
+            curl -X POST ${{ vars.INTEROP_STRAPI_URL }}/static-deploy/notify-workflow-end \
+              -H "Content-Type: application/json" \
+              -H "Authorization: Bearer ${{ secrets.INTEROP_WORKFLOW_NOTIFICATIONS_BEARER_TOKEN }}" \
+              -d '{"event": "prod-end"}'

--- a/.github/workflows/notify_staging_workflow_end.yaml
+++ b/.github/workflows/notify_staging_workflow_end.yaml
@@ -1,0 +1,56 @@
+name: Notify of Staging Workflow End
+
+on:
+  workflow_run:
+    workflows: ["Deploy Website to Staging"]
+    types:
+      - completed
+
+jobs:
+  call-api-demo:
+    if: ${{ github.event.workflow_run.inputs.environment == 'demo' }}
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Call Strapi API - DEMO
+        shell: bash
+        run: |
+            curl -X POST ${{ vars.DEMO_STRAPI_URL }}/static-deploy/notify-workflow-end \
+              -H "Content-Type: application/json" \
+              -H "Authorization: Bearer ${{ secrets.DEMO_WORKFLOW_NOTIFICATIONS_BEARER_TOKEN }}" \
+              -d '{"event": "staging-end"}'
+  
+  call-api-send:
+    if: ${{ github.event.workflow_run.inputs.environment == 'send' }}
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Call Strapi API - SEND
+        shell: bash
+        run: |
+            curl -X POST ${{ vars.SEND_STRAPI_URL }}/static-deploy/notify-workflow-end \
+              -H "Content-Type: application/json" \
+              -H "Authorization: Bearer ${{ secrets.SEND_WORKFLOW_NOTIFICATIONS_BEARER_TOKEN }}" \
+              -d '{"event": "staging-end"}'
+  
+  call-api-appio:
+    if: ${{ github.event.workflow_run.inputs.environment == 'appio' }}
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Call Strapi API - APPIO
+        shell: bash
+        run: |
+            curl -X POST ${{ vars.APPIO_STRAPI_URL }}/static-deploy/notify-workflow-end \
+              -H "Content-Type: application/json" \
+              -H "Authorization: Bearer ${{ secrets.APPIO_WORKFLOW_NOTIFICATIONS_BEARER_TOKEN }}" \
+              -d '{"event": "staging-end"}'
+  
+  call-api-interop:
+    if: ${{ github.event.workflow_run.inputs.environment == 'interop' }}
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Call Strapi API - INTEROP
+        shell: bash
+        run: |
+            curl -X POST ${{ vars.INTEROP_STRAPI_URL }}/static-deploy/notify-workflow-end \
+              -H "Content-Type: application/json" \
+              -H "Authorization: Bearer ${{ secrets.INTEROP_WORKFLOW_NOTIFICATIONS_BEARER_TOKEN }}" \
+              -d '{"event": "staging-end"}'

--- a/apps/strapi-cms/config/plugins.ts
+++ b/apps/strapi-cms/config/plugins.ts
@@ -45,6 +45,10 @@ export default ({ env }: any) => ({
       staging: {
         workflowID: env('STAGING_WORKFLOW_ID', 'deploy_website_staging.yaml'),
         branch: env('STAGING_TARGET_BRANCH'),
+      },
+      notifications: {
+        enabled: true,
+        bearerToken: env('WORKFLOW_NOTIFICATIONS_BEARER_TOKEN'),
       }
     },
   },

--- a/apps/strapi-cms/package.json
+++ b/apps/strapi-cms/package.json
@@ -36,7 +36,7 @@
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.0.0",
     "strapi-plugin-preview-button": "^3.0.0",
-    "strapi-plugin-static-deploy": "^0.0.9",
+    "strapi-plugin-static-deploy": "^0.0.11",
     "styled-components": "^6.0.0"
   },
   "strapi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -277,7 +277,7 @@
         "react-dom": "^18.0.0",
         "react-router-dom": "^6.0.0",
         "strapi-plugin-preview-button": "^3.0.0",
-        "strapi-plugin-static-deploy": "^0.0.9",
+        "strapi-plugin-static-deploy": "^0.0.11",
         "styled-components": "^6.0.0"
       },
       "devDependencies": {
@@ -33500,9 +33500,9 @@
       }
     },
     "node_modules/strapi-plugin-static-deploy": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/strapi-plugin-static-deploy/-/strapi-plugin-static-deploy-0.0.9.tgz",
-      "integrity": "sha512-LQyyuMLXg15xSaj2CE97Y4l4BYvik+xiAmdMXyAHGvqQUDfpoqVW0RX6JGB6rXDmAxAd6Aj5pAviADV3WVlW/w==",
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/strapi-plugin-static-deploy/-/strapi-plugin-static-deploy-0.0.11.tgz",
+      "integrity": "sha512-A9crHjY0L2539+KDDk8Os0CEhNg6gPHVo81WlBk49CxOu7FM23XHXb3mzXCbGDpuslbqHlJky3rxdnVicUOdog==",
       "dependencies": {
         "@strapi/design-system": "^2.0.0-rc.14",
         "@strapi/icons": "^2.0.0-rc.14",


### PR DESCRIPTION
Strapi users will now be able to add a list of emails to which the following email notifications will be sent:
1. Staging workflow has been triggered
2. Production workflow has been triggered
3. Staging workflow has completed
4. Production workflow has completed

#### List of Changes
<!--- Describe your changes in detail -->
- Update Strapi's deploy plugin version to include email notifications functionality
- Create github workflows to trigger email notifications on staging and production workflow end

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran locally using MailDev

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
