### PR TITLE
[B2BP-1601] Fix target attribute for external links

### DIFF
--- a/.changeset/green-hotels-give.md
+++ b/.changeset/green-hotels-give.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Fix target attribute for external links

--- a/apps/nextjs-website/react-components/components/Cards/CardsItem.tsx
+++ b/apps/nextjs-website/react-components/components/Cards/CardsItem.tsx
@@ -112,7 +112,7 @@ const CardsItem = ({
                     {link.label}
                   </Link>
                   <LinkIcon
-                    {...(link.href.startsWith('https://') && {
+                    {...(isValidExternalLink(link.href) && {
                       externaLinkIconTarget: '_blank',
                     })}
                     showExternalLinkIcon={isValidExternalLink(link.href)}

--- a/apps/nextjs-website/react-components/components/Feature/Subtitle.tsx
+++ b/apps/nextjs-website/react-components/components/Feature/Subtitle.tsx
@@ -37,6 +37,9 @@ const Subtitle = ({ item, theme, themeVariant }: FeatureStackItemProps) => {
                 'aria-label': item.link.ariaLabel,
               })}
               sx={{ fontWeight: 'bold' }}
+              {...(isValidExternalLink(item.link.href) && {
+                target: '_blank',
+              })}
             >
               {item.link.label}
             </Link>
@@ -51,6 +54,9 @@ const Subtitle = ({ item, theme, themeVariant }: FeatureStackItemProps) => {
                 }}
               />
             }
+            {...(isValidExternalLink(item.link.href) && {
+              externaLinkIconTarget: '_blank',
+            })}
           />
         </Stack>
       )}

--- a/apps/nextjs-website/react-components/components/FramedVideo/FramedVideo.helpers.tsx
+++ b/apps/nextjs-website/react-components/components/FramedVideo/FramedVideo.helpers.tsx
@@ -102,9 +102,17 @@ export const renderTextSection = ({
             marginBottom: '32px',
           }}
           {...(link.ariaLabel && { 'aria-label': link.ariaLabel })}
+          {...(isValidExternalLink(link.href) && {
+            target: '_blank',
+          })}
         >
           {link.label}
-          <ExternalLinkIcon show={isValidExternalLink(link.href)} />
+          <ExternalLinkIcon
+            show={isValidExternalLink(link.href)}
+            {...(isValidExternalLink(link.href) && {
+              target: '_blank',
+            })}
+          />
         </Link>
       </Typography>
     </Stack>

