### PR TITLE
[B2BP-1580] Set RowText content max width

### DIFF
--- a/.changeset/giant-terms-attack.md
+++ b/.changeset/giant-terms-attack.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Set RowText content max width

--- a/apps/nextjs-website/react-components/components/RowText/RowText.tsx
+++ b/apps/nextjs-website/react-components/components/RowText/RowText.tsx
@@ -23,6 +23,7 @@ const RowText = (props: RowTextProps) => {
       <Container
         sx={{
           width: { xs: '100%', md: '60%' },
+          maxWidth: { md: 684 },
           mx: 'auto',
           textAlign: layout,
           ml: { xs: 'auto', md: layout === 'left' ? 32 : 'auto' },


### PR DESCRIPTION
#### List of Changes
Set the RowText content max width to 684px on desktop viewports

#### Motivation and Context
This updates the RowText component styling to match the requested visual specification: all RowText content should be constrained to a maximum width of 684px

#### How Has This Been Tested?
<!--- Put an `x` in all the boxes that apply. -->
<!--- Where necessary, please describe in detail how you tested your changes. -->
<!--- Especially how your change affects other areas of the code. -->
- [ X] Tested locally in dev
- [ ] Ran Storybook locally
- [ ] Built locally
- [ ] Tested locally in dev fetching from production Strapi instance
- [ ] Built locally fetching from production Strapi instance

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
