### PR TITLE
[B2BP-1347] Fix misaligned arrow icon in HowToStep component

### DIFF
--- a/.changeset/angry-teachers-rhyme.md
+++ b/.changeset/angry-teachers-rhyme.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+fix misaligned arrow icon

--- a/apps/nextjs-website/react-components/components/HowTo/HowToStep.tsx
+++ b/apps/nextjs-website/react-components/components/HowTo/HowToStep.tsx
@@ -26,8 +26,8 @@ export const HowToStep = ({
     theme === 'dark'
       ? palette.custom.white
       : themeVariant === 'SEND'
-      ? palette.primary.main
-      : palette.custom.primaryColorDark;
+        ? palette.primary.main
+        : palette.custom.primaryColorDark;
 
   return (
     <Stack
@@ -115,7 +115,7 @@ export const HowToStep = ({
               alignItems: 'center',
               width: '100%',
               opacity: 1,
-              transform: { xs: 'rotate(90deg)', md: 'none' },
+              '> svg': { transform: { xs: 'rotate(90deg)', md: 'none' } },
               minHeight: '2em',
             }}
           >


### PR DESCRIPTION
#### List of Changes
Fix misaligned arrow icon in mobile version of HowToStep component without icon image

#### Motivation and Context
Arrow Icon is placed over the text and / or title of the component. The fix is about to the CSS selector.

#### How Has This Been Tested?
Add at least 2 HowToStep without icon image. The arrow icon is misaligned without this pull request

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