--- a/apps/nextjs-website/react-components/components/Header/helpers/Header.Card.helpers.tsx
+++ b/apps/nextjs-website/react-components/components/Header/helpers/Header.Card.helpers.tsx
@@ -65,11 +65,17 @@ export default function ActionAreaCard({
             <Button
               size='small'
               href={link.href}
+              {...(isValidExternalLink(link.href) && {
+                target: '_blank',
+              })}
               endIcon={
                 <LinkIcon
                   showExternalLinkIcon={isValidExternalLink(link.href)}
                   sxExternalLinkIcon={{ ml: 0 }}
                   internalLinkIcon={<ArrowForwardIcon />}
+                  {...(isValidExternalLink(link.href) && {
+                    externaLinkIconTarget: '_blank',
+                  })}
                 />
               }
               {...(link.ariaLabel && { 'aria-label': link.ariaLabel })}

--- a/apps/nextjs-website/react-components/components/Header/helpers/Header.MobileNav.helpers.tsx
+++ b/apps/nextjs-website/react-components/components/Header/helpers/Header.MobileNav.helpers.tsx
@@ -112,6 +112,9 @@ export default function MobileNav({
           fontWeight: 600,
           width: item.items ? 'default' : '100%',
         }}
+        {...(isValidExternalLink(item.href) && {
+          target: '_blank',
+        })}
       >
         <Typography
           style={{
@@ -120,7 +123,12 @@ export default function MobileNav({
           }}
         >
           {item.label}
-          <ExternalLinkIcon show={isValidExternalLink(item.href)} />
+          <ExternalLinkIcon
+            show={isValidExternalLink(item.href)}
+            {...(isValidExternalLink(item.href) && {
+              target: '_blank',
+            })}
+          />
         </Typography>
       </Link>
     );

--- a/apps/nextjs-website/react-components/components/Header/helpers/Header.SideDrawer.helpers.tsx
+++ b/apps/nextjs-website/react-components/components/Header/helpers/Header.SideDrawer.helpers.tsx
@@ -156,11 +156,17 @@ export default function SideDrawer({
             <Button
               size='small'
               href={ctaCard.link.href}
+              {...(isValidExternalLink(ctaCard.link.href) && {
+                target: '_blank',
+              })}
               endIcon={
                 <LinkIcon
                   sxExternalLinkIcon={{ ml: 0 }}
                   showExternalLinkIcon={isValidExternalLink(ctaCard.link.href)}
                   internalLinkIcon={<ArrowForwardIcon />}
+                  {...(isValidExternalLink(ctaCard.link.href) && {
+                    externaLinkIconTarget: '_blank',
+                  })}
                 />
               }
               {...(ctaCard.link.ariaLabel && {

--- a/apps/nextjs-website/react-components/components/Hero/Hero.helpers.tsx
+++ b/apps/nextjs-website/react-components/components/Hero/Hero.helpers.tsx
@@ -168,6 +168,9 @@ export const HeroTextContent = ({
             fontWeight: 'bold',
             fontSize: '1rem',
           }}
+          {...(isValidExternalLink(link.href) && {
+            target: '_blank',
+          })}
         >
           {link.label}
           <LinkIcon
@@ -186,6 +189,9 @@ export const HeroTextContent = ({
                 }}
               />
             }
+            {...(isValidExternalLink(link.href) && {
+              externaLinkIconTarget: '_blank',
+            })}
           />
         </Typography>
       )}

--- a/apps/nextjs-website/react-components/components/HeroCounter/HeroCounter.tsx
+++ b/apps/nextjs-website/react-components/components/HeroCounter/HeroCounter.tsx
@@ -139,6 +139,9 @@ const HeroCounter = ({
               fontSize: '1rem',
               position: 'relative',
             }}
+            {...(isValidExternalLink(link.href) && {
+              target: '_blank',
+            })}
           >
             {link.label}
             <LinkIcon
@@ -156,6 +159,9 @@ const HeroCounter = ({
                   }}
                 />
               }
+              {...(isValidExternalLink(link.href) && {
+                externaLinkIconTarget: '_blank',
+              })}
             />
           </Typography>
         )}

--- a/apps/nextjs-website/react-components/components/HighlightBox/HighlightBox.tsx
+++ b/apps/nextjs-website/react-components/components/HighlightBox/HighlightBox.tsx
@@ -89,9 +89,17 @@ const HighlightBox = ({
                   fontSize: '16px',
                   fontWeight: 700,
                 }}
+                {...(isValidExternalLink(link.href) && {
+                  target: '_blank',
+                })}
               >
                 {link.label}
-                <ExternalLinkIcon show={isValidExternalLink(link.href)} />
+                <ExternalLinkIcon
+                  show={isValidExternalLink(link.href)}
+                  {...(isValidExternalLink(link.href) && {
+                    target: '_blank',
+                  })}
+                />
               </Button>
             )}
           </Stack>

