### PR TITLE
[B2BP-1513] - Megaheader: fix selection and hover state

### DIFF
--- a/.changeset/many-files-breathe.md
+++ b/.changeset/many-files-breathe.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Update MegaHeader selected/hover state styling to match design: bold blue text with underline indicator instead of grey background

--- a/apps/nextjs-website/react-components/components/MegaHeader/MegaHeader.Helpers.tsx
+++ b/apps/nextjs-website/react-components/components/MegaHeader/MegaHeader.Helpers.tsx
@@ -57,22 +57,26 @@ export const Nav = styled('ul')({
     fontWeight: 400,
   },
   '& .menuPrimaryItem': {
+    position: 'relative',
     color: '#2B2E38',
     padding: '10px',
     fontWeight: 400,
     height: 'min-content',
     transition: 'none',
-    '&:hover, &.open': {
-      color: '#0B3EE3',
-      fontWeight: 600,
-      letterSpacing: '-0.003em',
-      backgroundColor: '#F4F4F4 !important',
-      borderRadius: 6,
-    },
-    '&.active': {
-      color: '#0B3EE3',
-      fontWeight: 600,
+    '&:hover, &.open, &.active': {
+      color: '#0B3EE3 !important',
+      fontWeight: 700,
       letterSpacing: '-0.0090em',
+    },
+    '&:hover::after, &.open::after, &.active::after': {
+      content: '""',
+      position: 'absolute',
+      left: 10,
+      right: 10,
+      bottom: 0,
+      height: 2,
+      backgroundColor: '#0B3EE3',
+      borderRadius: 6,
     },
   },
   '& .menuSecondaryItem': {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Update MegaHeader selected/hover state styling to match design: bold blue text with underline indicator instead of grey background

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Put an `x` in all the boxes that apply. -->
<!--- Where necessary, please describe in detail how you tested your changes. -->
<!--- Especially how your change affects other areas of the code. -->
- [X] Tested locally in dev
- [ ] Ran Storybook locally
- [ ] Built locally
- [ ] Tested locally in dev fetching from production Strapi instance
- [ ] Built locally fetching from production Strapi instance

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

<img width="1220" height="107" alt="mega-menu-figma" src="https://github.com/user-attachments/assets/171b2093-3945-4d8c-a8f2-6f58e9fe2f5c" />

