### PR TITLE
[B2BP-1479] feat: add Strapi audit logs

### DIFF
--- a/.changeset/bright-years-watch.md
+++ b/.changeset/bright-years-watch.md
@@ -1,0 +1,5 @@
+---
+"strapi-cms": patch
+---
+
+Add Strapi audit logs

--- a/apps/strapi-cms/config/plugins.ts
+++ b/apps/strapi-cms/config/plugins.ts
@@ -141,6 +141,12 @@ export default ({ env }: any) => ({
           'media-folder.create',
           'media-folder.update',
           'media-folder.delete',
+          'user.create',
+          'user.update',
+          'user.delete',
+          'role.create',
+          'role.update',
+          'role.delete',
         ],
       },
       adminPanel: {

--- a/apps/strapi-cms/config/plugins.ts
+++ b/apps/strapi-cms/config/plugins.ts
@@ -115,7 +115,7 @@ export default ({ env }: any) => ({
       deletion: {
         enabled: false,
       },
-      excludeContentTypes: [],
+      excludeContentTypes: ['api::feedback.feedback', 'plugin::users-permissions.user'],
       excludeEndpoints: ['/admin/renew-token'],
       redactedValues: [
         'password',

--- a/apps/strapi-cms/config/plugins.ts
+++ b/apps/strapi-cms/config/plugins.ts
@@ -116,7 +116,7 @@ export default ({ env }: any) => ({
         enabled: false,
       },
       excludeContentTypes: ['api::feedback.feedback', 'plugin::users-permissions.user'],
-      excludeEndpoints: ['/admin/renew-token'],
+      excludeEndpoints: [],
       redactedValues: [
         'password',
         'token',

--- a/apps/strapi-cms/config/plugins.ts
+++ b/apps/strapi-cms/config/plugins.ts
@@ -113,12 +113,7 @@ export default ({ env }: any) => ({
     config: {
       enabled: true,
       deletion: {
-        enabled: true,
-        frequency: 'logAge',
-        options: {
-          value: 90,
-          interval: 'day',
-        },
+        enabled: false,
       },
       excludeContentTypes: [],
       excludeEndpoints: ['/admin/renew-token'],

--- a/apps/strapi-cms/config/plugins.ts
+++ b/apps/strapi-cms/config/plugins.ts
@@ -154,8 +154,6 @@ export default ({ env }: any) => ({
           'action',
           'date',
           'user',
-          'method',
-          'ipAddress',
           'entry',
         ],
       },

--- a/apps/strapi-cms/config/plugins.ts
+++ b/apps/strapi-cms/config/plugins.ts
@@ -108,6 +108,58 @@ export default ({ env }: any) => ({
       ]
     }
   },
+  'audit-logs': {
+    enabled: true,
+    config: {
+      enabled: true,
+      deletion: {
+        enabled: true,
+        frequency: 'logAge',
+        options: {
+          value: 90,
+          interval: 'day',
+        },
+      },
+      excludeContentTypes: [],
+      excludeEndpoints: ['/admin/renew-token'],
+      redactedValues: [
+        'password',
+        'token',
+        'jwt',
+        'authorization',
+        'cookie',
+        'session',
+        'secret',
+        'key',
+        'private',
+      ],
+      events: {
+        track: [
+          'entry.create',
+          'entry.update',
+          'entry.delete',
+          'entry.publish',
+          'entry.unpublish',
+          'media.create',
+          'media.update',
+          'media.delete',
+          'media-folder.create',
+          'media-folder.update',
+          'media-folder.delete',
+        ],
+      },
+      adminPanel: {
+        indexTableColumns: [
+          'action',
+          'date',
+          'user',
+          'method',
+          'ipAddress',
+          'entry',
+        ],
+      },
+    },
+  },
   'collection-exporter': {
     enabled: true,
   },

--- a/apps/strapi-cms/package.json
+++ b/apps/strapi-cms/package.json
@@ -36,6 +36,7 @@
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.0.0",
+    "strapi-plugin-audit-logs": "2.1.3",
     "strapi-plugin-collection-exporter": "1.2.0",
     "strapi-plugin-preview-button": "3.0.0",
     "styled-components": "^6.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -369,6 +369,7 @@
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "react-router-dom": "^6.0.0",
+        "strapi-plugin-audit-logs": "2.1.3",
         "strapi-plugin-collection-exporter": "1.2.0",
         "strapi-plugin-preview-button": "3.0.0",
         "styled-components": "^6.0.0"
@@ -33408,6 +33409,28 @@
     "node_modules/strapi-cms": {
       "resolved": "apps/strapi-cms",
       "link": true
+    },
+    "node_modules/strapi-plugin-audit-logs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/strapi-plugin-audit-logs/-/strapi-plugin-audit-logs-2.1.3.tgz",
+      "integrity": "sha512-gE0qmI1WPCsgFbh6xSWb8szeu0QlBIkT8JtU70O8X9/aEzjLYlnT9rKovohhlDZn73T+YsrVoQM7tUMpZVPM3w==",
+      "license": "MIT",
+      "dependencies": {
+        "node-schedule": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0 <=22.x.x",
+        "npm": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "@strapi/design-system": "^2.0.0-rc.0",
+        "@strapi/icons": "^2.0.0-rc.0",
+        "@strapi/strapi": "^5.0.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0",
+        "react-router-dom": "^6.0.0",
+        "styled-components": "^6.0.0"
+      }
     },
     "node_modules/strapi-plugin-collection-exporter": {
       "version": "1.2.0",


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Add and enable the Strapi audit logs plugin.
- Track content, media, and media-folder lifecycle events.
- Redact sensitive values and retain logs for 90 days.

#### Motivation and Context
Introduce audit logging in Strapi to provide traceability for relevant content and media operations while protecting sensitive data.

#### How Has This Been Tested?
<!--- Put an `x` in all the boxes that apply. -->
<!--- Where necessary, please describe in detail how you tested your changes. -->
<!--- Especially how your change affects other areas of the code. -->
- [ ] Tested locally in dev
- [ ] Ran Storybook locally
- [ ] Built locally
- [ ] Tested locally in dev fetching from production Strapi instance
- [ ] Built locally fetching from production Strapi instance

#### Screenshots (if appropriate):
<img width="1893" height="866" alt="image" src="https://github.com/user-attachments/assets/f71dcb59-87bf-4b7c-a2c7-48c7335827ed" />

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
