### PR TITLE
[BSBP-1599] Fix order of focusable elements in Service Carousel component

### DIFF
--- a/.changeset/cold-ways-draw.md
+++ b/.changeset/cold-ways-draw.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Fix order of focusable elements in Service Carousel component

--- a/apps/nextjs-website/react-components/components/ServiceCarousel/ServiceCarousel.helpers.tsx
+++ b/apps/nextjs-website/react-components/components/ServiceCarousel/ServiceCarousel.helpers.tsx
@@ -173,6 +173,11 @@ export const SliderArrowControl = ({
           bgcolor: arrowBackgroundColor,
         },
         '&.Mui-focusVisible': { bgcolor: arrowBackgroundColor },
+        ...(direction === 'right' && {
+          position: 'absolute',
+          top: 1,
+          left: 40,
+        }),
       }}
       disableRipple={true}
       onClick={action}

--- a/apps/nextjs-website/react-components/components/ServiceCarousel/ServiceCarousel.helpers.tsx
+++ b/apps/nextjs-website/react-components/components/ServiceCarousel/ServiceCarousel.helpers.tsx
@@ -175,7 +175,7 @@ export const SliderArrowControl = ({
         '&.Mui-focusVisible': { bgcolor: arrowBackgroundColor },
         ...(direction === 'right' && {
           position: 'absolute',
-          top: 1,
+          top: 0,
           left: 40,
         }),
       }}

--- a/apps/nextjs-website/react-components/components/ServiceCarousel/ServiceCarousel.tsx
+++ b/apps/nextjs-website/react-components/components/ServiceCarousel/ServiceCarousel.tsx
@@ -4,7 +4,7 @@ import { Body, Title } from '../common/Common';
 import Slider from 'react-slick';
 import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { ServiceCard, SliderArrowControl } from './ServiceCarousel.helpers';
 import { visuallyHidden } from '@mui/utils';
 
