### PR TITLE
[B2BP-1333] Mega-Header sublinks are now also considered active when pointing to any of the current page's parents

### DIFF
--- a/.changeset/flat-beds-press.md
+++ b/.changeset/flat-beds-press.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Mega-Header sublinks are now also considered active when pointing to any of the current page's parents

--- a/apps/nextjs-website/react-components/components/MegaHeader/MegaHeader.tsx
+++ b/apps/nextjs-website/react-components/components/MegaHeader/MegaHeader.tsx
@@ -41,8 +41,12 @@ const MegaHeader = ({
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
+  // Sublink is active if it points to the current page or one of its parents
+  // .slice(1) is needed because (assuming a relative url built like /example-slug or /parent/child)
+  // the first item in the array is always going to be an empty string, which matches with the homepage
+  // We can safely assume a relative url because an external one will simply never strike a match
   const isActiveSubLink = (href: string): boolean =>
-    pathname === href || pathname === href + '/' || pathname + '/' === href;
+    pathname.split('/').slice(1).includes(href.replace('/', ''));
 
   // Returns true if any one of the link's sublinks is active
   const isActiveLink = (menuItem: MegaMenuItem): boolean =>


### PR DESCRIPTION
As per title.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Request from interop tenant. Better UX for static website visitors.

When a user is on a press release page (e.g. /press-releases/article-1) the header link of the page containing the list of press releases (assumed to be their parent page with slug /press-releases) should be highlighted.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran locally in dev

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
