### PR TITLE
[B2BP-1585] Wallet lastupdated border top

### DIFF
--- a/.changeset/tough-olives-knock.md
+++ b/.changeset/tough-olives-knock.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Add border top to LastUpdate component

--- a/apps/nextjs-website/react-components/components/LastUpdated/LastUpdated.tsx
+++ b/apps/nextjs-website/react-components/components/LastUpdated/LastUpdated.tsx
@@ -1,17 +1,30 @@
-import { Box, Container, Link, Typography } from '@mui/material';
+import { Box, Container, Link, Typography, useTheme } from '@mui/material';
 import { LastUpdatedProps } from '@react-components/types/LastUpdated/LastUpdated.types';
 import { ExternalLinkIcon, isValidExternalLink } from '../common/Common';
+import { resolveThemeVariant } from '../../theme';
 
 const LastUpdated = ({
   lastUpdated,
   label,
   sectionID,
   link,
+  themeVariant,
 }: LastUpdatedProps) => {
+  const { palette } = useTheme();
+
+  const borderColor = resolveThemeVariant<string>('borderColor', themeVariant, {
+    palette,
+    theme: 'light',
+  });
+
   return (
     <Box
       component='section'
-      sx={{ backgroundColor: '#ffffff', py: { xs: 3, md: 5 } }}
+      sx={{
+        backgroundColor: '#ffffff',
+        borderTop: `1px solid ${borderColor}`,
+        py: { xs: 3, md: 5 },
+      }}
       {...(sectionID && { sectionID })}
     >
       <Container sx={{ px: 3, width: { xs: '100%', md: '75%' } }}>

--- a/apps/nextjs-website/react-components/types/LastUpdated/LastUpdated.types.ts
+++ b/apps/nextjs-website/react-components/types/LastUpdated/LastUpdated.types.ts
@@ -1,8 +1,9 @@
-import { LinkProps } from '../common/Common.types';
+import { LinkProps, ThemeVariant } from '../common/Common.types';
 
 export interface LastUpdatedProps {
   readonly sectionID: string | null;
   readonly lastUpdated: string;
   readonly label: string;
   readonly link?: LinkProps;
+  readonly themeVariant: ThemeVariant;
 }

--- a/apps/nextjs-website/src/components/LastUpdated.tsx
+++ b/apps/nextjs-website/src/components/LastUpdated.tsx
@@ -33,12 +33,15 @@ const makeLastUpdatedProps = ({
   publishedAt,
   updatedAt,
   link,
-  ...rest
+  sectionID,
+  themeVariant,
 }: LastUpdatedSection &
   SiteWidePageData &
   PagePublishDates): LastUpdatedProps => {
   const effectiveDate = lastUpdated ?? publishedAt ?? updatedAt;
   return {
+    sectionID,
+    themeVariant,
     label: lastUpdatedLabels[locale],
     lastUpdated: formatDateToLocale(effectiveDate, locale),
     ...(link && {
@@ -48,7 +51,6 @@ const makeLastUpdatedProps = ({
         ...(link.ariaLabel && { ariaLabel: link.ariaLabel }),
       },
     }),
-    ...rest,
   };
 };
 

--- a/apps/nextjs-website/stories/LastUpdated/default.stories.tsx
+++ b/apps/nextjs-website/stories/LastUpdated/default.stories.tsx
@@ -17,6 +17,8 @@ const LastUpdatedTemplate: StoryFn<LastUpdatedProps> = (args) => (
 export const LastUpdatedSectionWithLink: StoryFn<typeof LastUpdated> =
   LastUpdatedTemplate.bind({});
 LastUpdatedSectionWithLink.args = {
+  sectionID: null,
+  themeVariant: 'SEND',
   label: 'Ultimo aggiornamento',
   lastUpdated: '05 maggio 2026',
   link: {
@@ -29,6 +31,8 @@ LastUpdatedSectionWithLink.args = {
 export const LastUpdatedSectionNoLink: StoryFn<typeof LastUpdated> =
   LastUpdatedTemplate.bind({});
 LastUpdatedSectionNoLink.args = {
+  sectionID: null,
+  themeVariant: 'SEND',
   label: 'Ultimo aggiornamento',
   lastUpdated: '05 maggio 2026',
 };


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
- Add a top border to the LastUpdated component using the existing theme border color.
- Pass themeVariant from the CMS wrapper to the shared LastUpdated component.
- Update LastUpdated stories with the required sectionID and themeVariant props.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Put an `x` in all the boxes that apply. -->
<!--- Where necessary, please describe in detail how you tested your changes. -->
<!--- Especially how your change affects other areas of the code. -->
- [X] Tested locally in dev
- [ ] Ran Storybook locally
- [ ] Built locally
- [ ] Tested locally in dev fetching from production Strapi instance
- [ ] Built locally fetching from production Strapi instance

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
