### PR TITLE
Rowtext max width

### DIFF
--- a/.changeset/calm-flies-sing.md
+++ b/.changeset/calm-flies-sing.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Update Card Styiling

--- a/.changeset/giant-terms-attack.md
+++ b/.changeset/giant-terms-attack.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Set RowText content max width

--- a/apps/nextjs-website/react-components/components/Cards/CardsItem.tsx
+++ b/apps/nextjs-website/react-components/components/Cards/CardsItem.tsx
@@ -26,13 +26,14 @@ const CardsItem = ({
   return (
     <Card
       component='li'
-      elevation={16}
+      // elevation={16}
       sx={{
         display: 'flex',
         minHeight: '200px',
         width: '100%',
+        border: '1px solid #E8EBF1',
         flex: { md: masonry ? '0 0 auto' : '1 1 0' },
-        borderRadius: '16px',
+        borderRadius: '24px',
         listStyle: 'none',
         padding: 0,
         margin: 0,

--- a/apps/nextjs-website/react-components/components/Cards/CardsItem.tsx
+++ b/apps/nextjs-website/react-components/components/Cards/CardsItem.tsx
@@ -23,15 +23,23 @@ const CardsItem = ({
     theme: 'light',
   });
 
+  const cardBorderColor = resolveThemeVariant<string>(
+    'cardsBorderColor',
+    themeVariant,
+    {
+      palette,
+      theme: 'light',
+    },
+  );
+
   return (
     <Card
       component='li'
-      // elevation={16}
       sx={{
         display: 'flex',
         minHeight: '200px',
         width: '100%',
-        border: '1px solid #E8EBF1',
+        border: `1px solid ${cardBorderColor}`,
         flex: { md: masonry ? '0 0 auto' : '1 1 0' },
         borderRadius: '24px',
         listStyle: 'none',

--- a/apps/nextjs-website/react-components/components/RowText/RowText.tsx
+++ b/apps/nextjs-website/react-components/components/RowText/RowText.tsx
@@ -23,6 +23,7 @@ const RowText = (props: RowTextProps) => {
       <Container
         sx={{
           width: { xs: '100%', md: '60%' },
+          maxWidth: { md: 684 },
           mx: 'auto',
           textAlign: layout,
           ml: { xs: 'auto', md: layout === 'left' ? 32 : 'auto' },

--- a/apps/nextjs-website/react-components/theme.ts
+++ b/apps/nextjs-website/react-components/theme.ts
@@ -333,6 +333,12 @@ export const bannerLinkTextColorMap: ThemeVariantMap<string> = {
     theme === 'dark' ? palette.primary.contrastText : palette.text.primary,
 };
 
+export const variantCardsBorderColorMap: ThemeVariantMap<string> = {
+  SEND: ({ palette }) => palette.custom.cardsBorderColor,
+  IO: ({ palette }) => palette.custom.cardsBorderColor,
+  WALLET: ({ palette }) => palette.custom.cardsBorderColor,
+};
+
 export const themeVariantMaps = {
   accentColor: variantAccentColorMap,
   actionColor: variantActionColorMap,
@@ -359,6 +365,7 @@ export const themeVariantMaps = {
   chipFocusOutlineColor: chipFocusOutlineColorMap,
   heroCounterNumberColor: heroCounterNumberColorMap,
   bannerLinkTextColor: bannerLinkTextColorMap,
+  cardsBorderColor: variantCardsBorderColorMap,
 };
 
 export const resolveThemeVariant = <T>(

--- a/apps/nextjs-website/src/app/theme.ts
+++ b/apps/nextjs-website/src/app/theme.ts
@@ -48,6 +48,7 @@ declare module '@mui/material/styles' {
       readonly sendChipsBackgroundColorLightHover: string;
       readonly chipsBackgroundColorDarkHover: string;
       readonly chipsTextColor: string;
+      readonly cardsBorderColor: string;
       readonly outlineColor: string;
       readonly walletOutlineColor: string;
     };
@@ -126,6 +127,7 @@ const themeStyles = {
       sendChipsBackgroundColorLightHover: '#0066CC',
       chipsBackgroundColorDarkHover: '#ebebf54d',
       chipsTextColor: '#ffffff',
+      cardsBorderColor: '#E8EBF1',
       outlineColor: '#0073e6',
       walletOutlineColor: '#0066CC',
     },


### PR DESCRIPTION
#### List of Changes
Set the RowText content max width to 684px on desktop viewports

#### Motivation and Context
This updates the RowText component styling to match the requested visual specification: all RowText content should be constrained to a maximum width of 684px

#### How Has This Been Tested?
<!--- Put an `x` in all the boxes that apply. -->
<!--- Where necessary, please describe in detail how you tested your changes. -->
<!--- Especially how your change affects other areas of the code. -->
- [ X] Tested locally in dev
- [ ] Ran Storybook locally
- [ ] Built locally
- [ ] Tested locally in dev fetching from production Strapi instance
- [ ] Built locally fetching from production Strapi instance

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
