### PR TITLE
[B2BP-1555] Implement custom background color in NextJS

### DIFF
--- a/.changeset/good-kiwis-melt.md
+++ b/.changeset/good-kiwis-melt.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Implement customBgColor for Accorion, BannerLink, Cards, Editorial, Feature and HowTo

--- a/apps/nextjs-website/react-components/components/Accordion/Accordion.tsx
+++ b/apps/nextjs-website/react-components/components/Accordion/Accordion.tsx
@@ -24,13 +24,14 @@ const Accordion = (props: AccordionProps) => {
     layout,
     textAlignment,
     sectionID,
+    customBgColor
   } = props;
 
   const textColor = TextColor(theme);
   const { palette } = useTheme();
   const ctx = { palette, theme };
 
-  const backgroundColor = resolveThemeVariant<string>(
+  const backgroundColor = customBgColor ?? resolveThemeVariant<string>(
     'sectionBackgroundAlternativeGrey',
     themeVariant,
     ctx,

--- a/apps/nextjs-website/react-components/components/BannerLink/BannerLink.tsx
+++ b/apps/nextjs-website/react-components/components/BannerLink/BannerLink.tsx
@@ -77,7 +77,8 @@ const BannerLink = ({
               gap={2}
               sx={{
                 ...styles.main,
-                backgroundColor: sectionBackgrounds[index % 2],
+                backgroundColor:
+                  section.customBgColor ?? sectionBackgrounds[index % 2],
                 width: '100%',
                 flex: 1,
                 display: 'flex',

--- a/apps/nextjs-website/react-components/components/Cards/Cards.tsx
+++ b/apps/nextjs-website/react-components/components/Cards/Cards.tsx
@@ -18,16 +18,15 @@ const Cards = ({
   sectionID,
   bottomCTA,
   titleTag,
+  customBgColor,
 }: CardsProps) => {
   const muiTheme = useTheme();
   const { palette } = muiTheme;
   const ctx = { palette, theme };
 
-  const backgroundColor = resolveThemeVariant<string>(
-    'sectionBackgroundColor',
-    themeVariant,
-    ctx,
-  );
+  const backgroundColor =
+    customBgColor ??
+    resolveThemeVariant<string>('sectionBackgroundColor', themeVariant, ctx);
 
   const textColor = TextColor(theme);
   const flexDirection = textPosition === 'right' ? 'row-reverse' : 'row';

--- a/apps/nextjs-website/react-components/components/Editorial/Editorial.tsx
+++ b/apps/nextjs-website/react-components/components/Editorial/Editorial.tsx
@@ -33,16 +33,15 @@ const Editorial = (props: EditorialProps) => {
     width = 'standard',
     reversed = false,
     sectionID,
+    customBgColor,
   } = props;
 
   const { palette } = useTheme();
   const ctx = { palette, theme };
 
-  const backgroundColor = resolveThemeVariant<string>(
-    'sectionBackgroundColor',
-    themeVariant,
-    ctx,
-  );
+  const backgroundColor =
+    customBgColor ??
+    resolveThemeVariant<string>('sectionBackgroundColor', themeVariant, ctx);
 
   const columns = {
     wide: 6,

--- a/apps/nextjs-website/react-components/components/Feature/Feature.tsx
+++ b/apps/nextjs-website/react-components/components/Feature/Feature.tsx
@@ -17,6 +17,7 @@ const Feature = ({
   background,
   sectionID,
   labels,
+  customBgColor,
 }: FeatureProps) => {
   const [activeStep, setActiveStep] = useState(0);
   const muiTheme = useTheme();
@@ -32,11 +33,13 @@ const Feature = ({
 
   const textColor = TextColor(theme);
 
-  const backgroundColorAlternative = resolveThemeVariant<string>(
-    'sectionBackgroundAlternativeGrey',
-    themeVariant,
-    ctx,
-  );
+  const backgroundColorAlternative =
+    customBgColor ??
+    resolveThemeVariant<string>(
+      'sectionBackgroundAlternativeGrey',
+      themeVariant,
+      ctx,
+    );
 
   return (
     <ContainerRC

--- a/apps/nextjs-website/react-components/components/HowTo/HowTo.tsx
+++ b/apps/nextjs-website/react-components/components/HowTo/HowTo.tsx
@@ -18,17 +18,20 @@ const HowTo = (props: HowToProps) => {
     rowMaxSteps = 4,
     stepsAlignment = 'center',
     sectionID,
+    customBgColor,
   } = props;
 
   const textColor = TextColor(theme);
   const { palette, spacing } = useTheme();
   const ctx = { palette, theme };
 
-  const backgroundColor = resolveThemeVariant<string>(
-    'sectionBackgroundAlternativeGrey',
-    themeVariant,
-    ctx,
-  );
+  const backgroundColor =
+    customBgColor ??
+    resolveThemeVariant<string>(
+      'sectionBackgroundAlternativeGrey',
+      themeVariant,
+      ctx,
+    );
 
   const alignment = { center: 'center', left: 'flex-start', right: 'flex-end' }[
     stepsAlignment

--- a/apps/nextjs-website/react-components/types/Accordion/Accordion.types.ts
+++ b/apps/nextjs-website/react-components/types/Accordion/Accordion.types.ts
@@ -16,4 +16,5 @@ export interface AccordionProps extends SectionProps {
   accordionItems: AccordionItemProps[];
   layout: 'left' | 'center';
   textAlignment: 'left' | 'center' | 'right';
+  customBgColor?: string;
 }

--- a/apps/nextjs-website/react-components/types/BannerLink/BannerLink.types.ts
+++ b/apps/nextjs-website/react-components/types/BannerLink/BannerLink.types.ts
@@ -5,6 +5,7 @@ export interface BannerLinkSectionProps {
   body: JSX.Element;
   iconURL?: string;
   ctaButtons?: CtaButtonProps[];
+  customBgColor?: string;
 }
 
 export interface BannerLinkProps extends SectionProps {

--- a/apps/nextjs-website/react-components/types/Cards/Cards.types.ts
+++ b/apps/nextjs-website/react-components/types/Cards/Cards.types.ts
@@ -17,6 +17,7 @@ export interface CardsProps extends SectionProps {
   ctaButtons?: CtaButtonProps[];
   textPosition: 'left' | 'right' | 'center' | 'none';
   bottomCTA?: CtaButtonProps;
+  customBgColor?: string;
 }
 
 export interface CardsItemProps {

--- a/apps/nextjs-website/react-components/types/Editorial/Editorial.types.ts
+++ b/apps/nextjs-website/react-components/types/Editorial/Editorial.types.ts
@@ -14,6 +14,7 @@ export interface EditorialProps
   readonly reversed?: boolean;
   readonly width: 'wide' | 'standard' | 'center';
   readonly storeButtons?: StoreButtonsProps;
+  readonly customBgColor?: string;
 }
 
 export interface EditorialContentProps {

--- a/apps/nextjs-website/react-components/types/Feature/Feature.types.ts
+++ b/apps/nextjs-website/react-components/types/Feature/Feature.types.ts
@@ -1,4 +1,9 @@
-import { LinkProps, SectionProps, Theme, ThemeVariant } from '../common/Common.types';
+import {
+  LinkProps,
+  SectionProps,
+  Theme,
+  ThemeVariant,
+} from '../common/Common.types';
 
 export interface FeatureItem {
   readonly iconURL: string;
@@ -18,6 +23,7 @@ export interface FeatureProps extends SectionProps {
   readonly items: ReadonlyArray<FeatureItem>;
   readonly showCarouselMobile?: boolean;
   readonly background?: string;
+  readonly customBgColor?: string;
   readonly labels: {
     cardNext: string;
     cardPrevious: string;

--- a/apps/nextjs-website/react-components/types/HowTo/HowTo.types.ts
+++ b/apps/nextjs-website/react-components/types/HowTo/HowTo.types.ts
@@ -21,4 +21,5 @@ export interface HowToProps extends SectionProps {
   };
   readonly rowMaxSteps?: number;
   readonly stepsAlignment?: 'right' | 'center' | 'left';
+  readonly customBgColor?: string;
 }

--- a/apps/nextjs-website/src/components/Accordion.tsx
+++ b/apps/nextjs-website/src/components/Accordion.tsx
@@ -14,9 +14,11 @@ const makeAccordionProps = ({
   accordionItems,
   textAlignment,
   trackItemOpen,
+  customBgColor,
   ...rest
 }: AccordionSection & SiteWidePageData): AccordionProps => ({
   ...(subtitle && { subtitle }),
+  ...(customBgColor && { customBgColor }),
   ...(description && {
     description: MarkdownRenderer({
       markdown: description,

--- a/apps/nextjs-website/src/components/BannerLink.tsx
+++ b/apps/nextjs-website/src/components/BannerLink.tsx
@@ -12,28 +12,31 @@ export const makeBannerLinkProps = ({
   sections,
   ...rest
 }: BannerLinkSection & SiteWidePageData): BannerLinkProps => ({
-  sections: sections.map(({ body, icon, ctaButtons, ...requiredFields }) => ({
-    ...requiredFields,
-    body: MarkdownRenderer({
-      markdown: body,
-      locale,
-      defaultLocale,
-      variant: 'body2',
+  sections: sections.map(
+    ({ body, icon, ctaButtons, customBgColor, ...requiredFields }) => ({
+      ...requiredFields,
+      ...(customBgColor && { customBgColor }),
+      body: MarkdownRenderer({
+        markdown: body,
+        locale,
+        defaultLocale,
+        variant: 'body2',
+      }),
+      ...(icon && {
+        iconURL: icon.url,
+      }),
+      ...(ctaButtons && {
+        ctaButtons: ctaButtons.map(
+          ({ href, openInNewTab, ariaLabel, ...ctaButton }) => ({
+            ...ctaButton,
+            ...(ariaLabel && { ariaLabel }),
+            ...(openInNewTab && { openInNewTab }),
+            href: LocalizeURL({ URL: href, locale, defaultLocale }),
+          }),
+        ),
+      }),
     }),
-    ...(icon && {
-      iconURL: icon.url,
-    }),
-    ...(ctaButtons && {
-      ctaButtons: ctaButtons.map(
-        ({ href, openInNewTab, ariaLabel, ...ctaButton }) => ({
-          ...ctaButton,
-          ...(ariaLabel && { ariaLabel }),
-          ...(openInNewTab && { openInNewTab }),
-          href: LocalizeURL({ URL: href, locale, defaultLocale }),
-        }),
-      ),
-    }),
-  })),
+  ),
   ...rest,
 });
 

--- a/apps/nextjs-website/src/components/Cards.tsx
+++ b/apps/nextjs-website/src/components/Cards.tsx
@@ -17,6 +17,7 @@ export const makeCardsProps = ({
   body,
   ctaButtons,
   bottomCTA,
+  customBgColor,
   ...rest
 }: CardsSection & SiteWidePageData): CardsProps => ({
   text: {
@@ -32,6 +33,7 @@ export const makeCardsProps = ({
     }),
   },
   ...(titleTag && { titleTag }),
+  ...(customBgColor && { customBgColor }),
   items: items.map(({ icon, label, text, title, links }) => ({
     title,
     themeVariant: rest.themeVariant,

--- a/apps/nextjs-website/src/components/Editorial.tsx
+++ b/apps/nextjs-website/src/components/Editorial.tsx
@@ -19,8 +19,10 @@ export const makeEditorialProps = ({
   storeButtons,
   titleTag,
   ariaLabelSection,
+  customBgColor,
   ...rest
 }: EditorialSection & SiteWidePageData): EditorialProps => ({
+  ...(customBgColor && { customBgColor }),
   ...(eyelet && { eyelet }),
   ...(titleTag && { titleTag }),
   ...(ariaLabelSection && { ariaLabelSection }),

--- a/apps/nextjs-website/src/components/Feature.tsx
+++ b/apps/nextjs-website/src/components/Feature.tsx
@@ -46,8 +46,10 @@ const makeFeatureProps = ({
   locale,
   defaultLocale,
   items,
+  customBgColor,
   ...rest
 }: FeatureSection & SiteWidePageData): FeatureProps => ({
+  ...(customBgColor && { customBgColor }),
   labels: featureLabels[locale],
   items: items.map((item) => ({
     title: item.title,

--- a/apps/nextjs-website/src/components/HowTo.tsx
+++ b/apps/nextjs-website/src/components/HowTo.tsx
@@ -11,8 +11,10 @@ const makeHowToProps = ({
   defaultLocale,
   link,
   steps,
+  customBgColor,
   ...rest
 }: HowToSection & SiteWidePageData): HowToProps => ({
+  ...(customBgColor && { customBgColor }),
   ...(link && {
     link: {
       label: link.label,

--- a/apps/nextjs-website/src/lib/fetch/__tests__/preview.test.ts
+++ b/apps/nextjs-website/src/lib/fetch/__tests__/preview.test.ts
@@ -142,6 +142,7 @@ const pageSwitchPageDataResponse: PreviewPageData = {
         title: 'title',
         titleTag: 'h1',
         width: 'standard',
+        customBgColor: null,
       },
     ],
     publishedAt: '2024-11-28T15:14:29.486Z',

--- a/apps/nextjs-website/src/lib/fetch/types/PageSection.ts
+++ b/apps/nextjs-website/src/lib/fetch/types/PageSection.ts
@@ -150,6 +150,7 @@ const HowToSectionCodec = t.strict({
   link: t.union([LinkCodec, t.null]),
   steps: t.array(StepCodec),
   sectionID: t.union([t.string, t.null]),
+  customBgColor: t.union([t.string, t.null]),
 });
 
 const BannerLinkSectionCodec = t.strict({

--- a/apps/nextjs-website/src/lib/fetch/types/PageSection.ts
+++ b/apps/nextjs-website/src/lib/fetch/types/PageSection.ts
@@ -199,6 +199,7 @@ const CardsSectionCodec = t.strict({
   }),
   sectionID: t.union([t.string, t.null]),
   bottomCTA: t.union([CTAButtonSimpleCodec, t.null]),
+  customBgColor: t.union([t.string, t.null]),
 });
 
 const RedirectSectionCodec = t.strict({

--- a/apps/nextjs-website/src/lib/fetch/types/PageSection.ts
+++ b/apps/nextjs-website/src/lib/fetch/types/PageSection.ts
@@ -121,6 +121,7 @@ const FeatureSectionCodec = t.strict({
   showCarouselMobile: t.boolean,
   sectionID: t.union([t.string, t.null]),
   items: t.array(FeatureItemCodec),
+  customBgColor: t.union([t.string, t.null]),
 });
 
 const StepCodec = t.strict({

--- a/apps/nextjs-website/src/lib/fetch/types/PageSection.ts
+++ b/apps/nextjs-website/src/lib/fetch/types/PageSection.ts
@@ -72,6 +72,7 @@ const EditorialContentCodec = t.strict({
   mobileImage: StrapiImageRequiredSchema,
   ctaButtons: t.array(CTAButtonSimpleCodec),
   storeButtons: t.union([StoreButtonsCodec, t.null]),
+  customBgColor: t.union([t.string, t.null]),
 });
 
 const EditorialSectionCodec = t.intersection([

--- a/apps/nextjs-website/src/lib/fetch/types/PageSection.ts
+++ b/apps/nextjs-website/src/lib/fetch/types/PageSection.ts
@@ -102,6 +102,7 @@ const AccordionSectionCodec = t.strict({
     t.literal('right'),
   ]),
   sectionID: t.union([t.string, t.null]),
+  customBgColor: t.union([t.string, t.null]),
 });
 
 const FeatureItemCodec = t.strict({

--- a/apps/nextjs-website/src/lib/fetch/types/PageSection.ts
+++ b/apps/nextjs-website/src/lib/fetch/types/PageSection.ts
@@ -160,6 +160,7 @@ const BannerLinkSectionCodec = t.strict({
       body: t.string,
       ctaButtons: t.array(CTAButtonSimpleCodec),
       icon: StrapiImageSchema,
+      customBgColor: t.union([t.string, t.null]),
     }),
   ),
 });


### PR DESCRIPTION
Affected components: Accordion, BannerLink, Cards, Editorial, Feature and HowTo

The custom background color (customBgColor) overwrites the component's default background color (ignoring theme), but won't overwrite an eventual background image

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Feature Request (IT Wallet)

#### How Has This Been Tested?
<!--- Put an `x` in all the boxes that apply. -->
<!--- Where necessary, please describe in detail how you tested your changes. -->
<!--- Especially how your change affects other areas of the code. -->
- [x] Tested locally in dev
- [x] Ran Storybook locally
- [x] Built locally
- [ ] Tested locally in dev fetching from production Strapi instance
- [ ] Built locally fetching from production Strapi instance

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
