### PR TITLE
[B2BP-1570] Preview font

### DIFF
--- a/.changeset/few-cougars-shave.md
+++ b/.changeset/few-cougars-shave.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Add CssBaseline to previw page

--- a/apps/nextjs-website/src/app/preview/page.tsx
+++ b/apps/nextjs-website/src/app/preview/page.tsx
@@ -8,6 +8,7 @@ import {
   getFeedbackToken,
 } from '@/lib/api';
 import { Locale } from '@/lib/fetch/siteWideSEO';
+import { CssBaseline } from '@mui/material';
 import { ThemeProvider } from '@mui/material/styles';
 import { isExperimentalThemeVariant } from '@react-components/components/common/Common.helpers';
 import Script from 'next/script';
@@ -84,6 +85,7 @@ const PreviewPage = async ({
         isExperimentalThemeVariant(themeVariant) ? themeExperimental : themeBase
       }
     >
+      <CssBaseline />
       <style>{`
           html {
             scroll-behavior: smooth;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Add CssBaseline to the Next.js preview page.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Preview pages were not applying the same MUI global baseline as standard pages. As a result, some preview links/CTAs inherited the browser default font instead of the theme font. Adding CssBaseline aligns preview rendering with the regular app layout and restores theme font inheritance.

#### How Has This Been Tested?
<!--- Put an `x` in all the boxes that apply. -->
<!--- Where necessary, please describe in detail how you tested your changes. -->
<!--- Especially how your change affects other areas of the code. -->
- [X] Tested locally in dev
- [ ] Ran Storybook locally
- [ ] Built locally
- [ ] Tested locally in dev fetching from production Strapi instance
- [ ] Built locally fetching from production Strapi instance

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