--- a/apps/nextjs-website/react-components/components/HowTo/HowTo.tsx
+++ b/apps/nextjs-website/react-components/components/HowTo/HowTo.tsx
@@ -143,9 +143,7 @@ const HowTo = (props: HowToProps) => {
               {link.label}
               <LinkIcon
                 showExternalLinkIcon={isValidExternalLink(link.href)}
-                {...(link.target === '_blank' && {
-                  externaLinkIconTarget: '_blank',
-                })}
+                {...(link.target && { externaLinkIconTarget: link.target })}
                 internalLinkIcon={
                   <ArrowForwardIcon
                     sx={{ ml: 1 }}

--- a/apps/nextjs-website/react-components/components/LastUpdated/LastUpdated.tsx
+++ b/apps/nextjs-website/react-components/components/LastUpdated/LastUpdated.tsx
@@ -46,7 +46,12 @@ const LastUpdated = ({
               {...(isValidExternalLink(link.href) && { target: '_blank' })}
             >
               {link.label}
-              <ExternalLinkIcon show={isValidExternalLink(link.href)} />
+              <ExternalLinkIcon
+                show={isValidExternalLink(link.href)}
+                {...(isValidExternalLink(link.href) && {
+                  target: '_blank',
+                })}
+              />
             </Link>
           )}
         </Box>

--- a/apps/nextjs-website/react-components/components/PressReleaseList/PressReleaseList.helpers.tsx
+++ b/apps/nextjs-website/react-components/components/PressReleaseList/PressReleaseList.helpers.tsx
@@ -53,6 +53,9 @@ export const PressReleasePreview = ({
             color='inherit'
             sx={{ textDecoration: 'none' }}
             aria-label={`${link.label} "${title}"`}
+            {...(isValidExternalLink(link.href) && {
+              target: '_blank',
+            })}
           >
             {link.label}
           </Link>
@@ -60,6 +63,9 @@ export const PressReleasePreview = ({
             sxExternalLinkIcon={{ ml: 0 }}
             showExternalLinkIcon={isValidExternalLink(link.href)}
             internalLinkIcon={<ArrowRightAlt color='inherit' />}
+            {...(isValidExternalLink(link.href) && {
+              externaLinkIconTarget: '_blank',
+            })}
           />
         </Typography>
       </Stack>

--- a/apps/nextjs-website/react-components/components/ServiceCarousel/ServiceCarousel.helpers.tsx
+++ b/apps/nextjs-website/react-components/components/ServiceCarousel/ServiceCarousel.helpers.tsx
@@ -109,6 +109,9 @@ export const ServiceCard = (
               {...(card.link.ariaLabel && {
                 'aria-label': card.link.ariaLabel,
               })}
+              {...(isValidExternalLink(card.link.href) && {
+                target: '_blank',
+              })}
             >
               {card.link.label}
               <LinkIcon
@@ -117,6 +120,9 @@ export const ServiceCard = (
                 internalLinkIcon={
                   <ArrowForward color='inherit' sx={{ fontSize: 18 }} />
                 }
+                {...(isValidExternalLink(card.link.href) && {
+                  externaLinkIconTarget: '_blank',
+                })}
               />
             </Link>
           </Typography>

--- a/apps/nextjs-website/react-components/components/StripeLink/StripeLink.tsx
+++ b/apps/nextjs-website/react-components/components/StripeLink/StripeLink.tsx
@@ -102,9 +102,15 @@ const StripeLink = ({
                 sxExternalLinkIcon={{ ml: 0 }}
                 showExternalLinkIcon={isValidExternalLink(link.href)}
                 internalLinkIcon={<ArrowForwardIcon color='inherit' />}
+                {...(isValidExternalLink(link.href) && {
+                  externaLinkIconTarget: '_blank',
+                })}
               />
             }
             href={link.href}
+            {...(isValidExternalLink(link.href) && {
+              target: '_blank',
+            })}
           >
             {link.label}
           </Button>

--- a/apps/nextjs-website/react-components/components/common/Common.tsx
+++ b/apps/nextjs-website/react-components/components/common/Common.tsx
@@ -421,7 +421,7 @@ interface LinkIconProps {
   showExternalLinkIcon?: boolean;
   internalLinkIcon: JSX.Element;
   sxExternalLinkIcon?: SxProps;
-  externaLinkIconTarget?: string;
+  externaLinkIconTarget?: React.HTMLAttributeAnchorTarget;
 }
 
 export const LinkIcon = ({


### PR DESCRIPTION
#### List of Changes
Fix target attribute for external link used with LinkIcon and ExternalLinkIcon components

#### Motivation and Context
Some links had no target=_blank attribute when href is an external link.

#### How Has This Been Tested?
<!--- Put an `x` in all the boxes that apply. -->
<!--- Where necessary, please describe in detail how you tested your changes. -->
<!--- Especially how your change affects other areas of the code. -->
- [x] Tested locally in dev
- [ ] Ran Storybook locally
- [x] Built locally
- [ ] Tested locally in dev fetching from production Strapi instance
- [ ] Built locally fetching from production Strapi instance

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
