### PR TITLE
[B2BP-1652] Use resolveByThemeVariant for link color in RowText component

### DIFF
--- a/.changeset/selfish-donkeys-speak.md
+++ b/.changeset/selfish-donkeys-speak.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Use resolveByThemeVariant for link color in RowText component

--- a/apps/nextjs-website/react-components/components/RowText/RowText.tsx
+++ b/apps/nextjs-website/react-components/components/RowText/RowText.tsx
@@ -10,6 +10,11 @@ const RowText = (props: RowTextProps) => {
   const textColor = TextColor('light', themeVariant);
   const backgroundColor = BackgroundColor('light', themeVariant);
   const { palette } = useTheme();
+  const richTextLinkColor = resolveThemeVariant<string>(
+    'contentLinkColor',
+    themeVariant,
+    { palette, theme: 'light' },
+  );
   const richTextLinkHoverColor = resolveThemeVariant<string>(
     'richTextLinkHoverColor',
     themeVariant,
@@ -67,7 +72,7 @@ const RowText = (props: RowTextProps) => {
               mt: 1,
               color: textColor,
               '& a': {
-                color: palette.primary.main,
+                color: richTextLinkColor,
                 textDecoration: 'underline',
                 '&:hover': {
                   color: richTextLinkHoverColor,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Replace use of palette color with resolveByThemeVariant method

#### Motivation and Context
Make use of color value by theme variant

#### How Has This Been Tested?
<!--- Put an `x` in all the boxes that apply. -->
<!--- Where necessary, please describe in detail how you tested your changes. -->
<!--- Especially how your change affects other areas of the code. -->
- [x] Tested locally in dev
- [x] Ran Storybook locally
- [ ] Built locally
- [ ] Tested locally in dev fetching from production Strapi instance
- [ ] Built locally fetching from production Strapi instance

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
