### PR TITLE
[B2BP-1587] Animate StandardHeader collapse after scroll

### DIFF
--- a/.changeset/small-pumas-shop.md
+++ b/.changeset/small-pumas-shop.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Animate StandardHeader collapse after scroll

--- a/apps/nextjs-website/react-components/components/Header/Header.tsx
+++ b/apps/nextjs-website/react-components/components/Header/Header.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react';
-import { Box, IconButton, Stack } from '@mui/material';
+import React, { useEffect, useRef, useState } from 'react';
+import { Box, IconButton, Link, Stack } from '@mui/material';
 import { useMediaQuery, useTheme } from '@mui/material';
 import { HeaderProps } from '@react-components/types/Header/Header.types';
 import { HeaderTitle } from './helpers/Header.HeaderTitle.helpers';
@@ -31,6 +31,8 @@ const Header = ({
   );
   const isMobile = useMediaQuery(muiTheme.breakpoints.down('md'));
   const pathname = usePathname();
+  const [isScrolled, setIsScrolled] = useState(false);
+  const hasScrolledRef = useRef(false);
 
   const openHeader = () => {
     setMenuOpen(true);
@@ -66,6 +68,23 @@ const Header = ({
     toggleAccessibility(menuOpen || openDropdownIndex == null ? false : true);
   }, [openDropdownIndex, menuOpen]);
 
+  useEffect(() => {
+    const handleScroll = () => {
+      if (!hasScrolledRef.current && window.scrollY > 200) {
+        hasScrolledRef.current = true;
+        setIsScrolled(true);
+      } else if (hasScrolledRef.current && window.scrollY < 80) {
+        hasScrolledRef.current = false;
+        setIsScrolled(false);
+      }
+    };
+
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    handleScroll();
+
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
   return (
     <>
       <TopBarHeader
@@ -96,8 +115,18 @@ const Header = ({
             direction='row'
             justifyContent='space-between'
             alignItems='center'
-            sx={{ padding: { xs: '16px 24px', md: '16px 32px' } }}
             color='#FFFFFF'
+            height={88}
+            sx={{
+              transition: 'all .3s ease-out',
+              '> *': {
+                transition: 'all .3s ease-out',
+              },
+              padding: { xs: '16px 24px', md: isScrolled ? 0 : '16px 32px' },
+              ...(isScrolled &&
+                !isMobile && { '> *': { opacity: 0 }, height: 0 }),
+            }}
+            {...(isScrolled && !isMobile && { inert: '' })}
           >
             <HeaderTitle
               product={product}
@@ -132,6 +161,24 @@ const Header = ({
                 padding: '0px 32px',
               }}
             >
+              {logo && (
+                <Link
+                  href={product.href}
+                  p={'0 !important'}
+                  my={'0 !important'}
+                  marginLeft={isScrolled ? 4 : 0}
+                  marginRight={isScrolled ? 5 : 0}
+                  sx={{
+                    transition: 'all .3s ease-out',
+                    maxWidth: isScrolled ? 80 : 0,
+                    opacity: isScrolled ? 1 : 0,
+                  }}
+                  {...(!isScrolled && { inert: '' })}
+                >
+                  <img src={logo.src} alt='Homepage' height={32} />
+                </Link>
+              )}
+
               <Navigation
                 labels={labels}
                 menu={menu.map((menu, index) => ({

--- a/apps/nextjs-website/react-components/types/Header/Header.types.ts
+++ b/apps/nextjs-website/react-components/types/Header/Header.types.ts
@@ -76,7 +76,7 @@ export interface NavigationProps {
 export interface HeaderTitleProps {
   product: {
     name: string;
-    href?: string;
+    href: string;
   };
   logo?: {
     src: string;


### PR DESCRIPTION
#### List of Changes
<!--- Describe your changes in detail -->
Mobile view remains unchanged.
On scroll, hide upper part of Header and show logo beside navigation links instead

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Design Request.
Save screen real estate.

#### How Has This Been Tested?
<!--- Put an `x` in all the boxes that apply. -->
<!--- Where necessary, please describe in detail how you tested your changes. -->
<!--- Especially how your change affects other areas of the code. -->
- [x] Tested locally in dev
- [x] Ran Storybook locally
- [x] Built locally
- [x] Tested locally in dev fetching from production Strapi instance
- [ ] Built locally fetching from production Strapi instance

#### Recordings:
https://github.com/user-attachments/assets/4b5d468c-f5e8-4276-97b5-d254ae5f4fd5

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
