### PR TITLE
[B2BP-1663] make Cards item links clickable

### DIFF
--- a/.changeset/nine-walls-appear.md
+++ b/.changeset/nine-walls-appear.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Make Cards item links clickable

--- a/apps/nextjs-website/react-components/components/Cards/CardsItem.tsx
+++ b/apps/nextjs-website/react-components/components/Cards/CardsItem.tsx
@@ -132,7 +132,7 @@ const CardsItem = ({
                   })}
                   sx={{
                     '&.MuiTypography-root': {
-                      marginTop: (theme) => theme.spacing(2),
+                      marginTop: spacing(2),
                     },
                     '&:hover': {
                       color: linkHoverColor,

--- a/apps/nextjs-website/react-components/components/Cards/CardsItem.tsx
+++ b/apps/nextjs-website/react-components/components/Cards/CardsItem.tsx
@@ -15,7 +15,7 @@ const CardsItem = ({
   label,
   themeVariant,
   masonry,
-  alignLinkIconLeft,
+  alignLinkIconLeft = true,
   sx,
 }: CardsItemProps) => {
   const { palette } = useTheme();
@@ -114,11 +114,10 @@ const CardsItem = ({
             ? links.map((link, index) => (
                 <Stack
                   key={index}
-                  mt={2}
-                  direction='row'
                   alignItems='center'
+                  direction='row'
                   color={linkColor}
-                  justifyContent={alignLinkIconLeft ? 'left' : 'space-between'}
+                  mt={2}
                   width='100%'
                   sx={{
                     '&:hover': {
@@ -127,35 +126,41 @@ const CardsItem = ({
                   }}
                 >
                   <Link
+                    alignItems='center'
                     color='inherit'
-                    underline='none'
-                    href={link.href}
-                    title={link.title}
+                    display='inline-flex'
                     fontSize={16}
                     fontWeight={700}
+                    href={link.href}
+                    justifyContent={
+                      alignLinkIconLeft ? 'flex-start' : 'space-between'
+                    }
+                    title={link.title}
+                    underline='none'
+                    width={alignLinkIconLeft ? 'auto' : '100%'}
                     {...(link.ariaLabel && { 'aria-label': link.ariaLabel })}
                     {...(isValidExternalLink(link.href) && {
                       target: '_blank',
                     })}
                   >
                     {link.label}
+                    <LinkIcon
+                      {...(isValidExternalLink(link.href) && {
+                        externaLinkIconTarget: '_blank',
+                      })}
+                      showExternalLinkIcon={isValidExternalLink(link.href)}
+                      internalLinkIcon={
+                        <ArrowForwardIcon
+                          sx={{
+                            color: 'inherit',
+                            height: 24,
+                            marginLeft: 1,
+                            width: 24,
+                          }}
+                        />
+                      }
+                    />
                   </Link>
-                  <LinkIcon
-                    {...(isValidExternalLink(link.href) && {
-                      externaLinkIconTarget: '_blank',
-                    })}
-                    showExternalLinkIcon={isValidExternalLink(link.href)}
-                    internalLinkIcon={
-                      <ArrowForwardIcon
-                        sx={{
-                          color: 'inherit',
-                          height: 24,
-                          marginLeft: 1,
-                          width: 24,
-                        }}
-                      />
-                    }
-                  />
                 </Stack>
               ))
             : null}

--- a/apps/nextjs-website/react-components/components/Cards/CardsItem.tsx
+++ b/apps/nextjs-website/react-components/components/Cards/CardsItem.tsx
@@ -18,7 +18,7 @@ const CardsItem = ({
   alignLinkIconLeft,
   sx,
 }: CardsItemProps) => {
-  const { palette } = useTheme();
+  const { spacing, palette } = useTheme();
 
   const linkColor = resolveThemeVariant<string>('actionColor', themeVariant, {
     palette,

--- a/apps/nextjs-website/react-components/components/Cards/CardsItem.tsx
+++ b/apps/nextjs-website/react-components/components/Cards/CardsItem.tsx
@@ -15,7 +15,7 @@ const CardsItem = ({
   label,
   themeVariant,
   masonry,
-  alignLinkIconLeft = true,
+  alignLinkIconLeft,
   sx,
 }: CardsItemProps) => {
   const { palette } = useTheme();
@@ -112,56 +112,49 @@ const CardsItem = ({
           </Typography>
           {links?.length
             ? links.map((link, index) => (
-                <Stack
+                <Link
                   key={index}
-                  alignItems='center'
-                  direction='row'
                   color={linkColor}
+                  display='inline-flex'
+                  alignItems='center'
+                  fontSize={16}
+                  fontWeight={700}
+                  href={link.href}
+                  justifyContent={
+                    alignLinkIconLeft ? 'flex-start' : 'space-between'
+                  }
                   mt={2}
-                  width='100%'
+                  title={link.title}
+                  underline='none'
+                  width={alignLinkIconLeft ? 'auto' : '100%'}
+                  {...(link.ariaLabel && { 'aria-label': link.ariaLabel })}
+                  {...(isValidExternalLink(link.href) && {
+                    target: '_blank',
+                  })}
                   sx={{
                     '&:hover': {
                       color: linkHoverColor,
                     },
                   }}
                 >
-                  <Link
-                    alignItems='center'
-                    color='inherit'
-                    display='inline-flex'
-                    fontSize={16}
-                    fontWeight={700}
-                    href={link.href}
-                    justifyContent={
-                      alignLinkIconLeft ? 'flex-start' : 'space-between'
-                    }
-                    title={link.title}
-                    underline='none'
-                    width={alignLinkIconLeft ? 'auto' : '100%'}
-                    {...(link.ariaLabel && { 'aria-label': link.ariaLabel })}
+                  {link.label}
+                  <LinkIcon
                     {...(isValidExternalLink(link.href) && {
-                      target: '_blank',
+                      externaLinkIconTarget: '_blank',
                     })}
-                  >
-                    {link.label}
-                    <LinkIcon
-                      {...(isValidExternalLink(link.href) && {
-                        externaLinkIconTarget: '_blank',
-                      })}
-                      showExternalLinkIcon={isValidExternalLink(link.href)}
-                      internalLinkIcon={
-                        <ArrowForwardIcon
-                          sx={{
-                            color: 'inherit',
-                            height: 24,
-                            marginLeft: 1,
-                            width: 24,
-                          }}
-                        />
-                      }
-                    />
-                  </Link>
-                </Stack>
+                    showExternalLinkIcon={isValidExternalLink(link.href)}
+                    internalLinkIcon={
+                      <ArrowForwardIcon
+                        sx={{
+                          color: 'inherit',
+                          height: 24,
+                          marginLeft: 1,
+                          width: 24,
+                        }}
+                      />
+                    }
+                  />
+                </Link>
               ))
             : null}
         </Stack>

--- a/apps/nextjs-website/react-components/components/Cards/CardsItem.tsx
+++ b/apps/nextjs-website/react-components/components/Cards/CardsItem.tsx
@@ -15,7 +15,7 @@ const CardsItem = ({
   label,
   themeVariant,
   masonry,
-  alignLinkIconLeft = true,
+  alignLinkIconLeft,
   sx,
 }: CardsItemProps) => {
   const { palette } = useTheme();
@@ -112,56 +112,51 @@ const CardsItem = ({
           </Typography>
           {links?.length
             ? links.map((link, index) => (
-                <Stack
+                <Link
                   key={index}
-                  alignItems='center'
-                  direction='row'
                   color={linkColor}
-                  mt={2}
-                  width='100%'
+                  display='inline-flex'
+                  alignItems='center'
+                  fontSize={16}
+                  fontWeight={700}
+                  href={link.href}
+                  justifyContent={
+                    alignLinkIconLeft ? 'flex-start' : 'space-between'
+                  }
+                  title={link.title}
+                  underline='none'
+                  width={alignLinkIconLeft ? 'auto' : '100%'}
+                  {...(link.ariaLabel && { 'aria-label': link.ariaLabel })}
+                  {...(isValidExternalLink(link.href) && {
+                    target: '_blank',
+                  })}
                   sx={{
+                    '&.MuiTypography-root': {
+                      marginTop: (theme) => theme.spacing(2),
+                    },
                     '&:hover': {
                       color: linkHoverColor,
                     },
                   }}
                 >
-                  <Link
-                    alignItems='center'
-                    color='inherit'
-                    display='inline-flex'
-                    fontSize={16}
-                    fontWeight={700}
-                    href={link.href}
-                    justifyContent={
-                      alignLinkIconLeft ? 'flex-start' : 'space-between'
-                    }
-                    title={link.title}
-                    underline='none'
-                    width={alignLinkIconLeft ? 'auto' : '100%'}
-                    {...(link.ariaLabel && { 'aria-label': link.ariaLabel })}
+                  {link.label}
+                  <LinkIcon
                     {...(isValidExternalLink(link.href) && {
-                      target: '_blank',
+                      externaLinkIconTarget: '_blank',
                     })}
-                  >
-                    {link.label}
-                    <LinkIcon
-                      {...(isValidExternalLink(link.href) && {
-                        externaLinkIconTarget: '_blank',
-                      })}
-                      showExternalLinkIcon={isValidExternalLink(link.href)}
-                      internalLinkIcon={
-                        <ArrowForwardIcon
-                          sx={{
-                            color: 'inherit',
-                            height: 24,
-                            marginLeft: 1,
-                            width: 24,
-                          }}
-                        />
-                      }
-                    />
-                  </Link>
-                </Stack>
+                    showExternalLinkIcon={isValidExternalLink(link.href)}
+                    internalLinkIcon={
+                      <ArrowForwardIcon
+                        sx={{
+                          color: 'inherit',
+                          height: 24,
+                          marginLeft: 1,
+                          width: 24,
+                        }}
+                      />
+                    }
+                  />
+                </Link>
               ))
             : null}
         </Stack>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Make Cards item labels and icons part of the same link.
- Preserve left/right link icon alignment through alignLinkIconLeft.

#### Motivation and Context
This fixes Cards item links so users can select both the link label and its icon.

#### How Has This Been Tested?
<!--- Put an `x` in all the boxes that apply. -->
<!--- Where necessary, please describe in detail how you tested your changes. -->
<!--- Especially how your change affects other areas of the code. -->
- [x] Tested locally in dev
- [ ] Ran Storybook locally
- [ ] Built locally
- [ ] Tested locally in dev fetching from production Strapi instance
- [ ] Built locally fetching from production Strapi instance

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
