### PR TITLE
[B2BP-1595] Set focus on first element when a dropdown in Standard Header is open

### DIFF
--- a/.changeset/loud-cats-explode.md
+++ b/.changeset/loud-cats-explode.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Set focus on first element when a dropdown in Standard Header is open

--- a/apps/nextjs-website/react-components/components/Header/helpers/Header.MenuDropdown.helpers.tsx
+++ b/apps/nextjs-website/react-components/components/Header/helpers/Header.MenuDropdown.helpers.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   Box,
   Link,
@@ -20,6 +19,7 @@ import {
   isValidExternalLink,
 } from '@react-components/components/common/Common';
 import { usePathname } from 'next/navigation';
+import { useRef } from 'react';
 
 const useStyles = ({ active }: MenuDropdownProp, { spacing }: Theme) => {
   return {
@@ -94,7 +94,18 @@ export const MenuDropdown = (
     return false;
   };
 
+  const itemsRef = useRef<Array<HTMLAnchorElement | null>>([]);
+
   const MenuItem = () => {
+    const onDropdownClickFn = () => {
+      if (!onDropdownClick) return;
+      onDropdownClick();
+      requestAnimationFrame(() => {
+        if (itemsRef && itemsRef.current[0]) {
+          itemsRef.current[0].focus();
+        }
+      });
+    };
     if (hasLinks) {
       return (
         <Button
@@ -107,7 +118,7 @@ export const MenuDropdown = (
               color: '#ffffff !important',
             },
           }}
-          onClick={onDropdownClick}
+          onClick={onDropdownClickFn}
         >
           <Typography
             variant='sidenav'
@@ -180,11 +191,10 @@ export const MenuDropdown = (
               sx={{ p: 0, m: 0, listStyleType: 'none' }}
             >
               {items?.map((item: DropdownItem, index) => (
-                <li style={{ margin: 0, padding: 0 }}>
+                <li style={{ margin: 0, padding: 0 }} key={item.key ?? index}>
                   <Link
                     variant='body1'
                     underline='none'
-                    key={item.key ?? index}
                     sx={{
                       color: '#5C6F82',
                       ...(isCurrentLink(item.href) && {
@@ -194,6 +204,9 @@ export const MenuDropdown = (
                       fontWeight: 600,
                       padding: 0,
                       m: 0,
+                    }}
+                    ref={(el) => {
+                      itemsRef.current[index] = el;
                     }}
                     href={item.href}
                     target={


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Accessibility navigation to Standard Header main menu is improved. When user open a dropdown of Standard Header main menu, the focus on first element of that dropdown is set.

#### Motivation and Context
Increase accessibility navigation

#### How Has This Been Tested?
<!--- Put an `x` in all the boxes that apply. -->
<!--- Where necessary, please describe in detail how you tested your changes. -->
<!--- Especially how your change affects other areas of the code. -->
- [x] Tested locally in dev
- [ ] Ran Storybook locally
- [x] Built locally
- [ ] Tested locally in dev fetching from production Strapi instance
- [ ] Built locally fetching from production Strapi instance

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
