### PR TITLE
[B2BP-1627] [B2BP-1629] Fix headings hierarchy

### DIFF
--- a/.changeset/slimy-rockets-shave.md
+++ b/.changeset/slimy-rockets-shave.md
@@ -1,0 +1,6 @@
+---
+"nextjs-website": patch
+"strapi-cms": patch
+---
+
+Make PreFooter title <p> instead of <h2>. Allow all heading levels + p for RowText.

--- a/apps/nextjs-website/react-components/components/PreFooter/PreFooter.tsx
+++ b/apps/nextjs-website/react-components/components/PreFooter/PreFooter.tsx
@@ -102,7 +102,7 @@ const PreFooter = (props: PreFooterProps) => {
           <Box sx={styles.main(isSmallScreen, layout)}>
             <Typography
               variant='h6'
-              component='h2'
+              component='p'
               color={theme === 'dark' ? 'white' : 'black'}
               mb={isSmallScreen || layout === 'center' ? 2 : 'unset'}
               sx={{

--- a/apps/nextjs-website/react-components/types/RowText/RowText.types.ts
+++ b/apps/nextjs-website/react-components/types/RowText/RowText.types.ts
@@ -2,7 +2,7 @@ import { ThemeVariant } from '../common/Common.types';
 
 export interface RowTextProps {
   title: string;
-  titleTag?: 'h1' | 'h2';
+  titleTag?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p';
   subtitle?: string;
   body?: JSX.Element;
   layout: 'left' | 'center';

--- a/apps/strapi-cms/src/components/sections/row-text.json
+++ b/apps/strapi-cms/src/components/sections/row-text.json
@@ -15,12 +15,12 @@
     },
     "layout": {
       "type": "enumeration",
+      "required": true,
+      "default": "left",
       "enum": [
         "left",
         "center"
-      ],
-      "required": true,
-      "default": "left"
+      ]
     },
     "sectionID": {
       "type": "string",
@@ -31,11 +31,16 @@
     },
     "titleTag": {
       "type": "enumeration",
+      "default": "h2",
       "enum": [
         "h1",
-        "h2"
-      ],
-      "default": "h2"
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "p"
+      ]
     }
   }
 }


### PR DESCRIPTION
#### List of Changes
<!--- Describe your changes in detail -->
Make PreFooter title `<p>` instead of `<h2>`.
Allow all heading levels + p for RowText.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
A11Y

#### How Has This Been Tested?
<!--- Put an `x` in all the boxes that apply. -->
<!--- Where necessary, please describe in detail how you tested your changes. -->
<!--- Especially how your change affects other areas of the code. -->
- [x] Tested locally in dev
- [ ] Ran Storybook locally
- [ ] Built locally
- [ ] Tested locally in dev fetching from production Strapi instance
- [ ] Built locally fetching from production Strapi instance

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