@@ -21,7 +21,8 @@ const ServiceCarousel = ({
   const { palette } = useTheme();
   const [currentCard, setCurrentCard] = useState(cards[0]);
   const liveRegionRef = useRef<HTMLDivElement>();
-
+  const leftArrowRef = useRef<HTMLDivElement>();
+  const rightArrowRef = useRef<HTMLDivElement>();
   const resetAttributes = () => {
     const slides = document.querySelectorAll('.slick-slide');
 
@@ -43,6 +44,24 @@ const ServiceCarousel = ({
       }
     });
   };
+
+  useEffect(() => {
+    if (
+      leftArrowRef &&
+      rightArrowRef &&
+      leftArrowRef.current &&
+      rightArrowRef.current
+    ) {
+      const leftArrowCoords = {
+        x: leftArrowRef.current.offsetLeft,
+        y: leftArrowRef.current.offsetTop,
+        w: leftArrowRef.current.offsetWidth,
+      };
+
+      rightArrowRef.current.style.left = `${leftArrowCoords.x + leftArrowCoords.w + 8}px`;
+      rightArrowRef.current.style.top = `${leftArrowCoords.y}px`;
+    }
+  }, []);
 
   return (
     <Box
@@ -79,7 +98,11 @@ const ServiceCarousel = ({
       </Stack>
 
       {/* Cards */}
-      <Stack gap={{ xs: 3.375, sm: 3.375, md: 4 }} width={'100%'}>
+      <Stack
+        gap={{ xs: 3.375, sm: 3.375, md: 4 }}
+        width={'100%'}
+        sx={{ position: 'relative' }}
+      >
         <Stack
           flexDirection='row'
           alignItems='center'
@@ -87,18 +110,14 @@ const ServiceCarousel = ({
           gap={2}
           display='flex'
         >
-          <SliderArrowControl
-            direction='left'
-            ariaLabel={labels.cardPrevious}
-            action={() => sliderRef.current?.slickPrev()}
-            themeVariant={themeVariant}
-          />
-          <SliderArrowControl
-            direction='right'
-            ariaLabel={labels.cardNext}
-            action={() => sliderRef.current?.slickNext()}
-            themeVariant={themeVariant}
-          />
+          <Box ref={leftArrowRef}>
+            <SliderArrowControl
+              direction='left'
+              ariaLabel={labels.cardPrevious}
+              action={() => sliderRef.current?.slickPrev()}
+              themeVariant={themeVariant}
+            />
+          </Box>
         </Stack>
 
         <Slider
@@ -131,7 +150,14 @@ const ServiceCarousel = ({
             </div>
           ))}
         </Slider>
-
+        <Box ref={rightArrowRef} style={{ position: 'absolute' }}>
+          <SliderArrowControl
+            direction='right'
+            ariaLabel={labels.cardNext}
+            action={() => sliderRef.current?.slickNext()}
+            themeVariant={themeVariant}
+          />
+        </Box>
         <Box ref={liveRegionRef} aria-live='polite' style={visuallyHidden}>
           {currentCard && ServiceCard(currentCard, themeVariant, true)}
         </Box>

--- a/apps/nextjs-website/react-components/components/ServiceCarousel/ServiceCarousel.tsx
+++ b/apps/nextjs-website/react-components/components/ServiceCarousel/ServiceCarousel.tsx
@@ -4,7 +4,7 @@ import { Body, Title } from '../common/Common';
 import Slider from 'react-slick';
 import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { ServiceCard, SliderArrowControl } from './ServiceCarousel.helpers';
 import { visuallyHidden } from '@mui/utils';
 
@@ -21,8 +21,6 @@ const ServiceCarousel = ({
   const { palette } = useTheme();
   const [currentCard, setCurrentCard] = useState(cards[0]);
   const liveRegionRef = useRef<HTMLDivElement>();
-  const leftArrowRef = useRef<HTMLDivElement>();
-  const rightArrowRef = useRef<HTMLDivElement>();
   const resetAttributes = () => {
     const slides = document.querySelectorAll('.slick-slide');
 
@@ -44,24 +42,6 @@ const ServiceCarousel = ({
       }
     });
   };
-
-  useEffect(() => {
-    if (
-      leftArrowRef &&
-      rightArrowRef &&
-      leftArrowRef.current &&
-      rightArrowRef.current
-    ) {
-      const leftArrowCoords = {
-        x: leftArrowRef.current.offsetLeft,
-        y: leftArrowRef.current.offsetTop,
-        w: leftArrowRef.current.offsetWidth,
-      };
-
-      rightArrowRef.current.style.left = `${leftArrowCoords.x + leftArrowCoords.w + 8}px`;
-      rightArrowRef.current.style.top = `${leftArrowCoords.y}px`;
-    }
-  }, []);
 
   return (
     <Box
@@ -103,22 +83,12 @@ const ServiceCarousel = ({
         width={'100%'}
         sx={{ position: 'relative' }}
       >
-        <Stack
-          flexDirection='row'
-          alignItems='center'
-          justifyContent='flex-start'
-          gap={2}
-          display='flex'
-        >
-          <Box ref={leftArrowRef}>
-            <SliderArrowControl
-              direction='left'
-              ariaLabel={labels.cardPrevious}
-              action={() => sliderRef.current?.slickPrev()}
-              themeVariant={themeVariant}
-            />
-          </Box>
-        </Stack>
+        <SliderArrowControl
+          direction='left'
+          ariaLabel={labels.cardPrevious}
+          action={() => sliderRef.current?.slickPrev()}
+          themeVariant={themeVariant}
+        />
 
         <Slider
           role='region'
@@ -150,14 +120,12 @@ const ServiceCarousel = ({
             </div>
           ))}
         </Slider>
-        <Box ref={rightArrowRef} style={{ position: 'absolute' }}>
-          <SliderArrowControl
-            direction='right'
-            ariaLabel={labels.cardNext}
-            action={() => sliderRef.current?.slickNext()}
-            themeVariant={themeVariant}
-          />
-        </Box>
+        <SliderArrowControl
+          direction='right'
+          ariaLabel={labels.cardNext}
+          action={() => sliderRef.current?.slickNext()}
+          themeVariant={themeVariant}
+        />
         <Box ref={liveRegionRef} aria-live='polite' style={visuallyHidden}>
           {currentCard && ServiceCard(currentCard, themeVariant, true)}
         </Box>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Change order of focusable elements in Service Carousel component. The new order is:
- Previous slide button
- Current card elements (link)
- Next slide button

#### Motivation and Context
Feature request

#### How Has This Been Tested?
<!--- Put an `x` in all the boxes that apply. -->
<!--- Where necessary, please describe in detail how you tested your changes. -->
<!--- Especially how your change affects other areas of the code. -->
- [x] Tested locally in dev
- [ ] Ran Storybook locally
- [x] Built locally
- [ ] Tested locally in dev fetching from production Strapi instance
- [ ] Built locally fetching from production Strapi instance

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
